### PR TITLE
EZP-31300: Refactored URL Search GW and handlers to rely on Doctrine

### DIFF
--- a/doc/bc/changes-1.0.md
+++ b/doc/bc/changes-1.0.md
@@ -298,6 +298,17 @@ Changes affecting version compatibility with deprecated ezpublish-kernel version
   ```php
   abstract public function getFieldDefinitions(): FieldDefinitionCollection;
   ```
+  
+* The signature of the `\eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler::handle` contract
+  accepts now `\Doctrine\DBAL\Query\QueryBuilder` instead of `\eZ\Publish\Core\Persistence\Database\SelectQuery`
+  and has the following form:
+  ```php
+  use \Doctrine\DBAL\Query\QueryBuilder;
+  use \eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
+  use \eZ\Publish\API\Repository\Values\URL\Query\Criterion;
+
+  public function handle(CriteriaConverter $converter, QueryBuilder $query, Criterion $criterion);
+  ```
 
 ## Removed services
 

--- a/eZ/Publish/API/Repository/Tests/URLServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLServiceTest.php
@@ -17,7 +17,7 @@ use eZ\Publish\API\Repository\Values\URL\UsageSearchResult;
 /**
  * Test case for operations in the UserService using in memory storage.
  *
- * @see eZ\Publish\API\Repository\URLService
+ * @see \eZ\Publish\API\Repository\URLService
  * @group integration
  * @group url
  */

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriteriaConverterTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriteriaConverterTest.php
@@ -6,16 +6,19 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query;
 
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\Expression;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 use PHPUnit\Framework\TestCase;
 
 class CriteriaConverterTest extends TestCase
 {
-    public function testConvertCriteriaSuccess()
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
+     */
+    public function testConvertCriteriaSuccess(): void
     {
         $fooCriterionHandler = $this->createMock(CriterionHandler::class);
         $barCriterionHandler = $this->createMock(CriterionHandler::class);
@@ -27,8 +30,7 @@ class CriteriaConverterTest extends TestCase
 
         $barCriterion = $this->createMock(Criterion::class);
 
-        $selectQuery = $this->createMock(SelectQuery::class);
-        $expression = $this->createMock(Expression::class);
+        $selectQuery = $this->createMock(QueryBuilder::class);
 
         $fooCriterionHandler
             ->expects($this->once())
@@ -46,24 +48,34 @@ class CriteriaConverterTest extends TestCase
             ->with($barCriterion)
             ->willReturn(true);
 
+        $sqlExpression = 'SQL EXPRESSION';
         $barCriterionHandler
             ->expects($this->once())
             ->method('handle')
             ->with($criteriaConverter, $selectQuery, $barCriterion)
-            ->willReturn($expression);
+            ->willReturn($sqlExpression);
 
-        $this->assertEquals($expression, $criteriaConverter->convertCriteria(
-            $selectQuery, $barCriterion
-        ));
+        $this->assertEquals(
+            $sqlExpression,
+            $criteriaConverter->convertCriteria(
+                $selectQuery,
+                $barCriterion
+            )
+        );
     }
 
-    public function testConvertCriteriaFailure()
+    /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter::convertCriteria
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
+     */
+    public function testConvertCriteriaFailure(): void
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotImplementedException::class);
+        $this->expectException(NotImplementedException::class);
 
         $criteriaConverter = new CriteriaConverter();
         $criteriaConverter->convertCriteria(
-            $this->createMock(SelectQuery::class),
+            $this->createMock(QueryBuilder::class),
             $this->createMock(Criterion::class)
         );
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/LogicalNotTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/LogicalNotTest.php
@@ -6,10 +6,9 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion\LogicalNot;
-use eZ\Publish\Core\Persistence\Database\Expression;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler\LogicalNot as LogicalNotHandler;
 
@@ -28,33 +27,27 @@ class LogicalNotTest extends CriterionHandlerTest
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
      */
-    public function testHandle()
+    public function testHandle(): void
     {
         $foo = $this->createMock(Criterion::class);
         $fooExpr = 'FOO';
-        $expected = 'NOT FOO';
+        $expected = 'NOT (FOO)';
 
-        $expr = $this->createMock(Expression::class);
-        $expr
-            ->expects($this->once())
-            ->method('not')
-            ->with($fooExpr)
-            ->willReturn($expected);
-
-        $query = $this->createMock(SelectQuery::class);
-        $query->expr = $expr;
+        $queryBuilder = $this->createMock(QueryBuilder::class);
 
         $converter = $this->createMock(CriteriaConverter::class);
         $converter
             ->expects($this->at(0))
             ->method('convertCriteria')
-            ->with($query, $foo)
+            ->with($queryBuilder, $foo)
             ->willReturn($fooExpr);
 
         $handler = new LogicalNotHandler();
         $actual = $handler->handle(
-            $converter, $query, new LogicalNot($foo)
+            $converter, $queryBuilder, new LogicalNot($foo)
         );
 
         $this->assertEquals($expected, $actual);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/MatchAllTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/MatchAllTest.php
@@ -6,9 +6,9 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion\MatchAll;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler\MatchAll as MatchAllHandler;
 
@@ -31,19 +31,13 @@ class MatchAllTest extends CriterionHandlerTest
     public function testHandle()
     {
         $criterion = new MatchAll();
-        $expected = ':value';
+        $expected = '1 = 1';
 
-        $query = $this->createMock(SelectQuery::class);
-        $query
-            ->expects($this->once())
-            ->method('bindValue')
-            ->with('1')
-            ->willReturn(':value');
-
+        $queryBuilder = $this->createMock(QueryBuilder::class);
         $converter = $this->createMock(CriteriaConverter::class);
 
         $handler = new MatchAllHandler();
-        $actual = $handler->handle($converter, $query, $criterion);
+        $actual = $handler->handle($converter, $queryBuilder, $criterion);
 
         $this->assertEquals($expected, $actual);
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/MatchNoneTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/MatchNoneTest.php
@@ -6,10 +6,10 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion\MatchNone;
-use eZ\Publish\Core\Persistence\Database\Expression;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler\MatchNone as MatchNoneHandler;
 
@@ -32,22 +32,20 @@ class MatchNoneTest extends CriterionHandlerTest
     public function testHandle()
     {
         $criterion = new MatchNone();
-        $expected = 'NOT :value';
+        $expected = '1 = 0';
 
-        $expr = $this->createMock(Expression::class);
-        $expr
+        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
+        $expressionBuilder
             ->expects($this->once())
-            ->method('not')
-            ->with(':value')
+            ->method('eq')
+            ->with(1, 0)
             ->willReturn($expected);
 
-        $query = $this->createMock(SelectQuery::class);
-        $query->expr = $expr;
+        $query = $this->createMock(QueryBuilder::class);
         $query
             ->expects($this->once())
-            ->method('bindValue')
-            ->with('1')
-            ->willReturn(':value');
+            ->method('expr')
+            ->willReturn($expressionBuilder);
 
         $converter = $this->createMock(CriteriaConverter::class);
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/MatchNoneTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/MatchNoneTest.php
@@ -6,7 +6,6 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;
 
-use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
 use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion\MatchNone;
@@ -34,19 +33,7 @@ class MatchNoneTest extends CriterionHandlerTest
         $criterion = new MatchNone();
         $expected = '1 = 0';
 
-        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
-        $expressionBuilder
-            ->expects($this->once())
-            ->method('eq')
-            ->with(1, 0)
-            ->willReturn($expected);
-
         $query = $this->createMock(QueryBuilder::class);
-        $query
-            ->expects($this->once())
-            ->method('expr')
-            ->willReturn($expressionBuilder);
-
         $converter = $this->createMock(CriteriaConverter::class);
 
         $handler = new MatchNoneHandler();

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/ValidityTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/ValidityTest.php
@@ -6,10 +6,11 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\Expression\ExpressionBuilder;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion\Validity;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\Expression;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler\Validity as ValidityHandler;
 
@@ -34,25 +35,28 @@ class ValidityTest extends CriterionHandlerTest
         $criterion = new Validity(true);
         $expected = 'is_valid = :is_valid';
 
-        $expr = $this->createMock(Expression::class);
-        $expr
+        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
+        $expressionBuilder
             ->expects($this->once())
             ->method('eq')
             ->with('is_valid', ':is_valid')
             ->willReturn($expected);
 
-        $query = $this->createMock(SelectQuery::class);
-        $query->expr = $expr;
-        $query
-            ->expects($this->once())
-            ->method('bindValue')
-            ->with($criterion->isValid)
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder
+            ->expects($this->any())
+            ->method('expr')
+            ->willReturn($expressionBuilder);
+        $queryBuilder
+            ->expects($this->any())
+            ->method('createNamedParameter')
+            ->with((int)$criterion->isValid, ParameterType::INTEGER, ':is_valid')
             ->willReturn(':is_valid');
 
         $converter = $this->createMock(CriteriaConverter::class);
 
         $handler = new ValidityHandler();
-        $actual = $handler->handle($converter, $query, $criterion);
+        $actual = $handler->handle($converter, $queryBuilder, $criterion);
 
         $this->assertEquals($expected, $actual);
     }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Gateway.php
@@ -28,6 +28,9 @@ abstract class Gateway
      * @param SortClause[] $sortClauses
      * @param bool $doCount
      * @return array
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException if Criterion is not applicable to its target
      */
     abstract public function find(Criterion $criterion, $offset, $limit, array $sortClauses = [], $doCount = true);
 

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriteriaConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriteriaConverter.php
@@ -6,9 +6,9 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 class CriteriaConverter
 {
@@ -44,15 +44,13 @@ class CriteriaConverter
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException if Criterion is not applicable to its target
      *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\URL\Query\Criterion $criterion
-     * @return \eZ\Publish\Core\Persistence\Database\Expression|string
+     * @return \Doctrine\DBAL\Query\Expression\CompositeExpression|string
      */
-    public function convertCriteria(SelectQuery $query, Criterion $criterion)
+    public function convertCriteria(QueryBuilder $queryBuilder, Criterion $criterion)
     {
         foreach ($this->handlers as $handler) {
             if ($handler->accept($criterion)) {
-                return $handler->handle($this, $query, $criterion);
+                return $handler->handle($this, $queryBuilder, $criterion);
             }
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler.php
@@ -6,8 +6,8 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 interface CriterionHandler
 {
@@ -15,6 +15,7 @@ interface CriterionHandler
      * Check if this criterion handler accepts to handle the given criterion.
      *
      * @param \eZ\Publish\API\Repository\Values\URL\Query\Criterion $criterion
+     *
      * @return bool
      */
     public function accept(Criterion $criterion);
@@ -24,10 +25,11 @@ interface CriterionHandler
      *
      * accept() must be called before calling this method.
      *
-     * @param \eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\URL\Query\Criterion $criterion
-     * @return \eZ\Publish\Core\Persistence\Database\Expression|string
+     * @return \Doctrine\DBAL\Query\Expression\CompositeExpression|string
      */
-    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion);
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion
+    );
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Base.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Base.php
@@ -8,59 +8,82 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
+use eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 
 abstract class Base implements CriterionHandler
 {
     /**
      * Inner join `ezurl_object_link` table if not joined yet.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      */
-    protected function joinContentObjectLink(SelectQuery $query): void
+    protected function joinContentObjectLink(QueryBuilder $query): void
     {
-        if (strpos($query->getQuery(), 'INNER JOIN ezurl_object_link ') === false) {
+        if (false === $this->hasJoinedTable($query, DoctrineDatabase::URL_LINK_TABLE)) {
             $query->innerJoin(
-                'ezurl_object_link',
-                $query->expr->eq('ezurl.id', 'ezurl_object_link.url_id')
+                'url',
+                DoctrineDatabase::URL_LINK_TABLE,
+                'u_lnk',
+                'url.id = u_lnk.url_id'
             );
         }
     }
 
     /**
      * Inner join `ezcontentobject` table if not joined yet.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      */
-    protected function joinContentObject(SelectQuery $query): void
+    protected function joinContentObject(QueryBuilder $query): void
     {
-        if (strpos($query->getQuery(), 'INNER JOIN ezcontentobject ') === false) {
+        if (false === $this->hasJoinedTable($query, ContentGateway::CONTENT_ITEM_TABLE)) {
             $query->innerJoin(
-                'ezcontentobject',
-                $query->expr->eq('ezcontentobject.id', 'ezcontentobject_attribute.contentobject_id')
+                'f_def',
+                ContentGateway::CONTENT_ITEM_TABLE,
+                'c',
+                'c.id = f_def.contentobject_id'
             );
         }
     }
 
     /**
      * Inner join `ezcontentobject_attribute` table if not joined yet.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      */
-    protected function joinContentObjectAttribute(SelectQuery $query): void
+    protected function joinContentObjectAttribute(QueryBuilder $query): void
     {
-        if (strpos($query->getQuery(), 'INNER JOIN ezcontentobject_attribute ') === false) {
-            $query->innerJoin('ezcontentobject_attribute', $query->expr->lAnd(
-                $query->expr->eq(
-                    'ezurl_object_link.contentobject_attribute_id',
-                    'ezcontentobject_attribute.id'
-                ),
-                $query->expr->eq(
-                    'ezurl_object_link.contentobject_attribute_version',
-                    'ezcontentobject_attribute.version'
+        if (false === $this->hasJoinedTable($query, ContentGateway::CONTENT_FIELD_TABLE)) {
+            $query->innerJoin(
+                'u_lnk',
+                ContentGateway::CONTENT_FIELD_TABLE,
+                'f_def',
+                $query->expr()->andX(
+                    'u_lnk.contentobject_attribute_id = f_def.id',
+                    'u_lnk.contentobject_attribute_version = f_def.version'
                 )
-            ));
+            );
         }
+    }
+
+    protected function hasJoinedTable(QueryBuilder $queryBuilder, string $tableName): bool
+    {
+        $joinedParts = $queryBuilder->getQueryPart('join');
+        if (empty($joinedParts)) {
+            return false;
+        }
+
+        // extract 'joinTable' nested key and flatten the structure of query parts, which is:
+        // ['fromAlias' => [['joinTable' => '<table_name>'], ...]]
+        // note that one 'fromAlias' can have multiple different tables joined for it, though it's not usual case
+        $joinedTables = array_merge(
+            ...array_values(
+                array_map(
+                    static function (array $joinedPart): array {
+                        return array_column($joinedPart, 'joinTable');
+                    },
+                    $joinedParts
+                )
+            )
+        );
+
+        return in_array($tableName, $joinedTables, true);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Base.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Base.php
@@ -20,7 +20,7 @@ abstract class Base implements CriterionHandler
      */
     protected function joinContentObjectLink(QueryBuilder $query): void
     {
-        if (false === $this->hasJoinedTable($query, DoctrineDatabase::URL_LINK_TABLE)) {
+        if (!$this->hasJoinedTable($query, DoctrineDatabase::URL_LINK_TABLE)) {
             $query->innerJoin(
                 'url',
                 DoctrineDatabase::URL_LINK_TABLE,
@@ -35,7 +35,7 @@ abstract class Base implements CriterionHandler
      */
     protected function joinContentObject(QueryBuilder $query): void
     {
-        if (false === $this->hasJoinedTable($query, ContentGateway::CONTENT_ITEM_TABLE)) {
+        if (!$this->hasJoinedTable($query, ContentGateway::CONTENT_ITEM_TABLE)) {
             $query->innerJoin(
                 'f_def',
                 ContentGateway::CONTENT_ITEM_TABLE,
@@ -50,7 +50,7 @@ abstract class Base implements CriterionHandler
      */
     protected function joinContentObjectAttribute(QueryBuilder $query): void
     {
-        if (false === $this->hasJoinedTable($query, ContentGateway::CONTENT_FIELD_TABLE)) {
+        if (!$this->hasJoinedTable($query, ContentGateway::CONTENT_FIELD_TABLE)) {
             $query->innerJoin(
                 'u_lnk',
                 ContentGateway::CONTENT_FIELD_TABLE,
@@ -65,25 +65,16 @@ abstract class Base implements CriterionHandler
 
     protected function hasJoinedTable(QueryBuilder $queryBuilder, string $tableName): bool
     {
+        // find table name in a structure: ['fromAlias' => [['joinTable' => '<table_name>'], ...]]
         $joinedParts = $queryBuilder->getQueryPart('join');
-        if (empty($joinedParts)) {
-            return false;
+        foreach ($joinedParts as $joinedTables) {
+            foreach ($joinedTables as $join) {
+                if ($join['joinTable'] === $tableName) {
+                    return true;
+                }
+            }
         }
 
-        // extract 'joinTable' nested key and flatten the structure of query parts, which is:
-        // ['fromAlias' => [['joinTable' => '<table_name>'], ...]]
-        // note that one 'fromAlias' can have multiple different tables joined for it, though it's not usual case
-        $joinedTables = array_merge(
-            ...array_values(
-                array_map(
-                    static function (array $joinedPart): array {
-                        return array_column($joinedPart, 'joinTable');
-                    },
-                    $joinedParts
-                )
-            )
-        );
-
-        return in_array($tableName, $joinedTables, true);
+        return false;
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/LogicalAnd.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/LogicalAnd.php
@@ -6,10 +6,10 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 class LogicalAnd implements CriterionHandler
 {
@@ -23,14 +23,16 @@ class LogicalAnd implements CriterionHandler
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
      */
-    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion)
+    public function handle(CriteriaConverter $converter, QueryBuilder $queryBuilder, Criterion $criterion)
     {
         $subexpressions = [];
         foreach ($criterion->criteria as $subCriterion) {
-            $subexpressions[] = $converter->convertCriteria($query, $subCriterion);
+            $subexpressions[] = $converter->convertCriteria($queryBuilder, $subCriterion);
         }
 
-        return $query->expr->lAnd($subexpressions);
+        return $queryBuilder->expr()->andX(...$subexpressions);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/LogicalNot.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/LogicalNot.php
@@ -6,10 +6,10 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 class LogicalNot implements CriterionHandler
 {
@@ -23,11 +23,17 @@ class LogicalNot implements CriterionHandler
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
      */
-    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion)
-    {
-        return $query->expr->not(
-            $converter->convertCriteria($query, $criterion->criteria[0])
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion
+    ) {
+        return sprintf(
+            'NOT (%s)',
+            $converter->convertCriteria($queryBuilder, $criterion->criteria[0])
         );
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/LogicalOr.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/LogicalOr.php
@@ -6,10 +6,10 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 class LogicalOr implements CriterionHandler
 {
@@ -23,14 +23,19 @@ class LogicalOr implements CriterionHandler
 
     /**
      * {@inheritdoc}
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
      */
-    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion)
-    {
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion
+    ) {
         $subexpressions = [];
         foreach ($criterion->criteria as $subCriterion) {
-            $subexpressions[] = $converter->convertCriteria($query, $subCriterion);
+            $subexpressions[] = $converter->convertCriteria($queryBuilder, $subCriterion);
         }
 
-        return $query->expr->lOr($subexpressions);
+        return $queryBuilder->expr()->orX(...$subexpressions);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/MatchAll.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/MatchAll.php
@@ -6,10 +6,10 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 class MatchAll implements CriterionHandler
 {
@@ -24,8 +24,11 @@ class MatchAll implements CriterionHandler
     /**
      * {@inheritdoc}
      */
-    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion)
-    {
-        return $query->bindValue('1');
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion
+    ) {
+        return '1 = 1';
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/MatchNone.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/MatchNone.php
@@ -6,10 +6,10 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 class MatchNone implements CriterionHandler
 {
@@ -24,8 +24,11 @@ class MatchNone implements CriterionHandler
     /**
      * {@inheritdoc}
      */
-    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion)
-    {
-        return $query->expr->not($query->bindValue('1'));
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion
+    ) {
+        return $queryBuilder->expr()->eq(1, 0);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/MatchNone.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/MatchNone.php
@@ -29,6 +29,6 @@ class MatchNone implements CriterionHandler
         QueryBuilder $queryBuilder,
         Criterion $criterion
     ) {
-        return $queryBuilder->expr()->eq(1, 0);
+        return '1 = 0';
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Pattern.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Pattern.php
@@ -6,10 +6,11 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 class Pattern implements CriterionHandler
 {
@@ -24,12 +25,19 @@ class Pattern implements CriterionHandler
     /**
      * {@inheritdoc}
      */
-    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion)
-    {
-        /** @var Criterion\Pattern $criterion */
-        return $query->expr->like(
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion
+    ) {
+        /** @var \eZ\Publish\API\Repository\Values\URL\Query\Criterion\Pattern $criterion */
+        return $queryBuilder->expr()->like(
             'url',
-            $query->bindValue('%' . $criterion->pattern . '%')
+            $queryBuilder->createNamedParameter(
+                '%' . $criterion->pattern . '%',
+                ParameterType::STRING,
+                ':pattern'
+            )
         );
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/SectionId.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/SectionId.php
@@ -8,8 +8,9 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 
 class SectionId extends Base
@@ -25,12 +26,22 @@ class SectionId extends Base
     /**
      * {@inheritdoc}
      */
-    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion): string
-    {
-        $this->joinContentObjectLink($query);
-        $this->joinContentObjectAttribute($query);
-        $this->joinContentObject($query);
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion
+    ) {
+        $this->joinContentObjectLink($queryBuilder);
+        $this->joinContentObjectAttribute($queryBuilder);
+        $this->joinContentObject($queryBuilder);
 
-        return $query->expr->in('ezcontentobject.section_id', $criterion->sectionIds);
+        return $queryBuilder->expr()->in(
+            'c.section_id',
+            $queryBuilder->createNamedParameter(
+                $criterion->sectionIds,
+                Connection::PARAM_INT_ARRAY,
+                ':section_ids'
+            )
+        );
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/SectionIdentifier.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/SectionIdentifier.php
@@ -8,8 +8,10 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
+use eZ\Publish\Core\Persistence\Legacy\Content\Section\Gateway as SectionGateway;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 
 class SectionIdentifier extends Base
@@ -25,19 +27,29 @@ class SectionIdentifier extends Base
     /**
      * {@inheritdoc}
      */
-    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion): string
-    {
-        $this->joinContentObjectLink($query);
-        $this->joinContentObjectAttribute($query);
-        $this->joinContentObject($query);
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion
+    ) {
+        $this->joinContentObjectLink($queryBuilder);
+        $this->joinContentObjectAttribute($queryBuilder);
+        $this->joinContentObject($queryBuilder);
 
-        if (strpos($query->getQuery(), 'INNER JOIN ezsection ') === false) {
-            $query->innerJoin(
-                'ezsection',
-                $query->expr->eq('ezcontentobject.section_id', 'ezsection.id')
-            );
-        }
+        $queryBuilder->innerJoin(
+            'c',
+            SectionGateway::CONTENT_SECTION_TABLE,
+            's',
+            'c.section_id = s.id'
+        );
 
-        return $query->expr->in('ezsection.identifier', $criterion->sectionIdentifiers);
+        return $queryBuilder->expr()->in(
+            's.identifier',
+            $queryBuilder->createNamedParameter(
+                $criterion->sectionIdentifiers,
+                Connection::PARAM_STR_ARRAY,
+                ':section_identifiers'
+            )
+        );
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Validity.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Validity.php
@@ -6,10 +6,11 @@
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
 
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\URL\Query\Criterion;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
 use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 class Validity implements CriterionHandler
 {
@@ -24,12 +25,19 @@ class Validity implements CriterionHandler
     /**
      * {@inheritdoc}
      */
-    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion)
-    {
-        /** @var Criterion\Validity $criterion */
-        return $query->expr->eq(
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion
+    ) {
+        /** @var \eZ\Publish\API\Repository\Values\URL\Query\Criterion\Validity $criterion */
+        return $queryBuilder->expr()->eq(
             'is_valid',
-            $query->bindValue((int) $criterion->isValid)
+            $queryBuilder->createNamedParameter(
+                (int)$criterion->isValid,
+                ParameterType::INTEGER,
+                ':is_valid'
+            )
         );
     }
 }

--- a/eZ/Publish/Core/settings/storage_engines/legacy/url.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/url.yml
@@ -2,7 +2,7 @@ services:
     ezpublish.persistence.legacy.url.gateway.inner:
         class: eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase
         arguments:
-            - '@ezpublish.api.storage_engine.legacy.dbhandler'
+            - '@ezpublish.persistence.connection'
             - '@ezpublish.spi.persistence.legacy.url.criterion_converter'
 
     ezpublish.persistence.legacy.url.gateway.exception_conversion:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31300](https://jira.ez.no/browse/EZP-31300) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921) (#11)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0`
| **BC breaks**                          | yes
| **Tests pass**                          | [yes](https://travis-ci.com/github/ezsystems/ezplatform-kernel/builds/156384093)
| **Doc needed**                       | yes

This PR replaces usages of eZc `DatabaseHandler` with Doctrine `Connection` and `QueryBuilder` in URL Search Gateway and Criteria handlers. The alignment of tests is separated from production code changes for the Reviewers convenience.

Note that only some changes to code style and strict types are applied. They're out of scope anyway and, when it comes to strict types, too risky to be handled now, before final.

For the overview of package-wide changes related to the subject see #11

### Doc:
Please see `doc/bc/changes-1.0.md` (9b9c5bd) in this PR

#### Checklist:
- [x] PR description is updated.
- [x] Tests are aligned.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
