### PR TITLE
EZP-31528: Offset option added to search reindex command

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -251,6 +251,10 @@ EOT
         }
 
         $offset = (int) $input->getOption('offset');
+        if ($offset < 0) {
+            throw new InvalidArgumentException('--offset', "The value must be >= 0, you provided '{$offset}'");
+        }
+
         if ($since = $input->getOption('since')) {
             $stmt = $this->getStatementContentSince(new DateTime($since), false, $offset);
             $count = max((int) $this->getStatementContentSince(new DateTime($since), true, $offset)->fetchColumn(), 0);
@@ -389,7 +393,7 @@ EOT
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    private function getStatementSubtree($locationId, $count = false, int $offset = 0)
+    private function getStatementSubtree($locationId, $count = false, int $offset)
     {
         $location = $this->locationHandler->load($locationId);
         $q = $this->connection->createQueryBuilder()
@@ -411,7 +415,7 @@ EOT
      *
      * @return \Doctrine\DBAL\Driver\Statement
      */
-    private function getStatementContentAll($count = false, int $offset = 0)
+    private function getStatementContentAll($count = false, int $offset)
     {
         $q = $this->connection->createQueryBuilder()
             ->select($count ? 'count(c.id)' : 'c.id')


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31528](https://jira.ez.no/browse/EZP-31528)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

It might take a lot of time to rebuild the search index on big projects, and there should be an option to resume interrupted command

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
