### PR TITLE
EZP-30392: [LSE] Dropped deprecated support for `%` as a wildcard

### DIFF
--- a/doc/bc/changes-1.0.md
+++ b/doc/bc/changes-1.0.md
@@ -260,6 +260,8 @@ Changes affecting version compatibility with deprecated ezpublish-kernel version
   Security package of Symfony framework to provide authenticated user, as it may happen there are
   different ways of providing users configured in the application (ref.: https://symfony.com/doc/current/security/user_provider.html).
 
+* Legacy (SQL) Search Engine will no longer treat deprecated `%` as a search wildcard. Use `*` instead.
+
 ## Deprecated features
 
 * Using SiteAccess-aware `pagelayout` setting is derecated, use `page_layout` instead.

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
@@ -1113,16 +1113,6 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
         $criteria = new Field('data', Operator::LIKE, $valueTwo);
 
         $this->assertFindResult($context, $criteria, false, true, $filter, $content, $modifyField);
-
-        // BC support for "%" for Legacy Storage engine only
-        // @deprecated In 6.13.x/7.3.x and higher, to be removed in 8.0
-        if (!$this->supportsLikeWildcard($valueTwo) || get_class($this->getSetupFactory()) !== Legacy::class) {
-            return;
-        }
-
-        $criteria = new Field('data', Operator::LIKE, substr_replace($valueTwo, '%', 1, 1));
-
-        $this->assertFindResult($context, $criteria, false, true, $filter, $content, $modifyField);
     }
 
     /**

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler.php
@@ -105,17 +105,7 @@ abstract class Handler
                 break;
 
             case Criterion\Operator::LIKE:
-                if (strpos($criterion->value, '%') !== false) {
-                    // @deprecated In 6.13.x/7.3.x and higher, to be removed in 8.0
-                    @trigger_error(
-                        "Usage of '%' in Operator::LIKE criteria with Legacy Search Engine was never intended, " .
-                        "and is deprecated for removal in 8.0. Please use '*' like in FullText, works across engines",
-                        E_USER_DEPRECATED
-                    );
-                    $value = $this->lowerCase($criterion->value);
-                } else {
-                    $value = str_replace('*', '%', $this->prepareLikeString($criterion->value));
-                }
+                $value = str_replace('*', '%', $this->prepareLikeString($criterion->value));
 
                 $filter = $query->expr->like(
                     $column,

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Collection.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Collection.php
@@ -59,18 +59,9 @@ class Collection extends Handler
 
         switch ($criterion->operator) {
             case Criterion\Operator::LIKE:
-                if (strpos($criterion->value, '%') !== false) {
-                    // @deprecated In 6.13.x/7.3.x and higher, to be removed in 8.0
-                    @trigger_error(
-                        "Usage of '%' in Operator::LIKE criteria with Legacy Search Engine was never intended, " .
-                        "and is deprecated for removal in 8.0. Please use '*' like in FullText, works across engines",
-                        E_USER_DEPRECATED
-                    );
-                    $value = $this->lowerCase($criterion->value);
-                } else {
-                    // Allow usage of * as wildcards in ::LIKE
-                    $value = str_replace('*', '%', $this->prepareLikeString($criterion->value));
-                }
+                // Allow usage of * as wildcards in ::LIKE
+                $value = str_replace('*', '%', $this->prepareLikeString($criterion->value));
+
                 $singleValueExpr = 'like';
                 // No break here, rest is handled by shared code with ::CONTAINS below
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-30392](https://jira.ez.no/browse/EZP-30392)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0`
| **BC breaks**                          | yes
| **Tests pass**                          | yes
| **Doc needed**                       | yes

This PR drops deprecated support for `%` sign as a wildcard operator in the Legacy (SQL) Search Engine. Search API consumer should use `*` instead.

#### Checklist:
- [x] PR description is updated.
- [x] Tests are passing.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.