### PR TITLE
EZP-31517: Refactored Search Indexers to rely on Doctrine\DBAL

### DIFF
--- a/eZ/Publish/Core/Search/Common/IncrementalIndexer.php
+++ b/eZ/Publish/Core/Search/Common/IncrementalIndexer.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common;
 
+use Doctrine\DBAL\FetchMode;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
-use PDO;
 
 /**
  * Base class for the Search Engine Indexer Service aimed to recreate Search Engine Index.
@@ -46,7 +44,7 @@ abstract class IncrementalIndexer extends Indexer
         do {
             $contentIds = [];
             for ($k = 0; $k <= $iterationCount; ++$k) {
-                if (!$row = $stmt->fetch(PDO::FETCH_ASSOC)) {
+                if (!$row = $stmt->fetch(FetchMode::ASSOCIATIVE)) {
                     break;
                 }
 

--- a/eZ/Publish/Core/Search/Common/Indexer.php
+++ b/eZ/Publish/Core/Search/Common/Indexer.php
@@ -9,14 +9,11 @@ namespace eZ\Publish\Core\Search\Common;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Driver\Statement;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
-use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
-use PDO;
 
 /**
  * Base class for the Search Engine Indexer Service aimed to recreate Search Engine Index.
@@ -71,36 +68,5 @@ abstract class Indexer
             ->where($query->expr()->eq('status', ContentInfo::STATUS_PUBLISHED));
 
         return $query->execute();
-    }
-
-    /**
-     * Fetch location Ids for the given content object.
-     *
-     * @param int $contentObjectId
-     * @return array Location nodes Ids
-     */
-    protected function getContentLocationIds($contentObjectId)
-    {
-        $query = $this->connection->createQueryBuilder();
-        $query->select('node_id')
-            ->from(LocationGateway::CONTENT_TREE_TABLE)
-            ->where($query->expr()->eq('contentobject_id', $contentObjectId));
-        $stmt = $query->execute();
-        $nodeIds = $stmt->fetchAll(PDO::FETCH_COLUMN);
-
-        return is_array($nodeIds) ? array_map('intval', $nodeIds) : [];
-    }
-
-    /**
-     * Log warning while progress bar is shown.
-     *
-     * @param \Symfony\Component\Console\Helper\ProgressBar $progress
-     * @param $message
-     */
-    protected function logWarning(ProgressBar $progress, $message)
-    {
-        $progress->clear();
-        $this->logger->warning($message);
-        $progress->display();
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Indexer.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Indexer.php
@@ -1,18 +1,17 @@
 <?php
 
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content;
 
+use Doctrine\DBAL\Connection;
 use Exception;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\Search\Common\IncrementalIndexer;
 use eZ\Publish\Core\Search\Legacy\Content\Handler as LegacySearchHandler;
+use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use Psr\Log\LoggerInterface;
 
@@ -21,10 +20,10 @@ class Indexer extends IncrementalIndexer
     public function __construct(
         LoggerInterface $logger,
         PersistenceHandler $persistenceHandler,
-        DatabaseHandler $databaseHandler,
+        Connection $connection,
         LegacySearchHandler $searchHandler
     ) {
-        parent::__construct($logger, $persistenceHandler, $databaseHandler, $searchHandler);
+        parent::__construct($logger, $persistenceHandler, $connection, $searchHandler);
     }
 
     public function getName()

--- a/eZ/Publish/Core/Search/Legacy/Content/Indexer.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Indexer.php
@@ -37,7 +37,7 @@ class Indexer extends IncrementalIndexer
         foreach ($contentIds as $contentId) {
             try {
                 $info = $contentHandler->loadContentInfo($contentId);
-                if ($info->isPublished) {
+                if ($info->status === ContentInfo::STATUS_PUBLISHED) {
                     $this->searchHandler->indexContent(
                         $contentHandler->load($info->id, $info->currentVersionNo)
                     );

--- a/eZ/Publish/Core/settings/search_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy.yml
@@ -83,10 +83,10 @@ services:
     ezpublish.spi.search.legacy.indexer:
         class: eZ\Publish\Core\Search\Legacy\Content\Indexer
         arguments:
-            - "@logger"
-            - "@ezpublish.api.storage_engine"
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.spi.search.legacy"
+            $logger: '@logger'
+            $persistenceHandler: '@ezpublish.api.storage_engine'
+            $connection: '@ezpublish.persistence.connection'
+            $searchHandler: "@ezpublish.spi.search.legacy"
         tags:
             - {name: ezpublish.searchEngineIndexer, alias: legacy}
         lazy: true


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31517](https://jira.ez.no/browse/EZP-31517) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921)
| **Required by**                        | ezsystems/ezplatform-solr-search-engine#177
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0`
| **BC breaks**                          | yes
| **Tests pass**                          | yes
| **Doc needed**                       | yes

#### Summary

This PR refactors Search Indexers to rely on Doctrine Connection instead of Database Handler from Zeta Components.

Additionally Indexer code relied on deprecated SPI `ContentInfo::$isPublished` property, which was fixed as well during refactoring.

#### Background 

Search Indexer is a service called by the `ezplatform:reindex` command to bulk-index Content items. Each Search Engine should implement its own Indexer via (hidden, not very well documented) Service Provider Interface in the form of abstract Indexers.

#### Doc

Service Provider abstracts for Search Engine Indexer implementations (`\eZ\Publish\Core\Search\Common\IncrementalIndexer` and `\eZ\Publish\Core\Search\Common\Indexer`) accept now `\Doctrine\DBAL\Connection $connection` instead of `\eZ\Publish\Core\Persistence\Database\DatabaseHandler $databaseHandler`. Inject it via `@ezpublish.persistence.connection`.

Moreover the methods `getContentLocationIds` and `logWarning` of `\eZ\Publish\Core\Search\Common\Indexer` were dropped. For the former one use Location SPI Persistence Handler, for the latter one use Logger directly instead.

#### QA
Can be tested with #23 (common branch [for-qa-ezp-31301-31517-lse-sanity](https://github.com/ezsystems/ezplatform-kernel/compare/for-qa-ezp-31301-31517-lse-sanity)).

- [ ] Sanity for `ezplatform:reindex` on Legacy Search Engine (MySQL, PostgreSQL).


#### Checklist:
- [x] PR description is updated.
- ~Tests are implemented~ missing test coverage, indexing itself covered on API.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
