### PR TITLE
EZP-31529: Added --no-interaction option to cmd regenerating URL aliases

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
@@ -82,7 +82,7 @@ EOT;
                 'force',
                 'f',
                 InputOption::VALUE_NONE,
-                'Prevents confirmation dialog. Please use it carefully.'
+                'Prevents confirmation dialog when used with --no-interaction. Please use it carefully.'
             )->setHelp(
                 <<<EOT
 {$beforeRunningHints}

--- a/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
@@ -78,6 +78,11 @@ EOT;
                 InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY,
                 'Only Locations with provided ID\'s will have URL aliases regenerated',
                 []
+            )->addOption(
+                'force',
+                'f',
+                InputOption::VALUE_NONE,
+                'Prevents confirmation dialog. Please use it carefully.'
             )->setHelp(
                 <<<EOT
 {$beforeRunningHints}
@@ -136,6 +141,8 @@ EOT
             if (!$helper->ask($input, $output, $question)) {
                 return 0;
             }
+        } elseif (!$input->getOption('force')) {
+            return 1;
         }
 
         $this->regenerateSystemUrlAliases($output, $locationsCount, $locationIds, $iterationCount);

--- a/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
@@ -123,17 +123,19 @@ EOT
             return 0;
         }
 
-        $helper = $this->getHelper('question');
-        $question = new ConfirmationQuestion(
-            sprintf(
-                "<info>Found %d Locations.</info>\n%s\n<info>Do you want to proceed? [y/N] </info>",
-                $locationsCount,
-                self::BEFORE_RUNNING_HINTS
-            ),
-            false
-        );
-        if (!$helper->ask($input, $output, $question)) {
-            return 0;
+        if (!$input->getOption('no-interaction')) {
+            $helper = $this->getHelper('question');
+            $question = new ConfirmationQuestion(
+                sprintf(
+                    "<info>Found %d Locations.</info>\n%s\n<info>Do you want to proceed? [y/N] </info>",
+                    $locationsCount,
+                    self::BEFORE_RUNNING_HINTS
+                ),
+                false
+            );
+            if (!$helper->ask($input, $output, $question)) {
+                return 0;
+            }
         }
 
         $this->regenerateSystemUrlAliases($output, $locationsCount, $locationIds, $iterationCount);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31529](https://jira.ez.no/browse/EZP-31529)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

Regenerate URL aliases command is an important part of upgrade scripts. And because it ignores `no-interaction` option it is much harder to automate the upgrade scripts.

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
