### PR TITLE
EZEE-3069: Ensured type of $destination property value is int for location based url aliases

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -202,21 +202,21 @@ abstract class BaseTest extends TestCase
      * @param mixed[] $expectedValues
      * @param \eZ\Publish\API\Repository\Values\ValueObject $actualObject
      */
-    protected function assertPropertiesCorrect(array $expectedValues, ValueObject $actualObject, bool $strictComparison = false)
+    protected function assertPropertiesCorrect(array $expectedValues, ValueObject $actualObject)
     {
         foreach ($expectedValues as $propertyName => $propertyValue) {
             if ($propertyValue instanceof ValueObject) {
-                $this->assertStructPropertiesCorrect($propertyValue, $actualObject->$propertyName, [], $strictComparison);
+                $this->assertStructPropertiesCorrect($propertyValue, $actualObject->$propertyName);
             } elseif (is_array($propertyValue)) {
                 foreach ($propertyValue as $key => $value) {
                     if ($value instanceof ValueObject) {
-                        $this->assertStructPropertiesCorrect($value, $actualObject->$propertyName[$key], [], $strictComparison);
+                        $this->assertStructPropertiesCorrect($value, $actualObject->$propertyName[$key]);
                     } else {
-                        $this->assertPropertiesEqual("$propertyName\[$key\]", $value, $actualObject->$propertyName[$key], false, $strictComparison);
+                        $this->assertPropertiesEqual("$propertyName\[$key\]", $value, $actualObject->$propertyName[$key]);
                     }
                 }
             } else {
-                $this->assertPropertiesEqual($propertyName, $propertyValue, $actualObject->$propertyName, false, $strictComparison);
+                $this->assertPropertiesEqual($propertyName, $propertyValue, $actualObject->$propertyName);
             }
         }
     }
@@ -252,18 +252,18 @@ abstract class BaseTest extends TestCase
      * @param \eZ\Publish\API\Repository\Values\ValueObject $actualObject
      * @param array $propertyNames
      */
-    protected function assertStructPropertiesCorrect(ValueObject $expectedValues, ValueObject $actualObject, array $additionalProperties = [], bool $strictComparison = false)
+    protected function assertStructPropertiesCorrect(ValueObject $expectedValues, ValueObject $actualObject, array $additionalProperties = [])
     {
         foreach ($expectedValues as $propertyName => $propertyValue) {
             if ($propertyValue instanceof ValueObject) {
-                $this->assertStructPropertiesCorrect($propertyValue, $actualObject->$propertyName, $additionalProperties, $strictComparison);
+                $this->assertStructPropertiesCorrect($propertyValue, $actualObject->$propertyName);
             } else {
-                $this->assertPropertiesEqual($propertyName, $propertyValue, $actualObject->$propertyName, false, $strictComparison);
+                $this->assertPropertiesEqual($propertyName, $propertyValue, $actualObject->$propertyName);
             }
         }
 
         foreach ($additionalProperties as $propertyName) {
-            $this->assertPropertiesEqual($propertyName, $expectedValues->$propertyName, $actualObject->$propertyName, $strictComparison);
+            $this->assertPropertiesEqual($propertyName, $expectedValues->$propertyName, $actualObject->$propertyName);
         }
     }
 
@@ -284,7 +284,7 @@ abstract class BaseTest extends TestCase
         usort($items, $sorter);
     }
 
-    private function assertPropertiesEqual($propertyName, $expectedValue, $actualValue, $sortArray = false, bool $strictComparison = false)
+    private function assertPropertiesEqual($propertyName, $expectedValue, $actualValue, $sortArray = false)
     {
         if ($expectedValue instanceof ArrayObject) {
             $expectedValue = $expectedValue->getArrayCopy();
@@ -302,19 +302,11 @@ abstract class BaseTest extends TestCase
             $this->sortItems($expectedValue);
         }
 
-        if ($strictComparison) {
-            $this->assertSame(
-                $expectedValue,
-                $actualValue,
-                sprintf('Object property "%s" incorrect.', $propertyName)
-            );
-        } else {
-            $this->assertEquals(
-                $expectedValue,
-                $actualValue,
-                sprintf('Object property "%s" incorrect.', $propertyName)
-            );
-        }
+        $this->assertEquals(
+            $expectedValue,
+            $actualValue,
+            sprintf('Object property "%s" incorrect.', $propertyName)
+        );
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
@@ -122,6 +122,31 @@ class URLAliasServiceTest extends BaseTest
         );
     }
 
+    public function testLoad(): void
+    {
+        $repository = $this->getRepository();
+
+        $urlAliasService = $repository->getURLAliasService();
+
+        // Load URL alias for root location
+        $loadedUrlAlias = $urlAliasService->load('0-d41d8cd98f00b204e9800998ecf8427e');
+
+        $this->assertPropertiesCorrect(
+            [
+                'type' => URLAlias::LOCATION,
+                'destination' => 2,
+                'path' => '/',
+                'languageCodes' => ['eng-US', 'eng-GB'],
+                'alwaysAvailable' => true,
+                'isHistory' => false,
+                'isCustom' => false,
+                'forward' => false,
+            ],
+            $loadedUrlAlias,
+            true
+        );
+    }
+
     /**
      * @param array $testData
      *

--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
@@ -131,7 +131,7 @@ class URLAliasServiceTest extends BaseTest
         // Load URL alias for root location
         $loadedUrlAlias = $urlAliasService->load('0-d41d8cd98f00b204e9800998ecf8427e');
 
-        $this->assertPropertiesCorrect(
+        $this->assertUrlAliasPropertiesSame(
             [
                 'type' => URLAlias::LOCATION,
                 'destination' => 2,
@@ -142,8 +142,7 @@ class URLAliasServiceTest extends BaseTest
                 'isCustom' => false,
                 'forward' => false,
             ],
-            $loadedUrlAlias,
-            true
+            $loadedUrlAlias
         );
     }
 
@@ -1630,6 +1629,23 @@ class URLAliasServiceTest extends BaseTest
 
         $contentTypeService->updateContentTypeDraft($contentTypeDraft, $contentTypeUpdateStruct);
         $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+    }
+
+    private function assertUrlAliasPropertiesSame(array $expectedValues, URLAlias $urlAlias): void
+    {
+        $this->assertSame(
+            $expectedValues,
+            [
+                'type' => $urlAlias->type,
+                'destination' => $urlAlias->destination,
+                'path' => $urlAlias->path,
+                'languageCodes' => $urlAlias->languageCodes,
+                'alwaysAvailable' => $urlAlias->alwaysAvailable,
+                'isHistory' => $urlAlias->isHistory,
+                'isCustom' => $urlAlias->isCustom,
+                'forward' => $urlAlias->forward,
+            ]
+        );
     }
 
     private function assertUrlAliasPropertiesCorrect(

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Mapper.php
@@ -108,7 +108,7 @@ class Mapper
             switch ($actionType) {
                 case 'eznode':
                     $type = UrlAlias::LOCATION;
-                    $destination = $actionValue;
+                    $destination = (int)$actionValue;
                     break;
 
                 case 'module':


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZEE-3069](https://jira.ez.no/browse/EZEE-3069)
| **Type**                                   | bug
| **Target eZ Platform version** | `3.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

According to doc: if url alias type is `URLAlias::LOCATION` then `destination` property contains location id which should be typeof int.  

#### Changes

Actual bugfix: https://github.com/ezsystems/ezplatform-kernel/pull/26/files#diff-50956c9b2b9e4174ee6c9013cf358264R111

Actual test: https://github.com/ezsystems/ezplatform-kernel/pull/26/files#diff-ce61cc0866ae34a229c2e0d39d33cd6bR125-R148

all other intorduced changes allows to use strict comparison in `assertPropertiesCorrect`.

#### Checklist:
- [X] PR description is updated.
- [X] Tests are implemented.
- [X] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
