### PR TITLE
[Travis] Enabled notifications for Slack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-# Use trusty for better performance (and avoiding mysql/postgres/solr gone issues on precise and container infra)
 dist: xenial
 sudo: required
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,8 +88,7 @@ script:
 notifications:
   slack:
     rooms:
-      - secure: Xb/nKrA5C4E5pNZulEVht1fT4gsOgoQp9WDNWVSBXz8i8JVPUZo20MtKt67pXK2SmxXbgY8aWbHrD1Y3Lv5YLUCHPJQKVxFiDLTh7sACxvHoEa8EuLiQo9naitMSXL1S4PaC8ptaVn9fe2Fwfg+ydSFLCsFDa+qmdBYjNaf8W4M=
-      - secure: qEgnhpVaWJZQNvJRisv5Kb1vfuZ4H0LjPGWdTk9Q1+MmQMhv/zGV1Z/H1+FEmxlZxk7zrC5ooLs5+K5Nf24XycAM1yczYWGBWJa0P+WKO1KfPx/NbOdSugXIKfbW4JcmwY5mpxPHf+9nUbEOv6zu3cOhWJg41MbTLcGRle+NZVc=
+      - secure: "PYKf96lJCy3hK28PAkI6sB167hUwiGKl7x800Er81pXHhs6CbfVUp0Q+ojsRX8rh45hqbulQ9pzY8G1Y7JZejPJ/e3tWwXsbNSCRfB2B9XE1T5T2KGdws0ExllRsA6hC8FzC7BEId3QUNsXurGrSYgV5aCJw7B5dZliNwJmutVOTGhYkcUivKR5qrQP3Wdg+qwbslYYvJ5VaRh0O+WPlM6AnC9a88tK6yLygnG+h7j7Uc2maBeXihZoyJrjYSx8JEzk9sMh2VCTANMCek6KkxGeORsUl+GH3upHyzu9iYna3vPfGiF5Ur0XpWfjk6uZ4IHY7+H6kaxvJBbKnBcLVLji3+i8Lj/XIyuumSMfLgKVj3PQVFIpzW+jSByk1ZvY75k6LlmrcNd38t7wsNEoUUEI128GBS13SbEepp4lIpvW5iqjofHPlVS/U4B669sHDeZJRbSSxZ9oRwlT9ehPB7N6dkjSjx49LblMl7C5GU/tU9HFy4+3QFnepebhzoFZzsLsrLZc/2+OxV93rt14vn7Arnt8mgXZOJLvIu9Di0gYjgppHt6pq/tRYRo6AG7NOnMW/Vvvn3WggP8g5Z1IOmrNLUiN75AHJq4WO51Rj+FWSp2te0NEqGx8Jisr0l49ftkzC4YxTxuxnthkevy/EeUniXvgz7e2B19jF2S6jRKo="
     on_success: change
     on_failure: always
     on_pull_requests: false


### PR DESCRIPTION
This PR updates tokens for Travis notifications for Slack. Old tokens were configured for `ezpublish-kernel` repository and won't work here.

#### TODO:
- [ ] Wait for Travis.
- [ ] Trigger branch build manually to test notifications.
