### PR TITLE
EZP-31301: Refactored WordIndexer SearchIndex GW to rely on Doctrine

### DIFF
--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
@@ -1,21 +1,18 @@
 <?php
+
 /**
- * File containing the DoctrineDatabase Content search Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway;
 
+use Doctrine\DBAL\Connection;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator;
 use eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\Persistence\TransformationProcessor;
 use eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex;
 use eZ\Publish\Core\Search\Legacy\Content\FullTextData;
-use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as SPITypeHandler;
-use eZ\Publish\SPI\Search\Field;
 
 /**
  * WordIndexer gateway implementation using the Doctrine database.
@@ -29,13 +26,8 @@ class DoctrineDatabase extends Gateway
      */
     const DB_INT_MAX = 2147483647;
 
-    /**
-     * Database handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     * @deprecated Start to use DBAL $connection instead.
-     */
-    protected $dbHandler;
+    /** @var \Doctrine\DBAL\Connection */
+    protected $connection;
 
     /**
      * SPI Content Type Handler.
@@ -75,24 +67,17 @@ class DoctrineDatabase extends Gateway
     protected $fullTextSearchConfiguration;
 
     /**
-     * Construct from handler handler.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\Type\Handler $typeHandler
-     * @param \eZ\Publish\Core\Persistence\TransformationProcessor $transformationProcessor
-     * @param \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex $searchIndex
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator $languageMaskGenerator
      * @param array $fullTextSearchConfiguration
      */
     public function __construct(
-        DatabaseHandler $dbHandler,
+        Connection $connection,
         SPITypeHandler $typeHandler,
         TransformationProcessor $transformationProcessor,
         SearchIndex $searchIndex,
         MaskGenerator $languageMaskGenerator,
         array $fullTextSearchConfiguration
     ) {
-        $this->dbHandler = $dbHandler;
+        $this->connection = $connection;
         $this->typeHandler = $typeHandler;
         $this->transformationProcessor = $transformationProcessor;
         $this->searchIndex = $searchIndex;
@@ -167,7 +152,7 @@ class DoctrineDatabase extends Gateway
         }
 
         $wordIDArray = $this->buildWordIDArray(array_keys($indexArrayOnlyWords));
-        $this->dbHandler->beginTransaction();
+        $this->connection->beginTransaction();
         for ($arrayCount = 0; $arrayCount < $wordCount; $arrayCount += 1000) {
             $placement = $this->indexWords(
                 $fullTextData,
@@ -176,7 +161,7 @@ class DoctrineDatabase extends Gateway
                 $placement
             );
         }
-        $this->dbHandler->commit();
+        $this->connection->commit();
     }
 
     /**
@@ -209,7 +194,7 @@ class DoctrineDatabase extends Gateway
     public function remove($contentId, $versionId = null)
     {
         $doDelete = false;
-        $this->dbHandler->beginTransaction();
+        $this->connection->beginTransaction();
         // fetch all the words and decrease the object count on all the words
         $wordIDList = $this->searchIndex->getContentObjectWords($contentId);
         if (count($wordIDList) > 0) {
@@ -220,7 +205,7 @@ class DoctrineDatabase extends Gateway
             $this->searchIndex->deleteWordsWithoutObjects();
             $this->searchIndex->deleteObjectWordsLink($contentId);
         }
-        $this->dbHandler->commit();
+        $this->connection->commit();
 
         return true;
     }
@@ -313,7 +298,7 @@ class DoctrineDatabase extends Gateway
         $wordArray = [];
 
         // store the words in the index and remember the ID
-        $this->dbHandler->beginTransaction();
+        $this->connection->beginTransaction();
         for ($arrayCount = 0; $arrayCount < $wordCount; $arrayCount += 500) {
             // Fetch already indexed words from database
             $wordArrayChuck = array_slice($indexArrayOnlyWords, $arrayCount, 500);
@@ -345,7 +330,7 @@ class DoctrineDatabase extends Gateway
                 }
             }
         }
-        $this->dbHandler->commit();
+        $this->connection->commit();
 
         return $wordArray;
     }

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
@@ -66,9 +66,6 @@ class DoctrineDatabase extends Gateway
      */
     protected $fullTextSearchConfiguration;
 
-    /**
-     * @param array $fullTextSearchConfiguration
-     */
     public function __construct(
         Connection $connection,
         SPITypeHandler $typeHandler,

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Repository/SearchIndex.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Repository/SearchIndex.php
@@ -1,61 +1,48 @@
 <?php
 
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository;
 
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
-use PDO;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
 
 /**
  * A service encapsulating database operations on ezsearch* tables.
  */
 class SearchIndex
 {
-    /**
-     * Database handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     * @deprecated Start to use DBAL $connection instead.
-     */
-    protected $dbHandler;
+    public const SEARCH_WORD_TABLE = 'ezsearch_word';
+    public const SEARCH_OBJECT_WORD_LINK_TABLE = 'ezsearch_object_word_link';
 
-    /**
-     * SearchIndex constructor.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
-     */
-    public function __construct(
-        DatabaseHandler $dbHandler
-    ) {
-        $this->dbHandler = $dbHandler;
+    protected $connection;
+
+    public function __construct(Connection $connection)
+    {
+        $this->connection = $connection;
     }
 
     /**
      * Fetch already indexed words from database (legacy db table: ezsearch_word).
      *
      * @param array $words
-     *
-     * @return array
      */
-    public function getWords(array $words)
+    public function getWords(array $words): array
     {
-        $query = $this->dbHandler->createSelectQuery();
+        $query = $this->connection->createQueryBuilder();
 
-        // use array_map as some DBMS-es do not cast integers to strings by default
-        $query->select('*')
-            ->from('ezsearch_word')
-            ->where($query->expr->in('word', array_map('strval', $words)));
+        $query
+            ->select('*')
+            ->from(self::SEARCH_WORD_TABLE)
+            ->where($query->expr()->in('word', ':words'))
+            // use array_map as some DBMS-es do not cast integers to strings by default
+            ->setParameter('words', array_map('strval', $words), Connection::PARAM_STR_ARRAY);
 
-        $stmt = $query->prepare();
-        $stmt->execute();
-
-        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+        return $query->execute()->fetchAll(FetchMode::ASSOCIATIVE);
     }
 
     /**
@@ -63,9 +50,12 @@ class SearchIndex
      *
      * @param array $wordId
      */
-    public function incrementWordObjectCount(array $wordId)
+    public function incrementWordObjectCount(array $wordId): void
     {
-        $this->updateWordObjectCount($wordId, ['object_count' => 'object_count + 1']);
+        $this
+            ->getWordUpdateQuery($wordId)
+            ->set('object_count', 'object_count + 1')
+            ->execute();
     }
 
     /**
@@ -73,9 +63,12 @@ class SearchIndex
      *
      * @param array $wordId
      */
-    public function decrementWordObjectCount(array $wordId)
+    public function decrementWordObjectCount(array $wordId): void
     {
-        $this->updateWordObjectCount($wordId, ['object_count' => 'object_count - 1']);
+        $this
+            ->getWordUpdateQuery($wordId)
+            ->set('object_count', 'object_count - 1')
+            ->execute();
     }
 
     /**
@@ -83,184 +76,189 @@ class SearchIndex
      *
      * @param array $words
      */
-    public function addWords(array $words)
+    public function addWords(array $words): void
     {
-        $query = $this->dbHandler->createInsertQuery();
-        $query->insertInto('ezsearch_word');
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->insert(self::SEARCH_WORD_TABLE)
+            ->values(
+                [
+                    'word' => ':word',
+                    'object_count' => ':one',
+                ]
+            )
+            ->setParameter(':one', 1, ParameterType::INTEGER);
 
-        $word = null;
-
-        $query->set(
-            'word',
-            ':word'
-        )->set(
-            'object_count',
-            '1'
-        );
-        $stmt = $query->prepare();
         foreach ($words as $word) {
-            $stmt->execute(['word' => $word]);
+            $query->setParameter('word', $word);
+            $query->execute();
         }
     }
 
     /**
      * Remove entire search index.
      */
-    public function purge()
+    public function purge(): void
     {
-        $this->dbHandler->beginTransaction();
-        $query = $this->dbHandler->createDeleteQuery();
-        $tables = [
-            'ezsearch_object_word_link',
-            'ezsearch_word',
+        $this->connection->beginTransaction();
+        $searchIndexTables = [
+            self::SEARCH_OBJECT_WORD_LINK_TABLE,
+            self::SEARCH_WORD_TABLE,
         ];
-        foreach ($tables as $tbl) {
-            $query->deleteFrom($tbl);
-            $stmt = $query->prepare();
-            $stmt->execute();
+        foreach ($searchIndexTables as $tableName) {
+            $this->connection
+                ->createQueryBuilder()
+                ->delete($tableName)
+                ->execute();
         }
-        $this->dbHandler->commit();
+        $this->connection->commit();
     }
 
     /**
      * Link word with specific content object (legacy db table: ezsearch_object_word_link).
-     *
-     * @param $wordId
-     * @param $contentId
-     * @param $frequency
-     * @param $placement
-     * @param $nextWordId
-     * @param $prevWordId
-     * @param $contentTypeId
-     * @param $fieldTypeId
-     * @param $published
-     * @param $sectionId
-     * @param $identifier
-     * @param $integerValue
-     * @param $languageMask
      */
-    public function addObjectWordLink($wordId,
-                                      $contentId,
-                                      $frequency,
-                                      $placement,
-                                      $nextWordId,
-                                      $prevWordId,
-                                      $contentTypeId,
-                                      $fieldTypeId,
-                                      $published,
-                                      $sectionId,
-                                      $identifier,
-                                      $integerValue,
-                                      $languageMask
-    ) {
-        $assoc = [
-            'word_id' => $wordId,
-            'contentobject_id' => $contentId,
-            'frequency' => $frequency,
-            'placement' => $placement,
-            'next_word_id' => $nextWordId,
-            'prev_word_id' => $prevWordId,
-            'contentclass_id' => $contentTypeId,
-            'contentclass_attribute_id' => $fieldTypeId,
-            'published' => $published,
-            'section_id' => $sectionId,
-            'identifier' => $identifier,
-            'integer_value' => $integerValue,
-            'language_mask' => $languageMask,
-        ];
-        $query = $this->dbHandler->createInsertQuery();
-        $query->insertInto('ezsearch_object_word_link');
-        foreach ($assoc as $column => $value) {
-            $query->set($this->dbHandler->quoteColumn($column), $query->bindValue($value));
-        }
-        $stmt = $query->prepare();
-        $stmt->execute();
+    public function addObjectWordLink(
+        int $wordId,
+        int $contentId,
+        float $frequency,
+        int $placement,
+        int $nextWordId,
+        int $prevWordId,
+        int $contentTypeId,
+        int $fieldTypeId,
+        int $published,
+        int $sectionId,
+        string $identifier,
+        int $integerValue,
+        int $languageMask
+    ): void {
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->insert(self::SEARCH_OBJECT_WORD_LINK_TABLE)
+            ->values(
+                [
+                    'word_id' => $query->createPositionalParameter($wordId, ParameterType::INTEGER),
+                    'contentobject_id' => $query->createPositionalParameter(
+                        $contentId,
+                        ParameterType::INTEGER
+                    ),
+                    'frequency' => $query->createPositionalParameter($frequency),
+                    'placement' => $query->createPositionalParameter(
+                        $placement,
+                        ParameterType::INTEGER
+                    ),
+                    'next_word_id' => $query->createPositionalParameter(
+                        $nextWordId,
+                        ParameterType::INTEGER
+                    ),
+                    'prev_word_id' => $query->createPositionalParameter(
+                        $prevWordId,
+                        ParameterType::INTEGER
+                    ),
+                    'contentclass_id' => $query->createPositionalParameter(
+                        $contentTypeId,
+                        ParameterType::INTEGER
+                    ),
+                    'contentclass_attribute_id' => $query->createPositionalParameter(
+                        $fieldTypeId,
+                        ParameterType::INTEGER
+                    ),
+                    'published' => $query->createPositionalParameter(
+                        $published,
+                        ParameterType::INTEGER
+                    ),
+                    'section_id' => $query->createPositionalParameter(
+                        $sectionId,
+                        ParameterType::INTEGER
+                    ),
+                    'identifier' => $query->createPositionalParameter(
+                        $identifier,
+                        ParameterType::STRING
+                    ),
+                    'integer_value' => $query->createPositionalParameter(
+                        $integerValue,
+                        ParameterType::INTEGER
+                    ),
+                    'language_mask' => $query->createPositionalParameter(
+                        $languageMask,
+                        ParameterType::INTEGER
+                    ),
+                ]
+            );
+
+        $query->execute();
     }
 
     /**
      * Get all words related to the content object (legacy db table: ezsearch_object_word_link).
-     *
-     * @param $contentId
-     *
-     * @return array
      */
-    public function getContentObjectWords($contentId)
+    public function getContentObjectWords(int $contentId): array
     {
-        $query = $this->dbHandler->createSelectQuery();
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->select('word_id')
+            ->from(self::SEARCH_OBJECT_WORD_LINK_TABLE)
+            ->where(
+                $query->expr()->eq(
+                    'contentobject_id',
+                    $query->createPositionalParameter($contentId, ParameterType::INTEGER)
+                )
+            );
 
-        $this->setContentObjectWordsSelectQuery($query);
-
-        $stmt = $query->prepare();
-        $stmt->execute(['contentId' => $contentId]);
-
-        $wordIDList = [];
-
-        while (false !== ($row = $stmt->fetch(PDO::FETCH_NUM))) {
-            $wordIDList[] = $row[0];
-        }
-
-        return $wordIDList;
+        return $query->execute()->fetchAll(FetchMode::COLUMN);
     }
 
     /**
      * Delete words not related to any content object.
      */
-    public function deleteWordsWithoutObjects()
+    public function deleteWordsWithoutObjects(): void
     {
-        $query = $this->dbHandler->createDeleteQuery();
-
-        $query->deleteFrom($this->dbHandler->quoteTable('ezsearch_word'))
-            ->where($query->expr->eq($this->dbHandler->quoteColumn('object_count'), ':c'));
-
-        $stmt = $query->prepare();
-        $stmt->execute(['c' => 0]);
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->delete(self::SEARCH_WORD_TABLE)
+            ->where(
+                $query->expr()->eq(
+                    'object_count',
+                    $query->createPositionalParameter(0, ParameterType::INTEGER)
+                )
+            );
+        $query->execute();
     }
 
     /**
      * Delete relation between a word and a content object.
-     *
-     * @param $contentId
      */
-    public function deleteObjectWordsLink($contentId)
+    public function deleteObjectWordsLink(int $contentId): void
     {
-        $query = $this->dbHandler->createDeleteQuery();
-        $query->deleteFrom($this->dbHandler->quoteTable('ezsearch_object_word_link'))
-            ->where($query->expr->eq($this->dbHandler->quoteColumn('contentobject_id'), ':contentId'));
-
-        $stmt = $query->prepare();
-        $stmt->execute(['contentId' => $contentId]);
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->delete(self::SEARCH_OBJECT_WORD_LINK_TABLE)
+            ->where(
+                $query->expr()->eq(
+                    'contentobject_id',
+                    $query->createPositionalParameter($contentId, ParameterType::INTEGER)
+                )
+            );
+        $query->execute();
     }
 
     /**
-     * Set query selecting word ids for content object (method was extracted to be reusable).
+     * Build ezsearch_word update query, without any columns set.
      *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
+     * @param array $wordIds list of word IDs
      */
-    private function setContentObjectWordsSelectQuery(SelectQuery $query)
+    private function getWordUpdateQuery(array $wordIds): QueryBuilder
     {
-        $query->select('word_id')
-            ->from($this->dbHandler->quoteTable('ezsearch_object_word_link'))
-            ->where($query->expr->eq($this->dbHandler->quoteColumn('contentobject_id'), ':contentId'));
-    }
+        $query = $this->connection->createQueryBuilder();
+        $query
+            ->update(self::SEARCH_WORD_TABLE)
+            ->where(
+                $query->expr()->in(
+                    'id',
+                    $query->createPositionalParameter($wordIds, Connection::PARAM_INT_ARRAY)
+                )
+            );
 
-    /**
-     * Update object count for words (legacy db table: ezsearch_word).
-     *
-     * @param array $wordId list of word IDs
-     * @param array $columns map of columns and values to be updated ([column => value])
-     */
-    private function updateWordObjectCount(array $wordId, array $columns)
-    {
-        $query = $this->dbHandler->createUpdateQuery();
-        $query->update($this->dbHandler->quoteTable('ezsearch_word'));
-
-        foreach ($columns as $column => $value) {
-            $query->set($this->dbHandler->quoteColumn($column), $value);
-        }
-
-        $query->where($query->expr->in($this->dbHandler->quoteColumn('id'), $wordId));
-
-        $stmt = $query->prepare();
-        $stmt->execute();
+        return $query;
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Repository/SearchIndex.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Repository/SearchIndex.php
@@ -211,7 +211,7 @@ class SearchIndex
     /**
      * Delete words not related to any content object.
      */
-    public function deleteWordsWithoutObjects(): void
+    public function deleteWordsWithoutObjects(): int
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -222,13 +222,14 @@ class SearchIndex
                     $query->createPositionalParameter(0, ParameterType::INTEGER)
                 )
             );
-        $query->execute();
+
+        return $query->execute();
     }
 
     /**
      * Delete relation between a word and a content object.
      */
-    public function deleteObjectWordsLink(int $contentId): void
+    public function deleteObjectWordsLink(int $contentId): int
     {
         $query = $this->connection->createQueryBuilder();
         $query
@@ -239,7 +240,8 @@ class SearchIndex
                     $query->createPositionalParameter($contentId, ParameterType::INTEGER)
                 )
             );
-        $query->execute();
+
+        return $query->execute();
     }
 
     /**

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Repository/SearchIndex.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Repository/SearchIndex.php
@@ -29,7 +29,7 @@ class SearchIndex
     /**
      * Fetch already indexed words from database (legacy db table: ezsearch_word).
      *
-     * @param array $words
+     * @param string[] $words
      */
     public function getWords(array $words): array
     {
@@ -48,7 +48,7 @@ class SearchIndex
     /**
      * Increase the object count of the given words by one.
      *
-     * @param array $wordId
+     * @param int[] $wordId
      */
     public function incrementWordObjectCount(array $wordId): void
     {
@@ -61,7 +61,7 @@ class SearchIndex
     /**
      * Decrease the object count of the given words by one.
      *
-     * @param array $wordId
+     * @param int[] $wordId
      */
     public function decrementWordObjectCount(array $wordId): void
     {
@@ -74,7 +74,7 @@ class SearchIndex
     /**
      * Insert new words (legacy db table: ezsearch_word).
      *
-     * @param array $words
+     * @param string[] $words
      */
     public function addWords(array $words): void
     {

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
@@ -77,7 +77,7 @@ class HandlerContentSortTest extends AbstractTestCase
             ),
             $this->createMock(LocationGateway::class),
             new Content\WordIndexer\Gateway\DoctrineDatabase(
-                $this->getDatabaseHandler(),
+                $this->getDatabaseConnection(),
                 $this->getContentTypeHandler(),
                 $this->getDefinitionBasedTransformationProcessor(),
                 new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseConnection()),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
@@ -80,7 +80,7 @@ class HandlerContentSortTest extends AbstractTestCase
                 $this->getDatabaseHandler(),
                 $this->getContentTypeHandler(),
                 $this->getDefinitionBasedTransformationProcessor(),
-                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler()),
+                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseConnection()),
                 $this->getLanguageMaskGenerator(),
                 $this->getFullTextSearchConfiguration()
             ),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -177,7 +177,7 @@ class HandlerContentTest extends AbstractTestCase
                 $this->getDatabaseHandler(),
                 $this->getContentTypeHandler(),
                 $this->getDefinitionBasedTransformationProcessor(),
-                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler()),
+                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseConnection()),
                 $this->getLanguageMaskGenerator(),
                 $this->getFullTextSearchConfiguration()
             ),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -174,7 +174,7 @@ class HandlerContentTest extends AbstractTestCase
             ),
             $this->createMock(LocationGateway::class),
             new Content\WordIndexer\Gateway\DoctrineDatabase(
-                $this->getDatabaseHandler(),
+                $this->getDatabaseConnection(),
                 $this->getContentTypeHandler(),
                 $this->getDefinitionBasedTransformationProcessor(),
                 new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseConnection()),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
@@ -93,7 +93,7 @@ class HandlerLocationSortTest extends AbstractTestCase
                 $this->getDatabaseHandler(),
                 $this->getContentTypeHandler(),
                 $this->getDefinitionBasedTransformationProcessor(),
-                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler()),
+                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseConnection()),
                 $this->getLanguageMaskGenerator(),
                 $this->getFullTextSearchConfiguration()
             ),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
@@ -90,7 +90,7 @@ class HandlerLocationSortTest extends AbstractTestCase
                 $this->getLanguageHandler()
             ),
             new Content\WordIndexer\Gateway\DoctrineDatabase(
-                $this->getDatabaseHandler(),
+                $this->getDatabaseConnection(),
                 $this->getContentTypeHandler(),
                 $this->getDefinitionBasedTransformationProcessor(),
                 new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseConnection()),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
@@ -151,7 +151,7 @@ class HandlerLocationTest extends AbstractTestCase
                 $this->getLanguageHandler()
             ),
             new Content\WordIndexer\Gateway\DoctrineDatabase(
-                $this->getDatabaseHandler(),
+                $this->getDatabaseConnection(),
                 $this->getContentTypeHandler(),
                 $transformationProcessor,
                 new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseConnection()),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
@@ -154,7 +154,7 @@ class HandlerLocationTest extends AbstractTestCase
                 $this->getDatabaseHandler(),
                 $this->getContentTypeHandler(),
                 $transformationProcessor,
-                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseHandler()),
+                new Content\WordIndexer\Repository\SearchIndex($this->getDatabaseConnection()),
                 $this->getLanguageMaskGenerator(),
                 $this->getFullTextSearchConfiguration()
             ),

--- a/eZ/Publish/Core/settings/search_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy.yml
@@ -69,13 +69,13 @@ services:
     ezpublish.spi.search.legacy:
         class: eZ\Publish\Core\Search\Legacy\Content\Handler
         arguments:
-            - "@ezpublish.search.legacy.gateway.content"
-            - "@ezpublish.search.legacy.gateway.location"
-            - "@ezpublish.search.legacy.gateway.wordIndexer"
-            - "@ezpublish.persistence.legacy.content.mapper"
-            - "@ezpublish.persistence.legacy.location.mapper"
-            - "@ezpublish.spi.persistence.language_handler"
-            - "@ezpublish.search.legacy.fulltext_mapper"
+            - '@ezpublish.search.legacy.gateway.content'
+            - '@ezpublish.search.legacy.gateway.location'
+            - '@eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase'
+            - '@ezpublish.persistence.legacy.content.mapper'
+            - '@ezpublish.persistence.legacy.location.mapper'
+            - '@ezpublish.spi.persistence.language_handler'
+            - '@ezpublish.search.legacy.fulltext_mapper'
         tags:
             - {name: ezpublish.searchEngine, alias: legacy}
         lazy: true

--- a/eZ/Publish/Core/settings/search_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy.yml
@@ -69,13 +69,13 @@ services:
     ezpublish.spi.search.legacy:
         class: eZ\Publish\Core\Search\Legacy\Content\Handler
         arguments:
-            - '@ezpublish.search.legacy.gateway.content'
-            - '@ezpublish.search.legacy.gateway.location'
-            - '@eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase'
-            - '@ezpublish.persistence.legacy.content.mapper'
-            - '@ezpublish.persistence.legacy.location.mapper'
-            - '@ezpublish.spi.persistence.language_handler'
-            - '@ezpublish.search.legacy.fulltext_mapper'
+            $gateway: '@ezpublish.search.legacy.gateway.content'
+            $locationGateway: '@ezpublish.search.legacy.gateway.location'
+            $indexerGateway: '@eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase'
+            $contentMapper: '@ezpublish.persistence.legacy.content.mapper'
+            $locationMapper: '@ezpublish.persistence.legacy.location.mapper'
+            $languageHandler: '@ezpublish.spi.persistence.language_handler'
+            $mapper: '@ezpublish.search.legacy.fulltext_mapper'
         tags:
             - {name: ezpublish.searchEngine, alias: legacy}
         lazy: true

--- a/eZ/Publish/Core/settings/search_engines/legacy/indexer.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/indexer.yml
@@ -1,7 +1,7 @@
 services:
     eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase:
         arguments:
-            $dbHandler: '@ezpublish.api.storage_engine.legacy.dbhandler'
+            $connection: '@ezpublish.persistence.connection'
             $typeHandler: '@ezpublish.spi.persistence.content_type_handler'
             $transformationProcessor: '@ezpublish.api.storage_engine.transformation_processor'
             $searchIndex: '@eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex'

--- a/eZ/Publish/Core/settings/search_engines/legacy/indexer.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/indexer.yml
@@ -1,15 +1,13 @@
 services:
-    ezpublish.search.legacy.gateway.wordIndexer:
-        class: eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase
+    eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase:
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.spi.persistence.content_type_handler"
-            - "@ezpublish.api.storage_engine.transformation_processor"
-            - "@ezpublish.search.legacy.repository.searchIndex"
-            - "@ezpublish.persistence.legacy.language.mask_generator"
-            - "%ezpublish.search.legacy.criterion_handler.full_text.configuration%"
+            $dbHandler: '@ezpublish.api.storage_engine.legacy.dbhandler'
+            $typeHandler: '@ezpublish.spi.persistence.content_type_handler'
+            $transformationProcessor: '@ezpublish.api.storage_engine.transformation_processor'
+            $searchIndex: '@eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex'
+            $languageMaskGenerator: '@ezpublish.persistence.legacy.language.mask_generator'
+            $fullTextSearchConfiguration: '%ezpublish.search.legacy.criterion_handler.full_text.configuration%'
 
-    ezpublish.search.legacy.repository.searchIndex:
-        class: eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex
+    eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository\SearchIndex:
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
+            $connection: '@ezpublish.persistence.connection'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31301](https://jira.ez.no/browse/EZP-31301) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921)
| **Related to**                           | #10
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This PR replaces eZc `DatabaseHandler` with Doctrine `Connection` and `QueryBuilder` in Word Indexer gateways (the ones called "under the hood" for `ezplatform:reindex` for LSE).

Note: please look past confusing naming (I should refactor it as a follow up). FullText indexing for LSE was ported from eZ Publish by a noob who then, in 2016, recently joined the company (yes, me :P).

#### QA
Can be tested with #10 (common branch [for-qa-ezp-31301-31517-lse-sanity](https://github.com/ezsystems/ezplatform-kernel/compare/for-qa-ezp-31301-31517-lse-sanity)).
- [ ] Sanity for ezplatform:reindex on Legacy Search Engine (MySQL, PostgreSQL).

#### Checklist:
- [x] PR description is updated.
- [x] Tests are aligned.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
