### PR TITLE
[Travis] Named all jobs for better readability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,8 @@ matrix:
   fast_finish: true
   include:
 # 7.3
-    - php: 7.3
+    - name: 'Unit tests'
+      php: 7.3
       env: TEST_CONFIG="phpunit.xml"
     - name: "Kernel Behat Core tests"
       php: 7.3
@@ -34,11 +35,14 @@ matrix:
         - BEHAT_OPTS="--profile=core --tags=~@broken"
         - APP_ENV=behat
         - APP_DEBUG=1
-    - php: 7.3
+    - name: 'Solr 7.7.2 integration tests (using shared cores) with Redis cache pool'
+      php: 7.3
       env: SOLR_VERSION="7.7.2" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml" JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre/"
-    - php: 7.3
+    - name: 'PostgreSQL integration tests'
+      php: 7.3
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
-    - php: 7.3
+    - name: 'MySQL integration tests'
+      php: 7.3
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
     - name: 'Code Style Check'
       php: 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,6 @@ matrix:
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
     - php: 7.3
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
-# Disabled as it currently fails, integration tests are not written for language config awareness in Repo, should probably be opt in by test
-#    - php: 7.3
-#      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb" REPOSITORY_SERVICE_ID="ezpublish.siteaccessaware.repository"
     - name: 'Code Style Check'
       php: 7.3
       env: CHECK_CS=1


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | improvement
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

Provided names to all the jobs so an entire build is more readable.

Extra (for fast forward merge): Dropped obsolete commented-out job trying to use SiteAccess-aware Repository layer (it's enabled now by default, so all integration tests rely on it).

#### Checklist:
- [x] PR description is updated.
- [x] Travis passes
- [x] PR is ready for a review.
