### PR TITLE
Removed @deprecated annotation from UserService::loadUserByLogin

### DIFF
--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -146,9 +146,6 @@ interface UserService
      * Since 6.1 login is case-insensitive across all storage engines and database backends, like was the case
      * with mysql before in eZ Publish 3.x/4.x/5.x.
      *
-     * @deprecated since eZ Platform 2.5, will be dropped in the next major version as authentication
-     *             may depend on various user providers. Use UserService::checkUserCredentials() instead.
-     *
      * @param string $login
      * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   |  bug
| **Target eZ Platform version** | -
| **BC breaks**                          | no
| **Tests pass**                          | no
| **Doc needed**                       | no

Removed `@deprecated` annotation from `UserService::loadUserByLogin`. Propably conflicts has been incorrect resolved during the merge up.

#### Checklist:
- [X] PR description is updated.
- [ ] ~Tests are implemented.~
- [ ] ~Added code follows Coding Standards (use `$ composer fix-cs`).~
- [X] PR is ready for a review.
