### PR TITLE
EZP-31527: Changed ProgressBar of ezplatform:reindex command to be very verbose

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -284,6 +284,7 @@ EOT
         }
 
         $progress = new ProgressBar($output);
+        $progress->setFormat('very_verbose');
         $progress->start($iterations);
 
         if ($processCount > 1) {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31527](https://jira.ez.no/browse/EZP-31527)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

Right now `ezplatform.core.command.reindex` command does not show ETA. It is very useful to have this information on big projects where the script execution can take 5+ hours.

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
