### PR TITLE
Fixed integration tests to rely on `ezpublish.persistence.connection`

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -9,6 +9,7 @@
 namespace eZ\Publish\API\Repository\Tests;
 
 use Doctrine\DBAL\Connection;
+use ErrorException;
 use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
 use eZ\Publish\API\Repository\Exceptions\ForbiddenException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
@@ -140,22 +141,34 @@ abstract class BaseTest extends TestCase
 
     /**
      * @param bool $initialInitializeFromScratch Only has an effect if set in first call within a test
-     *
-     * @return \eZ\Publish\API\Repository\Repository
      */
-    protected function getRepository($initialInitializeFromScratch = true)
+    protected function getRepository(bool $initialInitializeFromScratch = true): Repository
     {
         if (null === $this->repository) {
-            $this->repository = $this->getSetupFactory()->getRepository($initialInitializeFromScratch);
+            try {
+                $this->repository = $this->getSetupFactory()->getRepository(
+                    $initialInitializeFromScratch
+                );
+            } catch (ErrorException $e) {
+                self::fail(
+                    sprintf(
+                        '%s: %s in %s:%d',
+                        __FUNCTION__,
+                        $e->getMessage(),
+                        $e->getFile(),
+                        $e->getLine()
+                    )
+                );
+            }
         }
 
         return $this->repository;
     }
 
     /**
-     * @return \eZ\Publish\API\Repository\Tests\SetupFactory
+     * @throws \ErrorException
      */
-    protected function getSetupFactory()
+    protected function getSetupFactory(): SetupFactory
     {
         if (null === $this->setupFactory) {
             if (false === ($setupClass = getenv('setupFactory'))) {
@@ -163,12 +176,12 @@ abstract class BaseTest extends TestCase
                 putenv("setupFactory=${setupClass}");
             }
 
-            if (false === ($fixtureDir = getenv('fixtureDir'))) {
+            if (false === getenv('fixtureDir')) {
                 putenv('fixtureDir=Legacy');
             }
 
             if (false === class_exists($setupClass)) {
-                throw new \ErrorException(
+                throw new ErrorException(
                     sprintf(
                         'Environment variable "setupFactory" does not reference an existing class: %s. Did you forget to install a package dependency?',
                         $setupClass
@@ -612,11 +625,9 @@ abstract class BaseTest extends TestCase
     }
 
     /**
-     * @return \Doctrine\DBAL\Connection
-     *
      * @throws \ErrorException
      */
-    protected function getRawDatabaseConnection()
+    protected function getRawDatabaseConnection(): Connection
     {
         $connection = $this
             ->getSetupFactory()

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -620,7 +620,7 @@ abstract class BaseTest extends TestCase
     {
         $connection = $this
             ->getSetupFactory()
-            ->getServiceContainer()->get('ezpublish.api.storage_engine.legacy.connection');
+            ->getServiceContainer()->get('ezpublish.persistence.connection');
 
         if (!$connection instanceof Connection) {
             throw new \RuntimeException(

--- a/eZ/Publish/Core/FieldType/Tests/Integration/BaseCoreFieldTypeIntegrationTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Integration/BaseCoreFieldTypeIntegrationTest.php
@@ -8,6 +8,8 @@
  */
 namespace eZ\Publish\Core\FieldType\Tests\Integration;
 
+use Doctrine\DBAL\Connection;
+use ErrorException;
 use eZ\Publish\API\Repository\Tests\BaseTest as APIBaseTest;
 
 /**
@@ -46,8 +48,20 @@ abstract class BaseCoreFieldTypeIntegrationTest extends APIBaseTest
      */
     protected function getDatabaseConnection()
     {
-        return $this->getSetupFactory()->getServiceContainer()->get(
-            'ezpublish.api.storage_engine.legacy.connection'
-        );
+        try {
+            return $this->getSetupFactory()->getServiceContainer()->get(
+                'ezpublish.persistence.connection'
+            );
+        } catch (ErrorException $e) {
+            self::fail(
+                sprintf(
+                    '%s: %s in %s:%d',
+                    __METHOD__,
+                    $e->getMessage(),
+                    $e->getFile(),
+                    $e->getLine()
+                )
+            );
+        }
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/Integration/BaseCoreFieldTypeIntegrationTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Integration/BaseCoreFieldTypeIntegrationTest.php
@@ -46,7 +46,7 @@ abstract class BaseCoreFieldTypeIntegrationTest extends APIBaseTest
      *
      * @return \Doctrine\DBAL\Connection|object
      */
-    protected function getDatabaseConnection()
+    protected function getDatabaseConnection(): Connection
     {
         try {
             return $this->getSetupFactory()->getServiceContainer()->get(


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.0` internal test framework
| **BC breaks**                          | no
| **Tests pass**                          | TBD
| **Doc needed**                       | no

The `ezpublish.persistence.connection` service is a more stable abstraction than `ezpublish.api.storage_engine.legacy.connection`. 
While the latter one is available for tests ran on `ezplatform-kernel` due to [some Container tricks](https://github.com/ezsystems/ezplatform-kernel/blob/0a7dac34e860d6aa179944bf42e9af2f4b43b0b1/eZ/Publish/Core/settings/containerBuilder.php#L87), it's not easily propagated to the dependencies, see failing [ezplatform-richtext job](https://travis-ci.org/github/ezsystems/ezplatform-richtext/builds/667649690). 
On the other hand `ezpublish.persistence.connection` seems to be available there also (requires confirming with CI).

Changed also Base integration test cases `getDatabaseConnection`, `getRawDatabaseConnection`, and `getSetupFactory` methods not to throw exception but to fail any test case as there's no point in running it nor examining stack trace (so added as a string only).

Side: fixed CS issues in the modified methods and methods related to their invocation chain.

#### Checklist:
- [x] PR description is updated.
- [x] Tests are passing.
- [x] Failing RichText test is passing.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
