### PR TITLE
EZEE-3054: Fixed exception occurrence about lack of user permissions on new Site preview

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
@@ -108,7 +108,12 @@ class SecurityListener implements EventSubscriberInterface
     {
         $token = $event->getAuthenticationToken();
         $originalUser = $token->getUser();
-        if ($originalUser instanceof eZUser || !$originalUser instanceof UserInterface) {
+        if ($originalUser instanceof eZUser) {
+            $this->permissionResolver->setCurrentUserReference($originalUser->getAPIUser());
+
+            return;
+        }
+        if (!$originalUser instanceof UserInterface) {
             return;
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/EventListener/SecurityListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/EventListener/SecurityListenerTest.php
@@ -94,7 +94,12 @@ class SecurityListenerTest extends TestCase
 
     public function testOnInteractiveLoginAlreadyEzUser()
     {
+        $apiUser = $this->createMock(APIUser::class);
         $user = $this->createMock(UserInterface::class);
+        $user
+            ->expects($this->once())
+            ->method('getAPIUser')
+            ->willReturn($apiUser);
         $token = $this->createMock(TokenInterface::class);
         $token
             ->expects($this->once())


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZEE-3054](https://jira.ez.no/browse/EZEE-3054)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

When for the first time the user tries to preview sites created by Site Factory then occurs permission exception about lack of access to created Site Access.

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
