### PR TITLE
EZP-30928: Dropped deprecated ContentService::removeTranslation method

### DIFF
--- a/doc/bc/changes-1.0.md
+++ b/doc/bc/changes-1.0.md
@@ -68,8 +68,9 @@ Changes affecting version compatibility with deprecated ezpublish-kernel version
 
 * Deprecated Symfony framework templating component integration has been dropped.
 
-* Following methods have been removed:
+* Following API methods have been removed:
 
+    * `\eZ\Publish\API\Repository\ContentService::removeTranslation`
     * `\eZ\Publish\API\Repository\UserService::loadAnonymousUser`
     * `\eZ\Publish\API\Repository\Repository::getCurrentUser`
     * `\eZ\Publish\API\Repository\Repository::getCurrentUserReference`
@@ -104,6 +105,10 @@ Changes affecting version compatibility with deprecated ezpublish-kernel version
     * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\Subtree::createFromQueryBuilder`
     * `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\Visibility::createFromQueryBuilder`
     
+* Following SPI methods have been removed:
+
+    * `\eZ\Publish\SPI\Persistence\Content\Handler::removeTranslationFromContent`
+
 * The "Setup" folder and Section have been removed from the initial (clean installation) data.
 
 * The "Design" Section has been removed from the initial (clean installation) data.

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -450,28 +450,6 @@ interface ContentService
     public function deleteRelation(VersionInfo $sourceVersion, ContentInfo $destinationContent): void;
 
     /**
-     * Remove Content Object translation from all Versions (including archived ones) of a Content Object.
-     *
-     * NOTE: this operation is risky and permanent, so user interface (ideally CLI) should provide
-     *       a warning before performing it.
-     *
-     * @deprecated since 6.13, use {@see deleteTranslation} instead
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException if the specified translation
-     *         is the only one a Version has or it is the main translation of a Content Object.
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed
-     *         to delete the content (in one of the locations of the given Content Object).
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if languageCode argument
-     *         is invalid for the given content.
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param string $languageCode
-     *
-     * @since 6.11
-     */
-    public function removeTranslation(ContentInfo $contentInfo, string $languageCode): void;
-
-    /**
      * Delete Content item Translation from all Versions (including archived ones) of a Content Object.
      *
      * NOTE: this operation is risky and permanent, so user interface should provide a warning before performing it.

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -459,14 +459,6 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
     /**
      * {@inheritdoc}
      */
-    public function removeTranslationFromContent($contentId, $languageCode)
-    {
-        $this->deleteTranslationFromContent($contentId, $languageCode);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function deleteTranslationFromContent($contentId, $languageCode)
     {
         $this->logger->logCall(

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -858,18 +858,6 @@ class Handler implements BaseContentHandler
     /**
      * {@inheritdoc}
      */
-    public function removeTranslationFromContent($contentId, $languageCode)
-    {
-        @trigger_error(
-            __METHOD__ . ' is deprecated, use deleteTranslationFromContent instead',
-            E_USER_DEPRECATED
-        );
-        $this->deleteTranslationFromContent($contentId, $languageCode);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function deleteTranslationFromContent($contentId, $languageCode)
     {
         $this->fieldHandler->deleteTranslationFromContentFields(

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -2262,18 +2262,6 @@ class ContentService implements ContentServiceInterface
     }
 
     /**
-     * {@inheritdoc}
-     */
-    public function removeTranslation(ContentInfo $contentInfo, string $languageCode): void
-    {
-        @trigger_error(
-            __METHOD__ . ' is deprecated, use deleteTranslation instead',
-            E_USER_DEPRECATED
-        );
-        $this->deleteTranslation($contentInfo, $languageCode);
-    }
-
-    /**
      * Delete Content item Translation from all Versions (including archived ones) of a Content Object.
      *
      * NOTE: this operation is risky and permanent, so user interface should provide a warning before performing it.

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -213,11 +213,6 @@ class ContentService implements ContentServiceInterface
         $this->service->deleteRelation($sourceVersion, $destinationContent);
     }
 
-    public function removeTranslation(ContentInfo $contentInfo, string $languageCode): void
-    {
-        $this->service->removeTranslation($contentInfo, $languageCode);
-    }
-
     public function deleteTranslation(ContentInfo $contentInfo, string $languageCode): void
     {
         $this->service->deleteTranslation($contentInfo, $languageCode);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
@@ -103,8 +103,6 @@ class ContentServiceTest extends AbstractServiceTest
 
             ['deleteRelation', [$versionInfo, $contentInfo], null],
 
-            ['removeTranslation', [$contentInfo, 'eng-GB'], null],
-
             ['deleteTranslation', [$contentInfo, 'eng-GB'], null],
 
             ['deleteTranslationFromDraft', [$versionInfo, 'eng-GB'], $content],

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -349,16 +349,6 @@ interface Handler
     public function publish($contentId, $versionNo, MetadataUpdateStruct $metaDataUpdateStruct);
 
     /**
-     * Remove the specified translation from all the Versions of a Content Object.
-     *
-     * @deprecated since 6.13, use {@see deleteTranslationFromContent} instead
-     *
-     * @param int $contentId
-     * @param string $languageCode language code of the translation
-     */
-    public function removeTranslationFromContent($contentId, $languageCode);
-
-    /**
      * Delete the specified translation from all the Versions of a Content Object.
      *
      * @param int $contentId

--- a/eZ/Publish/SPI/Repository/Decorator/ContentServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/ContentServiceDecorator.php
@@ -212,13 +212,6 @@ abstract class ContentServiceDecorator implements ContentService
         $this->innerService->deleteRelation($sourceVersion, $destinationContent);
     }
 
-    public function removeTranslation(
-        ContentInfo $contentInfo,
-        string $languageCode
-    ): void {
-        $this->innerService->removeTranslation($contentInfo, $languageCode);
-    }
-
     public function deleteTranslation(
         ContentInfo $contentInfo,
         string $languageCode

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/ContentServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/ContentServiceDecoratorTest.php
@@ -381,21 +381,6 @@ class ContentServiceDecoratorTest extends TestCase
         $decoratedService->deleteRelation(...$parameters);
     }
 
-    public function testRemoveTranslationDecorator()
-    {
-        $serviceMock = $this->createServiceMock();
-        $decoratedService = $this->createDecorator($serviceMock);
-
-        $parameters = [
-            $this->createMock(ContentInfo::class),
-            self::EXAMPLE_LANGUAGE_CODE,
-        ];
-
-        $serviceMock->expects($this->once())->method('removeTranslation')->with(...$parameters);
-
-        $decoratedService->removeTranslation(...$parameters);
-    }
-
     public function testDeleteTranslationDecorator()
     {
         $serviceMock = $this->createServiceMock();


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-30928](https://jira.ez.no/browse/EZP-30928)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0`
| **BC breaks**                          | yes
| **Tests pass**                          | yes
| **Doc needed**                       | yes

#### Doc

Dropped deprecated API `\eZ\Publish\API\Repository\ContentService::removeTranslation`. Use `\eZ\Publish\API\Repository\ContentService::deleteTranslation` instead.

Dropped deprecated SPI `\eZ\Publish\SPI\Persistence\Content\Handler::removeTranslationFromContent`. Use \eZ\Publish\SPI\Persistence\Content\Handler::deleteTranslationFromContent instead.

#### QA

 - [x] Sanity for translation removal (suggested Solr configured for search, if there were any LSE usages, I would rather see them).

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented (were already available).
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] Travis passes.
- [x] PR is ready for a review.