### PR TITLE
EZP-31302: Refactored LSE to rely on Doctrine Connection

### DIFF
--- a/doc/bc/changes-1.0.md
+++ b/doc/bc/changes-1.0.md
@@ -317,6 +317,67 @@ Changes affecting version compatibility with deprecated ezpublish-kernel version
   public function handle(CriteriaConverter $converter, QueryBuilder $query, Criterion $criterion);
   ```
 
+* The signature of the `\eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler::handle`
+  contract accepts now `\Doctrine\DBAL\Query\QueryBuilder` instead of `\eZ\Publish\Core\Persistence\Database\SelectQuery`
+  and has the following form:
+  ```php
+  use \Doctrine\DBAL\Query\QueryBuilder;
+  use \eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+  use \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
+
+  abstract public function handle(
+      CriteriaConverter $converter,
+      QueryBuilder $queryBuilder,
+      Criterion $criterion,
+      array $languageSettings
+  );
+  ```
+* The signature of the `\eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler::handle`
+  contract accepts now two new arguments of `\Doctrine\DBAL\Query\QueryBuilder` type instead of
+  `\eZ\Publish\Core\Persistence\Database\SelectQuery`. The first one is an outer query, to be used
+  only for parameter binding. The second one is a sub-query that can be modified according to a strategy
+  needed by a particular Field Type. This change is necessary due to the nature of Doctrine Query Builder.
+  While sub-queries are used for convenience, in the end, the only query having parameters bound
+  and being executed is the outer query. The sub-query is used just to generate nested SQL for the outer query.
+  The signature has the following form:
+  ```php
+    use \Doctrine\DBAL\Query\QueryBuilder;
+    use \eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+    use \Doctrine\DBAL\Query\Expression\CompositeExpression;
+
+    public function handle(
+        QueryBuilder $outerQuery,
+        QueryBuilder $subQuery,
+        Criterion $criterion,
+        string $column
+    ): CompositeExpression|string;
+  ```
+
+* The signature of the `\eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler::applySelect`
+  contract accepts now `\Doctrine\DBAL\Query\QueryBuilder` instead of `\eZ\Publish\Core\Persistence\Database\SelectQuery`
+  and has the following form:
+  ```php
+  use \Doctrine\DBAL\Query\QueryBuilder;
+  use \eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+
+  abstract public function applySelect(QueryBuilder $query, SortClause $sortClause, int $number): array;
+  ```
+
+* The signature of the `\eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler::applyJoin`
+  contract accepts now `\Doctrine\DBAL\Query\QueryBuilder` instead of `\eZ\Publish\Core\Persistence\Database\SelectQuery`
+  and has the following form:
+  ```php
+  use \Doctrine\DBAL\Query\QueryBuilder;
+  use \eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+
+  public function applyJoin(
+          QueryBuilder $query,
+          SortClause $sortClause,
+          int $number,
+          array $languageSettings
+  ): void;
+  ```
+
 ## Removed services
 
 * `ezpublish.field_type_collection.factory` has been removed in favor of `eZ\Publish\Core\FieldType\FieldTypeRegistry`

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriteriaConverter.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriteriaConverter.php
@@ -1,15 +1,13 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase criteria converter class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 
 /**
@@ -47,16 +45,14 @@ class CriteriaConverter
     /**
      * Generic converter of criteria into query fragments.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Criterion is not applicable to its target
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param array $languageSettings
      *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
+     * @return \Doctrine\DBAL\Query\Expression\CompositeExpression|string
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
      */
     public function convertCriteria(
-        SelectQuery $query,
+        QueryBuilder $query,
         Criterion $criterion,
         array $languageSettings
     ) {

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
@@ -71,13 +71,13 @@ abstract class CriterionHandler
         array $languageSettings
     );
 
-    protected function hasJoinedTable(QueryBuilder $queryBuilder, string $tableName): bool
+    protected function hasJoinedTableAs(QueryBuilder $queryBuilder, string $tableAlias): bool
     {
         // find table name in a structure: ['fromAlias' => [['joinTable' => '<table_name>'], ...]]
         $joinedParts = $queryBuilder->getQueryPart('join');
         foreach ($joinedParts as $joinedTables) {
             foreach ($joinedTables as $join) {
-                if ($join['joinTable'] === $tableName) {
+                if ($join['joinAlias'] === $tableAlias) {
                     return true;
                 }
             }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
@@ -31,9 +31,16 @@ abstract class CriterionHandler
     /** @var \Doctrine\DBAL\Connection */
     protected $connection;
 
+    /** @var \Doctrine\DBAL\Platforms\AbstractPlatform|null */
+    protected $dbPlatform;
+
+    /**
+     * @throws \Doctrine\DBAL\DBALException
+     */
     public function __construct(Connection $connection)
     {
         $this->connection = $connection;
+        $this->dbPlatform = $connection->getDatabasePlatform();
     }
 
     /**
@@ -53,6 +60,7 @@ abstract class CriterionHandler
      * @param array $languageSettings
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      *
      * @return \Doctrine\DBAL\Query\Expression\CompositeExpression|string
      */
@@ -62,4 +70,19 @@ abstract class CriterionHandler
         Criterion $criterion,
         array $languageSettings
     );
+
+    protected function hasJoinedTable(QueryBuilder $queryBuilder, string $tableName): bool
+    {
+        // find table name in a structure: ['fromAlias' => [['joinTable' => '<table_name>'], ...]]
+        $joinedParts = $queryBuilder->getQueryPart('join');
+        foreach ($joinedParts as $joinedTables) {
+            foreach ($joinedTables as $join) {
+                if ($join['joinTable'] === $tableName) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing the Legacy location criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 
 abstract class CriterionHandler
@@ -30,22 +28,12 @@ abstract class CriterionHandler
         Operator::LIKE => 'like',
     ];
 
-    /**
-     * Database handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     * @deprecated Start to use DBAL $connection instead.
-     */
-    protected $dbHandler;
+    /** @var \Doctrine\DBAL\Connection */
+    protected $connection;
 
-    /**
-     * Creates a new criterion handler.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
-     */
-    public function __construct(DatabaseHandler $dbHandler)
+    public function __construct(Connection $connection)
     {
-        $this->dbHandler = $dbHandler;
+        $this->connection = $connection;
     }
 
     /**
@@ -62,14 +50,15 @@ abstract class CriterionHandler
      *
      * accept() must be called before calling this method.
      *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
      * @param array $languageSettings
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
+     *
+     * @return \Doctrine\DBAL\Query\Expression\CompositeExpression|string
      */
     abstract public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     );

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
@@ -62,14 +62,4 @@ abstract class CriterionHandler
         Criterion $criterion,
         array $languageSettings
     );
-
-    /**
-     * Returns a unique table name.
-     *
-     * @return string
-     */
-    protected function getUniqueTableName()
-    {
-        return uniqid('CriterionHandler', true);
-    }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/CompositeCriterion.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/CompositeCriterion.php
@@ -8,10 +8,10 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 class CompositeCriterion extends CriterionHandler
 {
@@ -20,8 +20,12 @@ class CompositeCriterion extends CriterionHandler
         return $criterion instanceof Criterion\CompositeCriterion;
     }
 
-    public function handle(CriteriaConverter $converter, SelectQuery $query, Criterion $criterion, array $languageSettings)
-    {
-        return $converter->convertCriteria($query, $criterion->criteria, $languageSettings);
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        return $converter->convertCriteria($queryBuilder, $criterion->criteria, $languageSettings);
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentId.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase Content id criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content ID criterion handler.
@@ -30,27 +29,17 @@ class ContentId extends CriterionHandler
         return $criterion instanceof Criterion\ContentId;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
-            $criterion->value
+        $value = (array)$criterion->value;
+
+        return $queryBuilder->expr()->in(
+            'c.id',
+            $queryBuilder->createNamedParameter($value, Connection::PARAM_INT_ARRAY)
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeGroupId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeGroupId.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase content type group criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content type group criterion handler.
@@ -30,40 +29,28 @@ class ContentTypeGroupId extends CriterionHandler
         return $criterion instanceof Criterion\ContentTypeGroupId;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        $subSelect = $query->subSelect();
+        $subSelect = $this->connection->createQueryBuilder();
         $subSelect
             ->select(
-                $this->dbHandler->quoteColumn('contentclass_id')
+                'contentclass_id'
             )->from(
-                $this->dbHandler->quoteTable('ezcontentclass_classgroup')
+                'ezcontentclass_classgroup'
             )->where(
-                $query->expr->in(
-                    $this->dbHandler->quoteColumn('group_id'),
-                    $criterion->value
+                $queryBuilder->expr()->in(
+                    'group_id',
+                    $queryBuilder->createNamedParameter($criterion->value, Connection::PARAM_INT_ARRAY)
                 )
             );
 
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('contentclass_id', 'ezcontentobject'),
-            $subSelect
+        return $queryBuilder->expr()->in(
+            'c.contentclass_id',
+            $subSelect->getSQL()
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeId.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase content type criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content type criterion handler.
@@ -30,27 +29,15 @@ class ContentTypeId extends CriterionHandler
         return $criterion instanceof Criterion\ContentTypeId;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('contentclass_id', 'ezcontentobject'),
-            $criterion->value
+        return $queryBuilder->expr()->in(
+            'c.contentclass_id',
+            $queryBuilder->createNamedParameter($criterion->value, Connection::PARAM_INT_ARRAY)
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
@@ -1,16 +1,17 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase FieldRelation criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use RuntimeException;
 
@@ -19,6 +20,15 @@ use RuntimeException;
  */
 class FieldRelation extends FieldBase
 {
+    /**
+     * Field relation column, tied to chosen table alias.
+     *
+     * c_rel: ContentGateway::CONTENT_RELATION_TABLE
+     *
+     * @see \eZ\Publish\Core\Persistence\Legacy\Content\Gateway::CONTENT_RELATION_TABLE
+     */
+    private const CONTENT_ITEM_REL_COLUMN = 'c_rel.to_contentobject_id';
+
     /**
      * Check if this criterion handler accepts to handle the given criterion.
      *
@@ -34,18 +44,17 @@ class FieldRelation extends FieldBase
     /**
      * Returns a list of IDs of searchable FieldDefinitions for the given criterion target.
      *
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException If no searchable fields are found for the given $fieldIdentifier.
-     *
      * @param string $fieldDefinitionIdentifier
      *
      * @return array
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException If no searchable fields are found for the given $fieldIdentifier.
      */
     protected function getFieldDefinitionsIds($fieldDefinitionIdentifier)
     {
         $fieldDefinitionIdList = [];
         $fieldMap = $this->contentTypeHandler->getSearchableFieldMap();
 
-        foreach ($fieldMap as $contentTypeIdentifier => $fieldIdentifierMap) {
+        foreach ($fieldMap as $fieldIdentifierMap) {
             // First check if field exists in the current ContentType, there is nothing to do if it doesn't
             if (!isset($fieldIdentifierMap[$fieldDefinitionIdentifier])) {
                 continue;
@@ -64,103 +73,127 @@ class FieldRelation extends FieldBase
         return $fieldDefinitionIdList;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @throws \RuntimeException
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        $column = $this->dbHandler->quoteColumn('to_contentobject_id', 'ezcontentobject_link');
         $fieldDefinitionIds = $this->getFieldDefinitionsIds($criterion->target);
 
+        $criterionValue = (array)$criterion->value;
         switch ($criterion->operator) {
             case Criterion\Operator::CONTAINS:
-                if (count($criterion->value) > 1) {
-                    $subRequest = [];
-
-                    foreach ($criterion->value as $value) {
-                        $subSelect = $query->subSelect();
-
-                        $subSelect->select(
-                            $this->dbHandler->quoteColumn('from_contentobject_id')
-                        )->from(
-                            $this->dbHandler->quoteTable('ezcontentobject_link')
-                        );
-
-                        $subSelect->where(
-                            $subSelect->expr->lAnd(
-                                $subSelect->expr->eq(
-                                    $this->dbHandler->quoteColumn('from_contentobject_version', 'ezcontentobject_link'),
-                                    $this->dbHandler->quoteColumn('current_version', 'ezcontentobject')
-                                ),
-                                $subSelect->expr->in(
-                                    $this->dbHandler->quoteColumn('contentclassattribute_id', 'ezcontentobject_link'),
-                                    $fieldDefinitionIds
-                                ),
-                                $subSelect->expr->eq(
-                                    $column,
-                                    $value
-                                )
-                            )
-                        );
-
-                        $subRequest[] = $subSelect->expr->in(
-                            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
-                            $subSelect
-                        );
-                    }
-
-                    return $query->expr->lAnd(
-                        $subRequest
+                if (count($criterionValue) > 1) {
+                    $subRequest = $this->buildQueryForContainsOperator(
+                        $queryBuilder,
+                        $criterionValue,
+                        $fieldDefinitionIds
                     );
+
+                    return $queryBuilder->expr()->andX(...$subRequest);
                 }
-                // Intentionally omitting break
+            // Intentionally omitting break
 
             case Criterion\Operator::IN:
-                $subSelect = $query->subSelect();
-
-                $subSelect->select(
-                    $this->dbHandler->quoteColumn('from_contentobject_id')
-                )->from(
-                    $this->dbHandler->quoteTable('ezcontentobject_link')
+                $subSelect = $this->buildQueryForInOperator(
+                    $queryBuilder,
+                    $criterionValue,
+                    $fieldDefinitionIds
                 );
 
-                return $query->expr->in(
-                    $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
-                    $subSelect->where(
-                        $subSelect->expr->lAnd(
-                            $subSelect->expr->eq(
-                                $this->dbHandler->quoteColumn('from_contentobject_version', 'ezcontentobject_link'),
-                                $this->dbHandler->quoteColumn('current_version', 'ezcontentobject')
-                            ),
-                            $subSelect->expr->in(
-                                $this->dbHandler->quoteColumn('contentclassattribute_id', 'ezcontentobject_link'),
-                                $fieldDefinitionIds
-                            ),
-                            $subSelect->expr->in(
-                                $column,
-                                $criterion->value
-                            )
-                        )
-                    )
+                return $queryBuilder->expr()->in(
+                    'c.id',
+                    $subSelect->getSQL()
                 );
 
             default:
-                throw new RuntimeException("Unknown operator '{$criterion->operator}' for RelationList Criterion handler.");
+                throw new RuntimeException(
+                    "Unknown operator '{$criterion->operator}' for RelationList Criterion handler."
+                );
         }
+    }
+
+    protected function buildQueryForContainsOperator(
+        QueryBuilder $queryBuilder,
+        array $criterionValue,
+        array $fieldDefinitionIds
+    ): array {
+        $subRequest = [];
+
+        foreach ($criterionValue as $value) {
+            $subSelect = $this->connection->createQueryBuilder();
+            $expr = $subSelect->expr();
+
+            $subSelect
+                ->select('from_contentobject_id')
+                ->from(ContentGateway::CONTENT_RELATION_TABLE, 'c_rel');
+
+            $subSelect->where(
+                $expr->andX(
+                    $expr->eq(
+                        'c_rel.from_contentobject_version',
+                        'c.current_version'
+                    ),
+                    $expr->in(
+                        'c_rel.contentclassattribute_id',
+                        $queryBuilder->createNamedParameter($fieldDefinitionIds, Connection::PARAM_INT_ARRAY)
+                    ),
+                    $expr->eq(
+                        self::CONTENT_ITEM_REL_COLUMN,
+                        $queryBuilder->createNamedParameter(
+                            $value,
+                            ParameterType::INTEGER
+                        )
+                    )
+                )
+            );
+
+            $subRequest[] = $expr->in(
+                'c.id',
+                $subSelect->getSQL()
+            );
+        }
+
+        return $subRequest;
+    }
+
+    protected function buildQueryForInOperator(
+        QueryBuilder $queryBuilder,
+        array $criterionValue,
+        array $fieldDefinitionIds
+    ): QueryBuilder {
+        $subSelect = $this->connection->createQueryBuilder();
+        $expr = $subSelect->expr();
+
+        $subSelect
+            ->select('from_contentobject_id')
+            ->from(ContentGateway::CONTENT_RELATION_TABLE, 'c_rel')
+            ->where(
+                $expr->eq(
+                    'c_rel.from_contentobject_version',
+                    'c.current_version'
+                ),
+            )
+            ->andWhere(
+                $expr->in(
+                    'c_rel.contentclassattribute_id',
+                    $queryBuilder->createNamedParameter(
+                        $fieldDefinitionIds,
+                        Connection::PARAM_INT_ARRAY
+                    )
+                )
+            )
+            ->andWhere(
+                $expr->in(
+                    self::CONTENT_ITEM_REL_COLUMN,
+                    $queryBuilder->createNamedParameter(
+                        $criterionValue,
+                        Connection::PARAM_INT_ARRAY
+                    )
+                )
+            );
+
+        return $subSelect;
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Keyword.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Keyword.php
@@ -1,43 +1,39 @@
 <?php
 
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * FieldValue CriterionHandler handling ezkeyword External Storage for Legacy/SQL Search.
  */
 class Keyword extends Collection
 {
-    /**
-     * Generates query expression for operator and value of a Field Criterion.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param string $column
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
-    public function handle(SelectQuery $query, Criterion $criterion, $column)
-    {
-        $query
+    public function handle(
+        QueryBuilder $outerQuery,
+        QueryBuilder $subQuery,
+        Criterion $criterion,
+        string $column
+    ) {
+        $subQuery
             ->innerJoin(
-                $this->dbHandler->quoteTable('ezkeyword_attribute_link'),
-                'ezcontentobject_attribute.id',
-                'ezkeyword_attribute_link.objectattribute_id'
-            )->innerJoin(
-                $this->dbHandler->quoteTable('ezkeyword'),
-                'ezkeyword.id',
-                'ezkeyword_attribute_link.keyword_id'
+                'f_def',
+                'ezkeyword_attribute_link',
+                'kwd_lnk',
+                'f_def.id = kwd_lnk.objectattribute_id'
+            )
+            ->innerJoin(
+                'kwd_lnk',
+                'ezkeyword',
+                'kwd',
+                'kwd.id = kwd_lnk.keyword_id'
             );
 
-        return parent::handle($query, $criterion, 'keyword');
+        return parent::handle($outerQuery, $subQuery, $criterion, 'keyword');
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LanguageCode.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LanguageCode.php
@@ -1,19 +1,17 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase language code criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * LanguageCode criterion handler.
@@ -23,16 +21,11 @@ class LanguageCode extends CriterionHandler
     /** @var \eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator */
     private $maskGenerator;
 
-    /**
-     * Construct from language mask generator.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $dbHandler
-     * @param \eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator $maskGenerator
-     */
-    public function __construct(DatabaseHandler $dbHandler, MaskGenerator $maskGenerator)
+    public function __construct(Connection $connection, MaskGenerator $maskGenerator)
     {
+        parent::__construct($connection);
+
         $this->maskGenerator = $maskGenerator;
-        parent::__construct($dbHandler);
     }
 
     /**
@@ -47,28 +40,16 @@ class LanguageCode extends CriterionHandler
         return $criterion instanceof Criterion\LanguageCode;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
         /* @var $criterion \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LanguageCode */
-        return $query->expr->gt(
-            $query->expr->bitAnd(
-                $this->dbHandler->quoteColumn('language_mask', 'ezcontentobject'),
+        return $queryBuilder->expr()->gt(
+            $this->dbPlatform->getBitAndComparisonExpression(
+                'c.language_mask',
                 $this->maskGenerator->generateLanguageMaskFromLanguageCodes(
                     $criterion->value,
                     $criterion->matchAlwaysAvailable

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalAnd.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalAnd.php
@@ -1,17 +1,15 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase logical and criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Logical and criterion handler.
@@ -30,33 +28,21 @@ class LogicalAnd extends CriterionHandler
         return $criterion instanceof Criterion\LogicalAnd;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
         $subexpressions = [];
         foreach ($criterion->criteria as $subCriterion) {
             $subexpressions[] = $converter->convertCriteria(
-                $query,
+                $queryBuilder,
                 $subCriterion,
                 $languageSettings
             );
         }
 
-        return $query->expr->lAnd($subexpressions);
+        return $queryBuilder->expr()->andX(...$subexpressions);
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalNot.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalNot.php
@@ -1,17 +1,15 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase logical not criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Logical not criterion handler.
@@ -30,26 +28,15 @@ class LogicalNot extends CriterionHandler
         return $criterion instanceof Criterion\LogicalNot;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        return $query->expr->not(
-            $converter->convertCriteria($query, $criterion->criteria[0], $languageSettings)
+        return sprintf(
+            'NOT (%s)',
+            $converter->convertCriteria($queryBuilder, $criterion->criteria[0], $languageSettings)
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalOr.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalOr.php
@@ -1,17 +1,15 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase logical or criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Logical or criterion handler.
@@ -30,33 +28,21 @@ class LogicalOr extends CriterionHandler
         return $criterion instanceof Criterion\LogicalOr;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
         $subexpressions = [];
         foreach ($criterion->criteria as $subCriterion) {
             $subexpressions[] = $converter->convertCriteria(
-                $query,
+                $queryBuilder,
                 $subCriterion,
                 $languageSettings
             );
         }
 
-        return $query->expr->lOr($subexpressions);
+        return $queryBuilder->expr()->orX(...$subexpressions);
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MapLocationDistance.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MapLocationDistance.php
@@ -1,18 +1,17 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase MapLocationDistance criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value\MapLocationValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use RuntimeException;
 
 /**
@@ -45,18 +44,17 @@ class MapLocationDistance extends FieldBase
     /**
      * Returns a list of IDs of searchable FieldDefinitions for the given criterion target.
      *
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException If no searchable fields are found for the given $fieldIdentifier.
-     *
      * @param string $fieldIdentifier
      *
      * @return array
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentException If no searchable fields are found for the given $fieldIdentifier.
      */
     protected function getFieldDefinitionIds($fieldIdentifier)
     {
         $fieldDefinitionIdList = [];
         $fieldMap = $this->contentTypeHandler->getSearchableFieldMap();
 
-        foreach ($fieldMap as $contentTypeIdentifier => $fieldIdentifierMap) {
+        foreach ($fieldMap as $fieldIdentifierMap) {
             // First check if field exists in the current ContentType, there is nothing to do if it doesn't
             if (
                 !(
@@ -85,63 +83,33 @@ class MapLocationDistance extends FieldBase
         return $kilometers / self::DEGREE_KM;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException If no searchable fields are found for the given criterion target.
-     * @throws \RuntimeException If given criterion operator is not handled
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
         $fieldDefinitionIds = $this->getFieldDefinitionIds($criterion->target);
-        $subSelect = $query->subSelect();
+        $subSelect = $this->connection->createQueryBuilder();
 
         /** @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value\MapLocationValue $location */
         $location = $criterion->valueData;
 
-        /*
-         * Note: this formula is precise only for short distances.
-         * @todo if ABS function was available in Zeta Database component it should be possible to account for
-         * distances across the date line. Revisit when Doctrine DBAL is introduced.
-         */
-        $longitudeCorrectionByLatitude = cos(deg2rad($location->latitude)) ** 2;
-        $distanceExpression = $subSelect->expr->add(
-            $subSelect->expr->mul(
-                $subSelect->expr->sub(
-                    $this->dbHandler->quoteColumn('latitude', 'ezgmaplocation'),
-                    $subSelect->bindValue($location->latitude)
-                ),
-                $subSelect->expr->sub(
-                    $this->dbHandler->quoteColumn('latitude', 'ezgmaplocation'),
-                    $subSelect->bindValue($location->latitude)
-                )
-            ),
-            $subSelect->expr->mul(
-                $subSelect->expr->sub(
-                    $this->dbHandler->quoteColumn('longitude', 'ezgmaplocation'),
-                    $subSelect->bindValue($location->longitude)
-                ),
-                $subSelect->expr->sub(
-                    $this->dbHandler->quoteColumn('longitude', 'ezgmaplocation'),
-                    $subSelect->bindValue($location->longitude)
-                ),
-                $subSelect->bindValue($longitudeCorrectionByLatitude)
-            )
+        // note: avoid using literal names for parameters to account for multiple visits of the same Criterion
+        $latitudePlaceholder = $queryBuilder->createNamedParameter($location->latitude);
+        $longitudePlaceholder = $queryBuilder->createNamedParameter($location->longitude);
+        $correctionPlaceholder = $queryBuilder->createNamedParameter(
+            cos(deg2rad($location->latitude)) ** 2
         );
 
+        // build: (latitude1 - latitude2)^2 + (longitude2 - longitude2)^2 * longitude_correction)
+        $latitudeSubstrExpr = "(map.latitude - {$latitudePlaceholder})";
+        $longitudeSubstrExpr = "(map.longitude - {$longitudePlaceholder})";
+        $latitudeExpr = "{$latitudeSubstrExpr} * {$latitudeSubstrExpr}";
+        $longitudeExpr = "{$longitudeSubstrExpr} * {$longitudeSubstrExpr} * {$correctionPlaceholder}";
+        $distanceExpression = "{$latitudeExpr} + {$longitudeExpr}";
+
+        $expr = $subSelect->expr();
         switch ($criterion->operator) {
             case Criterion\Operator::IN:
             case Criterion\Operator::EQ:
@@ -151,10 +119,10 @@ class MapLocationDistance extends FieldBase
             case Criterion\Operator::LTE:
                 $operatorFunction = $this->comparatorMap[$criterion->operator];
                 $distanceInDegrees = $this->kilometersToDegrees($criterion->value) ** 2;
-                $distanceFilter = $subSelect->expr->$operatorFunction(
+                $distanceFilter = $expr->$operatorFunction(
                     $distanceExpression,
-                    $subSelect->expr->round(
-                        $subSelect->bindValue($distanceInDegrees),
+                    $this->dbPlatform->getRoundExpression(
+                        $queryBuilder->createNamedParameter($distanceInDegrees),
                         10
                     )
                 );
@@ -163,16 +131,16 @@ class MapLocationDistance extends FieldBase
             case Criterion\Operator::BETWEEN:
                 $distanceInDegrees1 = $this->kilometersToDegrees($criterion->value[0]) ** 2;
                 $distanceInDegrees2 = $this->kilometersToDegrees($criterion->value[1]) ** 2;
-                $distanceFilter = $subSelect->expr->between(
+                $distanceFilter = $this->dbPlatform->getBetweenExpression(
                     $distanceExpression,
-                    $subSelect->expr->round(
-                        $subSelect->bindValue($distanceInDegrees1),
+                    $this->dbPlatform->getRoundExpression(
+                        $queryBuilder->createNamedParameter($distanceInDegrees1),
                         10
                     ),
-                    $subSelect->expr->round(
-                        $subSelect->bindValue($distanceInDegrees2),
+                    $this->dbPlatform->getRoundExpression(
+                        $queryBuilder->createNamedParameter($distanceInDegrees2),
                         10
-                    )
+                    ),
                 );
                 break;
 
@@ -193,80 +161,77 @@ class MapLocationDistance extends FieldBase
                     $criterion->value[0] :
                     $criterion->value[1];
                 break;
+            default:
+                // Skip other operators
+                break;
         }
         if (isset($distanceUpper)) {
-            $boundingConstraints = $this->getBoundingConstraints($subSelect, $location, $distanceUpper);
+            $boundingConstraints = $this->getBoundingConstraints(
+                $queryBuilder,
+                $location,
+                $distanceUpper
+            );
         }
 
         $subSelect
-            ->select($this->dbHandler->quoteColumn('contentobject_id'))
-            ->from($this->dbHandler->quoteTable('ezcontentobject_attribute'))
+            ->select('contentobject_id')
+            ->from('ezcontentobject_attribute', 'f_def')
             ->innerJoin(
-                $this->dbHandler->quoteTable('ezgmaplocation'),
-                $subSelect->expr->lAnd(
-                    [
-                        $subSelect->expr->eq(
-                            $this->dbHandler->quoteColumn('contentobject_version', 'ezgmaplocation'),
-                            $this->dbHandler->quoteColumn('version', 'ezcontentobject_attribute')
-                        ),
-                        $subSelect->expr->eq(
-                            $this->dbHandler->quoteColumn('contentobject_attribute_id', 'ezgmaplocation'),
-                            $this->dbHandler->quoteColumn('id', 'ezcontentobject_attribute')
-                        ),
-                    ],
-                    $boundingConstraints
+                'f_def',
+                'ezgmaplocation',
+                'map',
+                $expr->andX(
+                    'map.contentobject_version = f_def.version',
+                    'map.contentobject_attribute_id = f_def.id',
+                    ...$boundingConstraints
                 )
             )
-            ->where(
-                $subSelect->expr->lAnd(
-                    $subSelect->expr->eq(
-                        $this->dbHandler->quoteColumn('version', 'ezcontentobject_attribute'),
-                        $this->dbHandler->quoteColumn('current_version', 'ezcontentobject')
-                    ),
-                    $subSelect->expr->in(
-                        $this->dbHandler->quoteColumn('contentclassattribute_id', 'ezcontentobject_attribute'),
-                        $fieldDefinitionIds
-                    ),
-                    $distanceFilter,
-                    $this->getFieldCondition($subSelect, $languageSettings)
+            // note: joining by correlation on outer table
+            ->where('f_def.version = c.current_version')
+            ->andWhere(
+                $expr->in(
+                    'f_def.contentclassattribute_id',
+                    $queryBuilder->createNamedParameter($fieldDefinitionIds, Connection::PARAM_INT_ARRAY)
                 )
-            );
+            )
+            ->andWhere($distanceFilter)
+            ->andWhere($this->getFieldCondition($queryBuilder, $languageSettings))
+        ;
 
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
-            $subSelect
+        return $queryBuilder->expr()->in(
+            'c.id',
+            $subSelect->getSQL()
         );
     }
 
     /**
      * Credit for the formula goes to http://janmatuschek.de/LatitudeLongitudeBoundingCoordinates.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value\MapLocationValue $location
-     * @param float $distance
-     *
-     * @return array
      */
-    protected function getBoundingConstraints(SelectQuery $query, MapLocationValue $location, $distance)
-    {
+    protected function getBoundingConstraints(
+        QueryBuilder $query,
+        MapLocationValue $location,
+        float $distance
+    ): array {
         $boundingCoordinates = $this->getBoundingCoordinates($location, $distance);
 
+        $expr = $query->expr();
+
         return [
-            $query->expr->gte(
-                $this->dbHandler->quoteColumn('latitude', 'ezgmaplocation'),
-                $query->bindValue($boundingCoordinates['lowLatitude'])
+            $expr->gte(
+                'map.latitude',
+                $query->createNamedParameter($boundingCoordinates['lowLatitude'])
             ),
-            $query->expr->gte(
-                $this->dbHandler->quoteColumn('longitude', 'ezgmaplocation'),
-                $query->bindValue($boundingCoordinates['lowLongitude'])
+            $expr->gte(
+                'map.longitude',
+                $query->createNamedParameter($boundingCoordinates['lowLongitude'])
             ),
-            $query->expr->lte(
-                $this->dbHandler->quoteColumn('latitude', 'ezgmaplocation'),
-                $query->bindValue($boundingCoordinates['highLatitude'])
+            $expr->lte(
+                'map.latitude',
+                $query->createNamedParameter($boundingCoordinates['highLatitude'])
             ),
-            $query->expr->lte(
-                $this->dbHandler->quoteColumn('longitude', 'ezgmaplocation'),
-                $query->bindValue($boundingCoordinates['highLongitude'])
+            $expr->lte(
+                'map.longitude',
+                $query->createNamedParameter($boundingCoordinates['highLongitude'])
             ),
         ];
     }
@@ -276,13 +241,12 @@ class MapLocationDistance extends FieldBase
      *
      * Credits: http://janmatuschek.de/LatitudeLongitudeBoundingCoordinates
      *
-     * @todo it should also be possible to calculate inner bounding box, which could be applied for the
-     * operators GT, GTE and lower distance of the BETWEEN operator.
-     *
      * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value\MapLocationValue $location
      * @param float $distance
      *
      * @return array
+     * @todo it should also be possible to calculate inner bounding box, which could be applied for the
+     * operators GT, GTE and lower distance of the BETWEEN operator.
      */
     protected function getBoundingCoordinates(MapLocationValue $location, $distance)
     {

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchAll.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchAll.php
@@ -1,17 +1,15 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase match all criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * MatchAll criterion handler.
@@ -30,24 +28,12 @@ class MatchAll extends CriterionHandler
         return $criterion instanceof Criterion\MatchAll;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        return $query->bindValue('1');
+        return '1 = 1';
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchNone.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchNone.php
@@ -1,17 +1,15 @@
 <?php
 
 /**
- * This file is part of the eZ Publish package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * MatchNone criterion handler.
@@ -30,24 +28,12 @@ class MatchNone extends CriterionHandler
         return $criterion instanceof Criterion\MatchNone;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        return $query->expr->not($query->bindValue('1'));
+        return '1 = 0';
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ObjectStateId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ObjectStateId.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase object state id criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * ObjectState ID criterion handler.
@@ -30,45 +29,29 @@ class ObjectStateId extends CriterionHandler
         return $criterion instanceof Criterion\ObjectStateId;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @todo: Needs optimisation since this subselect can potentially be problematic
-     * due to large number of contentobject_id values returned. One way to fix this
-     * is to use inner joins on ezcobj_state_link table, but this is not currently
-     * supported in legacy search gateway
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        $subSelect = $query->subSelect();
+        $subSelect = $this->connection->createQueryBuilder();
+        $value = (array)$criterion->value;
         $subSelect
             ->select(
-                $this->dbHandler->quoteColumn('contentobject_id')
+                'contentobject_id'
             )->from(
-                $this->dbHandler->quoteTable('ezcobj_state_link')
+                'ezcobj_state_link'
             )->where(
-                $query->expr->in(
-                    $this->dbHandler->quoteColumn('contentobject_state_id'),
-                    $criterion->value
+                $queryBuilder->expr()->in(
+                    'contentobject_state_id',
+                    $queryBuilder->createNamedParameter($value, Connection::PARAM_INT_ARRAY)
                 )
             );
 
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
-            $subSelect
+        return $queryBuilder->expr()->in(
+            'c.id',
+            $subSelect->getSQL()
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/RemoteId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/RemoteId.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase remote id criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Remote id criterion handler.
@@ -30,27 +29,17 @@ class RemoteId extends CriterionHandler
         return $criterion instanceof Criterion\RemoteId;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('remote_id', 'ezcontentobject'),
-            $criterion->value
+        $remoteIds = (array)$criterion->value;
+
+        return $queryBuilder->expr()->in(
+            'c.remote_id',
+            $queryBuilder->createNamedParameter($remoteIds, Connection::PARAM_STR_ARRAY)
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionId.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase section criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Section criterion handler.
@@ -30,27 +29,17 @@ class SectionId extends CriterionHandler
         return $criterion instanceof Criterion\SectionId;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('section_id', 'ezcontentobject'),
-            $criterion->value
+        $sectionIds = (array)$criterion->value;
+
+        return $queryBuilder->expr()->in(
+            'c.section_id',
+            $queryBuilder->createNamedParameter($sectionIds, Connection::PARAM_INT_ARRAY)
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionIdentifier.php
@@ -8,10 +8,11 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 class SectionIdentifier extends CriterionHandler
 {
@@ -22,38 +23,31 @@ class SectionIdentifier extends CriterionHandler
 
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        $subSelect = $query->subSelect();
+        $subSelect = $this->connection->createQueryBuilder();
+        $value = (array)$criterion->value;
         $subSelect
-            ->select(
-                $this->dbHandler->quoteColumn('id', 't1')
-            )->from(
-                $query->alias(
-                    $this->dbHandler->quoteTable('ezcontentobject'),
-                    't1'
-                )
-            )->leftJoin(
-                $query->alias(
-                    $this->dbHandler->quoteTable('ezsection'),
-                    't2'
-                ),
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('section_id', 't1'),
-                    $this->dbHandler->quoteColumn('id', 't2')
-                )
-            )->where(
-                $query->expr->in(
-                    $this->dbHandler->quoteColumn('identifier', 't2'),
-                    $criterion->value
+            ->select('t1.id')
+            ->from('ezcontentobject', 't1')
+            ->leftJoin(
+                't1',
+                'ezsection',
+                't2',
+                't1.section_id = t2.id'
+            )
+            ->where(
+                $queryBuilder->expr()->in(
+                    't2.identifier',
+                    $queryBuilder->createNamedParameter($value, Connection::PARAM_STR_ARRAY)
                 )
             );
 
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
-            $subSelect
+        return $queryBuilder->expr()->in(
+            'c.id',
+            $subSelect->getSQL()
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserEmail.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserEmail.php
@@ -8,21 +8,23 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Persistence\TransformationProcessor;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 class UserEmail extends CriterionHandler
 {
     /** @var \eZ\Publish\Core\Persistence\TransformationProcessor */
     private $transformationProcessor;
 
-    public function __construct(DatabaseHandler $dbHandler, TransformationProcessor $transformationProcessor)
-    {
-        parent::__construct($dbHandler);
+    public function __construct(
+        Connection $connection,
+        TransformationProcessor $transformationProcessor
+    ) {
+        parent::__construct($connection);
 
         $this->transformationProcessor = $transformationProcessor;
     }
@@ -34,14 +36,14 @@ class UserEmail extends CriterionHandler
 
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
         if (Criterion\Operator::LIKE === $criterion->operator) {
-            $expression = $query->expr->like(
-                $this->dbHandler->quoteColumn('email', 't1'),
-                $query->bindValue(
+            $expression = $queryBuilder->expr()->like(
+                't1.email',
+                $queryBuilder->createNamedParameter(
                     str_replace(
                         '*',
                         '%',
@@ -56,28 +58,22 @@ class UserEmail extends CriterionHandler
                 )
             );
         } else {
-            $expression = $query->expr->in(
-                $this->dbHandler->quoteColumn('email', 't1'),
-                $criterion->value
+            $value = (array)$criterion->value;
+            $expression = $queryBuilder->expr()->in(
+                't1.email',
+                $queryBuilder->createNamedParameter($value, Connection::PARAM_STR_ARRAY)
             );
         }
 
-        $subSelect = $query->subSelect();
+        $subSelect = $this->connection->createQueryBuilder();
         $subSelect
-            ->select(
-                $this->dbHandler->quoteColumn('contentobject_id', 't1')
-            )->from(
-                $query->alias(
-                    $this->dbHandler->quoteTable('ezuser'),
-                    't1'
-                )
-            )->where(
-                $expression
-            );
+            ->select('t1.contentobject_id')
+            ->from('ezuser', 't1')
+            ->where($expression);
 
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
-            $subSelect
+        return $queryBuilder->expr()->in(
+            'c.id',
+            $subSelect->getSQL()
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/AbstractRandom.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/AbstractRandom.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing a DoctrineDatabase sort clause handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,22 +27,21 @@ abstract class AbstractRandom extends SortClauseHandler
         return $sortClause instanceof SortClause\Random;
     }
 
-    /**
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query,
+        SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
+            ->addSelect(
+                sprintf(
+                    '%s AS %s',
                     $this->getRandomFunctionName($sortClause->targetData->seed),
                     $column = $this->getSortColumnName($number)
                 )
             );
 
-        return $column;
+        return [$column];
     }
 
     abstract public function getRandomFunctionName(?int $seed): string;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/ContentId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/ContentId.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing a DoctrineDatabase sort clause handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,31 +27,19 @@ class ContentId extends SortClauseHandler
         return $sortClause instanceof SortClause\ContentId;
     }
 
-    /**
-     * Apply selects to the query.
-     *
-     * Returns the name of the (aliased) column, which information should be
-     * used for sorting.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query,
+        SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
-                    $this->dbHandler->quoteColumn(
-                        'id',
-                        'ezcontentobject'
-                    ),
+            ->addSelect(
+                sprintf(
+                    'c.id AS %s',
                     $column = $this->getSortColumnName($number)
                 )
             );
 
-        return $column;
+        return [$column];
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/ContentName.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/ContentName.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing a DoctrineDatabase sort clause handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,31 +27,19 @@ class ContentName extends SortClauseHandler
         return $sortClause instanceof SortClause\ContentName;
     }
 
-    /**
-     * Apply selects to the query.
-     *
-     * Returns the name of the (aliased) column, which information should be
-     * used for sorting.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query,
+        SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
-                    $this->dbHandler->quoteColumn(
-                        'name',
-                        'ezcontentobject'
-                    ),
+            ->addSelect(
+                sprintf(
+                    'c.name AS %s',
                     $column = $this->getSortColumnName($number)
                 )
             );
 
-        return $column;
+        return (array)$column;
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/DateModified.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/DateModified.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing a DoctrineDatabase sort clause handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,31 +27,19 @@ class DateModified extends SortClauseHandler
         return $sortClause instanceof SortClause\DateModified;
     }
 
-    /**
-     * Apply selects to the query.
-     *
-     * Returns the name of the (aliased) column, which information should be
-     * used for sorting.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query,
+        SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
-                    $this->dbHandler->quoteColumn(
-                        'modified',
-                        'ezcontentobject'
-                    ),
+            ->addSelect(
+                sprintf(
+                    'c.modified AS %s',
                     $column = $this->getSortColumnName($number)
                 )
             );
 
-        return $column;
+        return [$column];
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/DatePublished.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/DatePublished.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing a DoctrineDatabase sort clause handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,31 +27,19 @@ class DatePublished extends SortClauseHandler
         return $sortClause instanceof SortClause\DatePublished;
     }
 
-    /**
-     * Apply selects to the query.
-     *
-     * Returns the name of the (aliased) column, which information should be
-     * used for sorting.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query,
+        SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
-                    $this->dbHandler->quoteColumn(
-                        'published',
-                        'ezcontentobject'
-                    ),
+            ->addSelect(
+                sprintf(
+                    'c.published AS %s',
                     $column = $this->getSortColumnName($number)
                 )
             );
 
-        return $column;
+        return [$column];
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/SectionIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/SectionIdentifier.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing a DoctrineDatabase sort clause handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,31 +27,19 @@ class SectionIdentifier extends SortClauseHandler
         return $sortClause instanceof SortClause\SectionIdentifier;
     }
 
-    /**
-     * Apply selects to the query.
-     *
-     * Returns the name of the (aliased) column, which information should be
-     * used for sorting.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query,
+        SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
-                    $this->dbHandler->quoteColumn(
-                        'section_id',
-                        'ezcontentobject'
-                    ),
+            ->addSelect(
+                sprintf(
+                    'c.section_id AS %s',
                     $column = $this->getSortColumnName($number)
                 )
             );
 
-        return $column;
+        return [$column];
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/SectionName.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/SectionName.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing a DoctrineDatabase sort clause handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,59 +27,36 @@ class SectionName extends SortClauseHandler
         return $sortClause instanceof SortClause\SectionName;
     }
 
-    /**
-     * Apply selects to the query.
-     *
-     * Returns the name of the (aliased) column, which information should be
-     * used for sorting.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query,
+        SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
-                    $this->dbHandler->quoteColumn(
-                        'name',
-                        $this->getSortTableName($number)
-                    ),
+            ->addSelect(
+                sprintf(
+                    '%s AS %s',
+                    $this->getSortTableName($number) . '.name',
                     $column = $this->getSortColumnName($number)
                 )
             );
 
-        return $column;
+        return [$column];
     }
 
-    /**
-     * Applies joins to the query, required to fetch sort data.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     * @param array $languageSettings
-     */
     public function applyJoin(
-        SelectQuery $query,
+        QueryBuilder $query,
         SortClause $sortClause,
-        $number,
+        int $number,
         array $languageSettings
-    ) {
+    ): void {
         $table = $this->getSortTableName($number);
         $query
             ->leftJoin(
-                $query->alias(
-                    $this->dbHandler->quoteTable('ezsection'),
-                    $this->dbHandler->quoteIdentifier($table)
-                ),
-                $query->expr->eq(
-                    $this->dbHandler->quoteColumn('id', $table),
-                    $this->dbHandler->quoteColumn('section_id', 'ezcontentobject')
-                )
+                'c',
+                'ezsection',
+                $table,
+                "{$table}.id = c.section_id"
             );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the Content Search Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -19,8 +17,6 @@ abstract class Gateway
     /**
      * Returns a list of object satisfying the $criterion.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Criterion is not applicable to its target
-     *
      * @param Criterion $criterion
      * @param int $offset
      * @param int $limit
@@ -29,6 +25,9 @@ abstract class Gateway
      * @param bool $doCount
      *
      * @return mixed[][]
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Criterion is not applicable to its target
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException if a given Criterion Handler or Sort Clause is not implemented
      */
     abstract public function find(
         Criterion $criterion,
@@ -37,5 +36,5 @@ abstract class Gateway
         array $sort = null,
         array $languageFilter = [],
         $doCount = true
-    );
+    ): array;
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Ancestor.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Ancestor.php
@@ -1,17 +1,15 @@
 <?php
 
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Visits the Ancestor criterion.
@@ -30,21 +28,9 @@ class Ancestor extends CriterionHandler
         return $criterion instanceof Criterion\Ancestor;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
@@ -55,20 +41,20 @@ class Ancestor extends CriterionHandler
             }
         }
 
-        $subSelect = $query->subSelect();
+        $subSelect = $this->connection->createQueryBuilder();
         $subSelect
-            ->select($this->dbHandler->quoteColumn('contentobject_id'))
-            ->from($this->dbHandler->quoteTable('ezcontentobject_tree'))
+            ->select('contentobject_id')
+            ->from('ezcontentobject_tree')
             ->where(
-                $query->expr->in(
-                    $this->dbHandler->quoteColumn('node_id'),
+                $queryBuilder->expr()->in(
+                    'node_id',
                     array_keys($idSet)
                 )
             );
 
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
-            $subSelect
+        return $queryBuilder->expr()->in(
+            'c.id',
+            $subSelect->getSQL()
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationId.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase location id criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Location id criterion handler.
@@ -30,40 +29,29 @@ class LocationId extends CriterionHandler
         return $criterion instanceof Criterion\LocationId;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        $subSelect = $query->subSelect();
+        $locationIds = (array)$criterion->value;
+        $subSelect = $this->connection->createQueryBuilder();
         $subSelect
             ->select(
-                $this->dbHandler->quoteColumn('contentobject_id')
+                'contentobject_id'
             )->from(
-                $this->dbHandler->quoteTable('ezcontentobject_tree')
+                'ezcontentobject_tree'
             )->where(
-                $query->expr->in(
-                    $this->dbHandler->quoteColumn('node_id'),
-                    $criterion->value
+                $queryBuilder->expr()->in(
+                    'node_id',
+                    $queryBuilder->createNamedParameter($locationIds, Connection::PARAM_INT_ARRAY)
                 )
             );
 
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
-            $subSelect
+        return $queryBuilder->expr()->in(
+            'c.id',
+            $subSelect->getSQL()
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/ParentLocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/ParentLocationId.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase parent location id criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Parent location id criterion handler.
@@ -30,40 +29,32 @@ class ParentLocationId extends CriterionHandler
         return $criterion instanceof Criterion\ParentLocationId;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        $subSelect = $query->subSelect();
+        $subSelect = $this->connection->createQueryBuilder();
+        $expr = $queryBuilder->expr();
         $subSelect
             ->select(
-                $this->dbHandler->quoteColumn('contentobject_id')
+                'contentobject_id'
             )->from(
-                $this->dbHandler->quoteTable('ezcontentobject_tree')
+                'ezcontentobject_tree'
             )->where(
-                $query->expr->in(
-                    $this->dbHandler->quoteColumn('parent_node_id'),
-                    $criterion->value
+                $expr->in(
+                    'parent_node_id',
+                    $queryBuilder->createNamedParameter(
+                        $criterion->value,
+                        Connection::PARAM_INT_ARRAY
+                    )
                 )
             );
 
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
-            $subSelect
+        return $expr->in(
+            'c.id',
+            $subSelect->getSQL()
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/PermissionSubtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/PermissionSubtree.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase permission subtree criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\Core\Repository\Values\Content\Query\Criterion\PermissionSubtree as PermissionSubtreeCriterion;
 
 /**
@@ -31,21 +30,9 @@ class PermissionSubtree extends CriterionHandler
         return $criterion instanceof PermissionSubtreeCriterion;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
@@ -53,34 +40,26 @@ class PermissionSubtree extends CriterionHandler
 
         $statements = [];
         foreach ($criterion->value as $pattern) {
-            $statements[] = $query->expr->like(
-                $this->dbHandler->quoteColumn('path_string', $table),
-                $query->bindValue($pattern . '%')
+            $statements[] = $queryBuilder->expr()->like(
+                "{$table}.path_string",
+                $queryBuilder->createNamedParameter($pattern . '%')
             );
         }
 
-        // Check if ezcontentobject_tree was already joined, if it was there is no need to join
-        // with it again - first join will be reused by all other PermissionSubtree criteria
-        /** @var $query \eZ\Publish\Core\Persistence\Doctrine\SelectDoctrineQuery */
-        if (!$query->permissionSubtreeJoinAdded) {
-            $query
+        if (!$this->hasJoinedTable($queryBuilder, LocationGateway::CONTENT_TREE_TABLE)) {
+            $locationTableAlias = $this->connection->quoteIdentifier($table);
+            $queryBuilder
                 ->leftJoin(
-                    $query->alias(
-                        $this->dbHandler->quoteTable('ezcontentobject_tree'),
-                        $this->dbHandler->quoteIdentifier($table)
-                    ),
-                    $query->expr->eq(
-                        $this->dbHandler->quoteColumn('contentobject_id', $table),
-                        $this->dbHandler->quoteColumn('id', 'ezcontentobject')
+                    'c',
+                    LocationGateway::CONTENT_TREE_TABLE,
+                    $locationTableAlias,
+                    $queryBuilder->expr()->eq(
+                        "{$locationTableAlias}.contentobject_id",
+                        'c.id'
                     )
                 );
-
-            // Set joined state to true
-            $query->permissionSubtreeJoinAdded = true;
         }
 
-        return $query->expr->lOr(
-            $statements
-        );
+        return $queryBuilder->expr()->orX(...$statements);
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/PermissionSubtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/PermissionSubtree.php
@@ -46,8 +46,8 @@ class PermissionSubtree extends CriterionHandler
             );
         }
 
-        if (!$this->hasJoinedTable($queryBuilder, LocationGateway::CONTENT_TREE_TABLE)) {
-            $locationTableAlias = $this->connection->quoteIdentifier($table);
+        $locationTableAlias = $this->connection->quoteIdentifier($table);
+        if (!$this->hasJoinedTableAs($queryBuilder, $locationTableAlias)) {
             $queryBuilder
                 ->leftJoin(
                     'c',

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Subtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Subtree.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase subtree criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Subtree criterion handler.
@@ -30,41 +29,29 @@ class Subtree extends CriterionHandler
         return $criterion instanceof Criterion\Subtree;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
         $statements = [];
         foreach ($criterion->value as $pattern) {
-            $statements[] = $query->expr->like(
-                $this->dbHandler->quoteColumn('path_string'),
-                $query->bindValue($pattern . '%')
+            $statements[] = $queryBuilder->expr()->like(
+                'path_string',
+                $queryBuilder->createNamedParameter($pattern . '%', ParameterType::STRING)
             );
         }
 
-        $subSelect = $query->subSelect();
+        $subSelect = $this->connection->createQueryBuilder();
         $subSelect
-            ->select($this->dbHandler->quoteColumn('contentobject_id'))
-            ->from($this->dbHandler->quoteTable('ezcontentobject_tree'))
-            ->where($query->expr->lOr($statements));
+            ->select('contentobject_id')
+            ->from('ezcontentobject_tree')
+            ->where($queryBuilder->expr()->orX(...$statements));
 
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('id', 'ezcontentobject'),
-            $subSelect
+        return $queryBuilder->expr()->in(
+            'c.id',
+            $subSelect->getSQL()
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -1,13 +1,12 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase Content search Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway;
 
+use Doctrine\DBAL\Connection;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseConverter;
 use eZ\Publish\Core\Search\Legacy\Content\Gateway;
@@ -24,12 +23,11 @@ use PDO;
  */
 class DoctrineDatabase extends Gateway
 {
-    /**
-     * Database handler.
-     *
-     * @var \eZ\Publish\Core\Persistence\Database\DatabaseHandler
-     */
-    protected $handler;
+    /** @var \Doctrine\DBAL\Connection */
+    protected $connection;
+
+    /** @var \Doctrine\DBAL\Platforms\AbstractPlatform */
+    private $dbPlatform;
 
     /**
      * Criteria converter.
@@ -53,20 +51,16 @@ class DoctrineDatabase extends Gateway
     protected $languageHandler;
 
     /**
-     * Construct from handler handler.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\DatabaseHandler $handler
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $criteriaConverter
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseConverter $sortClauseConverter
-     * @param \eZ\Publish\SPI\Persistence\Content\Language\Handler $languageHandler
+     * @throws \Doctrine\DBAL\DBALException
      */
     public function __construct(
-        DatabaseHandler $handler,
+        Connection $connection,
         CriteriaConverter $criteriaConverter,
         SortClauseConverter $sortClauseConverter,
         LanguageHandler $languageHandler
     ) {
-        $this->handler = $handler;
+        $this->connection = $connection;
+        $this->dbPlatform = $connection->getDatabasePlatform();
         $this->criteriaConverter = $criteriaConverter;
         $this->sortClauseConverter = $sortClauseConverter;
         $this->languageHandler = $languageHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -7,24 +7,27 @@
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\FetchMode;
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
+use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
+use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseConverter;
 use eZ\Publish\Core\Search\Legacy\Content\Gateway;
-use eZ\Publish\Core\Persistence\Database\DatabaseHandler;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
-use PDO;
+use RuntimeException;
 
 /**
  * Content locator gateway implementation using the Doctrine database.
  */
-class DoctrineDatabase extends Gateway
+final class DoctrineDatabase extends Gateway
 {
     /** @var \Doctrine\DBAL\Connection */
-    protected $connection;
+    private $connection;
 
     /** @var \Doctrine\DBAL\Platforms\AbstractPlatform */
     private $dbPlatform;
@@ -34,21 +37,21 @@ class DoctrineDatabase extends Gateway
      *
      * @var \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter
      */
-    protected $criteriaConverter;
+    private $criteriaConverter;
 
     /**
      * Sort clause converter.
      *
      * @var \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseConverter
      */
-    protected $sortClauseConverter;
+    private $sortClauseConverter;
 
     /**
      * Language handler.
      *
      * @var \eZ\Publish\SPI\Persistence\Content\Language\Handler
      */
-    protected $languageHandler;
+    private $languageHandler;
 
     /**
      * @throws \Doctrine\DBAL\DBALException
@@ -66,20 +69,6 @@ class DoctrineDatabase extends Gateway
         $this->languageHandler = $languageHandler;
     }
 
-    /**
-     * Returns a list of object satisfying the $filter.
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Criterion is not applicable to its target
-     *
-     * @param Criterion $criterion
-     * @param int $offset
-     * @param int $limit
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
-     * @param array $languageFilter
-     * @param bool $doCount
-     *
-     * @return mixed[][]
-     */
     public function find(
         Criterion $criterion,
         $offset,
@@ -87,11 +76,11 @@ class DoctrineDatabase extends Gateway
         array $sort = null,
         array $languageFilter = [],
         $doCount = true
-    ) {
+    ): array {
         $count = $doCount ? $this->getResultCount($criterion, $languageFilter) : null;
 
         if (!$doCount && $limit === 0) {
-            throw new \RuntimeException('Invalid query. Cannot disable count and request 0 items at the same time.');
+            throw new RuntimeException('Invalid query. Cannot disable count and request 0 items at the same time.');
         }
 
         if ($limit === 0 || ($count !== null && $count <= $offset)) {
@@ -112,8 +101,10 @@ class DoctrineDatabase extends Gateway
      * @param array $languageSettings
      *
      * @return int
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    protected function getLanguageMask(array $languageSettings)
+    private function getLanguageMask(array $languageSettings)
     {
         $mask = 0;
         if ($languageSettings['useAlwaysAvailable']) {
@@ -128,45 +119,44 @@ class DoctrineDatabase extends Gateway
     }
 
     /**
-     * Get query condition.
-     *
-     * @param Criterion $filter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
      * @param array $languageFilter
      *
      * @return string
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
      */
-    protected function getQueryCondition(
+    private function getQueryCondition(
         Criterion $filter,
-        SelectQuery $query,
+        QueryBuilder $query,
         array $languageFilter
     ) {
-        $condition = $query->expr->lAnd(
+        $expr = $query->expr();
+        $condition = $expr->andX(
             $this->criteriaConverter->convertCriteria($query, $filter, $languageFilter),
-            $query->expr->eq(
-                'ezcontentobject.status',
+            $expr->eq(
+                'c.status',
                 ContentInfo::STATUS_PUBLISHED
             ),
-            $query->expr->eq(
-                'ezcontentobject_version.status',
+            $expr->eq(
+                'v.status',
                 VersionInfo::STATUS_PUBLISHED
             )
         );
 
         // If not main-languages query
         if (!empty($languageFilter['languages'])) {
-            $condition = $query->expr->lAnd(
+            $condition = $expr->andX(
                 $condition,
-                $query->expr->gt(
-                    $query->expr->bitAnd(
-                        $this->handler->quoteColumn('language_mask', 'ezcontentobject'),
-                        $query->bindValue(
+                $expr->gt(
+                    $this->dbPlatform->getBitAndComparisonExpression(
+                        'c.language_mask',
+                        $query->createNamedParameter(
                             $this->getLanguageMask($languageFilter),
-                            null,
-                            PDO::PARAM_INT
+                            ParameterType::INTEGER,
+                            ':language_mask'
                         )
                     ),
-                    $query->bindValue(0, null, PDO::PARAM_INT)
+                    $query->createNamedParameter(0, ParameterType::INTEGER, ':zero')
                 )
             );
         }
@@ -182,26 +172,26 @@ class DoctrineDatabase extends Gateway
      *
      * @return int
      */
-    protected function getResultCount(Criterion $filter, array $languageFilter)
+    private function getResultCount(Criterion $filter, array $languageFilter)
     {
-        $query = $this->handler->createSelectQuery();
+        $query = $this->connection->createQueryBuilder();
 
-        $columnName = $this->handler->quoteColumn('id', 'ezcontentobject');
+        $columnName = 'c.id';
         $query
             ->select("COUNT( DISTINCT $columnName )")
-            ->from($this->handler->quoteTable('ezcontentobject'))
+            ->from(ContentGateway::CONTENT_ITEM_TABLE, 'c')
             ->innerJoin(
-                'ezcontentobject_version',
-                'ezcontentobject.id',
-                'ezcontentobject_version.contentobject_id'
+                'c',
+                ContentGateway::CONTENT_VERSION_TABLE,
+                'v',
+                'c.id = v.contentobject_id',
             );
 
         $query->where(
             $this->getQueryCondition($filter, $query, $languageFilter)
         );
 
-        $statement = $query->prepare();
-        $statement->execute();
+        $statement = $query->execute();
 
         return (int)$statement->fetchColumn();
     }
@@ -209,53 +199,48 @@ class DoctrineDatabase extends Gateway
     /**
      * Get sorted arrays of content IDs, which should be returned.
      *
-     * @param Criterion $filter
      * @param array $sort
      * @param mixed $offset
      * @param mixed $limit
      * @param array $languageFilter
      *
      * @return int[]
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
      */
-    protected function getContentInfoList(
+    private function getContentInfoList(
         Criterion $filter,
-        $sort,
-        $offset,
-        $limit,
+        ?array $sort,
+        ?int $offset,
+        ?int $limit,
         array $languageFilter
-    ) {
-        $query = $this->handler->createSelectQuery();
-        $query->selectDistinct(
-            'ezcontentobject.*',
-            $this->handler->aliasedColumn($query, 'main_node_id', 'main_tree')
+    ): array {
+        $query = $this->connection->createQueryBuilder();
+        $query->select(
+            'DISTINCT c.*, main_tree.main_node_id AS main_tree_main_node_id',
         );
 
         if ($sort !== null) {
             $this->sortClauseConverter->applySelect($query, $sort);
         }
 
-        $query->from(
-            $this->handler->quoteTable('ezcontentobject')
-        )->innerJoin(
-            'ezcontentobject_version',
-            'ezcontentobject.id',
-            'ezcontentobject_version.contentobject_id'
-        )->leftJoin(
-            $this->handler->alias(
-                $this->handler->quoteTable('ezcontentobject_tree'),
-                $this->handler->quoteIdentifier('main_tree')
-            ),
-            $query->expr->lAnd(
-                $query->expr->eq(
-                    $this->handler->quoteColumn('contentobject_id', 'main_tree'),
-                    $this->handler->quoteColumn('id', 'ezcontentobject')
-                ),
-                $query->expr->eq(
-                    $this->handler->quoteColumn('main_node_id', 'main_tree'),
-                    $this->handler->quoteColumn('node_id', 'main_tree')
-                )
+        $query
+            ->from(ContentGateway::CONTENT_ITEM_TABLE, 'c')
+            ->innerJoin(
+                'c',
+                ContentGateway::CONTENT_VERSION_TABLE,
+                'v',
+                'c.id = v.contentobject_id'
             )
-        );
+            ->leftJoin(
+                'c',
+                LocationGateway::CONTENT_TREE_TABLE,
+                'main_tree',
+                $query->expr()->andX(
+                    'main_tree.contentobject_id = c.id',
+                    'main_tree.main_node_id = main_tree.node_id'
+                )
+            );
 
         if ($sort !== null) {
             $this->sortClauseConverter->applyJoin($query, $sort, $languageFilter);
@@ -269,11 +254,11 @@ class DoctrineDatabase extends Gateway
             $this->sortClauseConverter->applyOrderBy($query);
         }
 
-        $query->limit($limit, $offset);
+        $query->setMaxResults($limit);
+        $query->setFirstResult($offset);
 
-        $statement = $query->prepare();
-        $statement->execute();
+        $statement = $query->execute();
 
-        return $statement->fetchAll(PDO::FETCH_ASSOC);
+        return $statement->fetchAll(FetchMode::ASSOCIATIVE);
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/ExceptionConversion.php
@@ -1,18 +1,16 @@
 <?php
 
 /**
- * File containing the Content Search Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway;
 
+use eZ\Publish\Core\Base\Exceptions\DatabaseException;
 use eZ\Publish\Core\Search\Legacy\Content\Gateway;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use Doctrine\DBAL\DBALException;
 use PDOException;
-use RuntimeException;
 
 /**
  * The Content Search Gateway provides the implementation for one database to
@@ -21,36 +19,15 @@ use RuntimeException;
 class ExceptionConversion extends Gateway
 {
     /**
-     * The wrapped gateway.
-     *
-     * @var Gateway
+     * @var \eZ\Publish\Core\Search\Legacy\Content\Gateway
      */
     protected $innerGateway;
 
-    /**
-     * Creates a new exception conversion gateway around $innerGateway.
-     *
-     * @param Gateway $innerGateway
-     */
     public function __construct(Gateway $innerGateway)
     {
         $this->innerGateway = $innerGateway;
     }
 
-    /**
-     * Returns a list of object satisfying the $criterion.
-     *
-     * @param Criterion $criterion
-     * @param int $offset
-     * @param int|null $limit
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sort
-     * @param array $languageFilter
-     * @param bool $doCount
-     *
-     * @throws \RuntimeException
-     *
-     * @return mixed[][]
-     */
     public function find(
         Criterion $criterion,
         $offset = 0,
@@ -58,13 +35,11 @@ class ExceptionConversion extends Gateway
         array $sort = null,
         array $languageFilter = [],
         $doCount = true
-    ) {
+    ): array {
         try {
             return $this->innerGateway->find($criterion, $offset, $limit, $sort, $languageFilter, $doCount);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway.php
@@ -1,8 +1,6 @@
 <?php
 
 /**
- * File containing the Search Location Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
@@ -26,6 +24,9 @@ abstract class Gateway
      * @param bool $doCount
      *
      * @return mixed[][]
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if Criterion is not applicable to its target
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException if a given Criterion Handler or Sort Clause is not implemented
      */
     abstract public function find(
         Criterion $criterion,
@@ -34,5 +35,5 @@ abstract class Gateway
         array $sortClauses = null,
         array $languageFilter = [],
         $doCount = true
-    );
+    ): array;
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Ancestor.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Ancestor.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * This file is part of the eZ Publish Kernel package.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Visits the Ancestor criterion.
@@ -30,21 +29,9 @@ class Ancestor extends CriterionHandler
         return $criterion instanceof Criterion\Ancestor;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
@@ -55,9 +42,9 @@ class Ancestor extends CriterionHandler
             }
         }
 
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('node_id', 'ezcontentobject_tree'),
-            array_keys($idSet)
+        return $queryBuilder->expr()->in(
+            't.node_id',
+            $queryBuilder->createNamedParameter(array_keys($idSet), Connection::PARAM_INT_ARRAY)
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Depth.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Depth.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase location depth criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location;
 
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use RuntimeException;
 
 /**
@@ -31,38 +30,26 @@ class Depth extends CriterionHandler
         return $criterion instanceof Criterion\Location\Depth;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        $column = $this->dbHandler->quoteColumn('depth', 'ezcontentobject_tree');
+        $column = 't.depth';
 
         switch ($criterion->operator) {
             case Criterion\Operator::IN:
-                return $query->expr->in(
+                return $queryBuilder->expr()->in(
                     $column,
                     $criterion->value
                 );
 
             case Criterion\Operator::BETWEEN:
-                return $query->expr->between(
+                return $this->dbPlatform->getBetweenExpression(
                     $column,
-                    $query->bindValue($criterion->value[0]),
-                    $query->bindValue($criterion->value[1])
+                    $queryBuilder->createNamedParameter($criterion->value[0], ParameterType::STRING),
+                    $queryBuilder->createNamedParameter($criterion->value[1], ParameterType::STRING)
                 );
 
             case Criterion\Operator::EQ:
@@ -72,9 +59,9 @@ class Depth extends CriterionHandler
             case Criterion\Operator::LTE:
                 $operatorFunction = $this->comparatorMap[$criterion->operator];
 
-                return $query->expr->$operatorFunction(
+                return $queryBuilder->expr()->$operatorFunction(
                     $column,
-                    $query->bindValue(reset($criterion->value))
+                    $queryBuilder->createNamedParameter(reset($criterion->value), ParameterType::STRING)
                 );
 
             default:

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/IsMainLocation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/IsMainLocation.php
@@ -1,18 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase location main status criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use RuntimeException;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Location main status criterion handler.
@@ -31,36 +29,24 @@ class IsMainLocation extends CriterionHandler
         return $criterion instanceof Criterion\Location\IsMainLocation;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        $idColumn = $this->dbHandler->quoteColumn('node_id', 'ezcontentobject_tree');
-        $mainIdColumn = $this->dbHandler->quoteColumn('main_node_id', 'ezcontentobject_tree');
+        $idColumn = 't.node_id';
+        $mainIdColumn = 't.main_node_id';
 
         switch ($criterion->value[0]) {
             case Criterion\Location\IsMainLocation::MAIN:
-                return $query->expr->eq(
+                return $queryBuilder->expr()->eq(
                     $idColumn,
                     $mainIdColumn
                 );
 
             case Criterion\Location\IsMainLocation::NOT_MAIN:
-                return $query->expr->neq(
+                return $queryBuilder->expr()->neq(
                     $idColumn,
                     $mainIdColumn
                 );

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Priority.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Priority.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase location priority criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location;
 
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 use RuntimeException;
 
 /**
@@ -31,32 +30,20 @@ class Priority extends CriterionHandler
         return $criterion instanceof Criterion\Location\Priority;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        $column = $this->dbHandler->quoteColumn('priority');
+        $column = 'priority';
 
         switch ($criterion->operator) {
             case Criterion\Operator::BETWEEN:
-                return $query->expr->between(
+                return $this->dbPlatform->getBetweenExpression(
                     $column,
-                    $query->bindValue($criterion->value[0]),
-                    $query->bindValue($criterion->value[1])
+                    $queryBuilder->createNamedParameter($criterion->value[0], ParameterType::STRING),
+                    $queryBuilder->createNamedParameter($criterion->value[1], ParameterType::STRING)
                 );
 
             case Criterion\Operator::GT:
@@ -65,9 +52,9 @@ class Priority extends CriterionHandler
             case Criterion\Operator::LTE:
                 $operatorFunction = $this->comparatorMap[$criterion->operator];
 
-                return $query->expr->$operatorFunction(
+                return $queryBuilder->expr()->$operatorFunction(
                     $column,
-                    $query->bindValue(reset($criterion->value))
+                    $queryBuilder->createNamedParameter(reset($criterion->value), ParameterType::STRING)
                 );
 
             default:

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationId.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase location id criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Location id criterion handler.
@@ -30,27 +29,17 @@ class LocationId extends CriterionHandler
         return $criterion instanceof Criterion\LocationId;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('node_id', 'ezcontentobject_tree'),
-            $criterion->value
+        $value = (array)$criterion->value;
+
+        return $queryBuilder->expr()->in(
+            't.node_id',
+            $queryBuilder->createNamedParameter($value, Connection::PARAM_INT_ARRAY)
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationRemoteId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationRemoteId.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase location remote id criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Location remote id criterion handler.
@@ -30,27 +29,17 @@ class LocationRemoteId extends CriterionHandler
         return $criterion instanceof Criterion\LocationRemoteId;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('remote_id', 'ezcontentobject_tree'),
-            $criterion->value
+        $value = (array)$criterion->value;
+
+        return $queryBuilder->expr()->in(
+            't.remote_id',
+            $queryBuilder->createNamedParameter($value, Connection::PARAM_STR_ARRAY)
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/ParentLocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/ParentLocationId.php
@@ -1,17 +1,16 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase parent location id criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Parent location id criterion handler.
@@ -30,27 +29,17 @@ class ParentLocationId extends CriterionHandler
         return $criterion instanceof Criterion\ParentLocationId;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        return $query->expr->in(
-            $this->dbHandler->quoteColumn('parent_node_id', 'ezcontentobject_tree'),
-            $criterion->value
+        $value = (array)$criterion->value;
+
+        return $queryBuilder->expr()->in(
+            't.parent_node_id',
+            $queryBuilder->createNamedParameter($value, Connection::PARAM_INT_ARRAY)
         );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Subtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Subtree.php
@@ -1,23 +1,39 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase subtree criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Location subtree criterion handler.
  */
 class Subtree extends CriterionHandler
 {
+    public function handle(
+        CriteriaConverter $converter,
+        QueryBuilder $queryBuilder,
+        Criterion $criterion,
+        array $languageSettings
+    ) {
+        $statements = [];
+        foreach ($criterion->value as $pattern) {
+            $statements[] = $queryBuilder->expr()->like(
+                't.path_string',
+                $queryBuilder->createNamedParameter($pattern . '%', ParameterType::STRING)
+            );
+        }
+
+        return $queryBuilder->expr()->orX(...$statements);
+    }
+
     /**
      * Check if this criterion handler accepts to handle the given criterion.
      *
@@ -28,36 +44,5 @@ class Subtree extends CriterionHandler
     public function accept(Criterion $criterion)
     {
         return $criterion instanceof Criterion\Subtree;
-    }
-
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
-    public function handle(
-        CriteriaConverter $converter,
-        SelectQuery $query,
-        Criterion $criterion,
-        array $languageSettings
-    ) {
-        $statements = [];
-        foreach ($criterion->value as $pattern) {
-            $statements[] = $query->expr->like(
-                $this->dbHandler->quoteColumn('path_string', 'ezcontentobject_tree'),
-                $query->bindValue($pattern . '%')
-            );
-        }
-
-        return $query->expr->lOr(
-            $statements
-        );
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Visibility.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Visibility.php
@@ -1,19 +1,17 @@
 <?php
 
 /**
- * File containing the DoctrineDatabase location visibility criterion handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;
 
+use Doctrine\DBAL\ParameterType;
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use RuntimeException;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
-use PDO;
 
 /**
  * Location visibility criterion handler.
@@ -32,37 +30,25 @@ class Visibility extends CriterionHandler
         return $criterion instanceof Criterion\Visibility;
     }
 
-    /**
-     * Generate query expression for a Criterion this handler accepts.
-     *
-     * accept() must be called before calling this method.
-     *
-     * @param \eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter $converter
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param array $languageSettings
-     *
-     * @return \eZ\Publish\Core\Persistence\Database\Expression
-     */
     public function handle(
         CriteriaConverter $converter,
-        SelectQuery $query,
+        QueryBuilder $queryBuilder,
         Criterion $criterion,
         array $languageSettings
     ) {
-        $column = $this->dbHandler->quoteColumn('is_invisible', 'ezcontentobject_tree');
+        $column = 't.is_invisible';
 
         switch ($criterion->value[0]) {
             case Criterion\Visibility::VISIBLE:
-                return $query->expr->eq(
+                return $queryBuilder->expr()->eq(
                     $column,
-                    $query->bindValue(0, null, PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter(0, ParameterType::INTEGER)
                 );
 
             case Criterion\Visibility::HIDDEN:
-                return $query->expr->eq(
+                return $queryBuilder->expr()->eq(
                     $column,
-                    $query->bindValue(1, null, PDO::PARAM_INT)
+                    $queryBuilder->createNamedParameter(1, ParameterType::INTEGER)
                 );
 
             default:

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -1,18 +1,16 @@
 <?php
 
 /**
- * File containing the Location Gateway class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\Core\Base\Exceptions\DatabaseException;
 use eZ\Publish\Core\Search\Legacy\Content\Location\Gateway;
 use Doctrine\DBAL\DBALException;
 use PDOException;
-use RuntimeException;
 
 /**
  * Base class for location gateways.
@@ -36,20 +34,6 @@ class ExceptionConversion extends Gateway
         $this->innerGateway = $innerGateway;
     }
 
-    /**
-     * Returns total count and data for all Locations satisfying the parameters.
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion $criterion
-     * @param int $offset
-     * @param int|null $limit
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause[] $sortClauses
-     * @param array $languageFilter
-     * @param bool $doCount
-     *
-     * @throws \RuntimeException
-     *
-     * @return mixed[][]
-     */
     public function find(
         Criterion $criterion,
         $offset = 0,
@@ -57,13 +41,11 @@ class ExceptionConversion extends Gateway
         array $sortClauses = null,
         array $languageFilter = [],
         $doCount = true
-    ) {
+    ): array {
         try {
             return $this->innerGateway->find($criterion, $offset, $limit, $sortClauses, $languageFilter, $doCount);
-        } catch (DBALException $e) {
-            throw new RuntimeException('Database error', 0, $e);
-        } catch (PDOException $e) {
-            throw new RuntimeException('Database error', 0, $e);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
         }
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Depth.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Depth.php
@@ -8,9 +8,9 @@
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,31 +29,15 @@ class Depth extends SortClauseHandler
         return $sortClause instanceof SortClause\Location\Depth;
     }
 
-    /**
-     * Apply selects to the query.
-     *
-     * Returns the name of the (aliased) column, which information should be
-     * used for sorting.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query, SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
-                    $this->dbHandler->quoteColumn(
-                        'depth',
-                        'ezcontentobject_tree'
-                    ),
-                    $column = $this->getSortColumnName($number)
-                )
+            ->addSelect(
+                sprintf('t.depth AS %s', $column = $this->getSortColumnName($number))
             );
 
-        return $column;
+        return [$column];
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Id.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Id.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing a DoctrineDatabase Location id sort clause handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,31 +27,19 @@ class Id extends SortClauseHandler
         return $sortClause instanceof SortClause\Location\Id;
     }
 
-    /**
-     * Apply selects to the query.
-     *
-     * Returns the name of the (aliased) column, which information should be
-     * used for sorting.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query,
+        SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
-                    $this->dbHandler->quoteColumn(
-                        'node_id',
-                        'ezcontentobject_tree'
-                    ),
+            ->addSelect(
+                sprintf(
+                    't.node_id AS %s',
                     $column = $this->getSortColumnName($number)
                 )
             );
 
-        return $column;
+        return [$column];
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/IsMainLocation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/IsMainLocation.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing a DoctrineDatabase Location main status sort clause handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,31 +27,23 @@ class IsMainLocation extends SortClauseHandler
         return $sortClause instanceof SortClause\Location\IsMainLocation;
     }
 
-    /**
-     * Apply selects to the query.
-     *
-     * Returns the name of the (aliased) column, which information should be
-     * used for sorting.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query,
+        SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
-                    $query->expr->eq(
-                        $this->dbHandler->quoteColumn('node_id', 'ezcontentobject_tree'),
-                        $this->dbHandler->quoteColumn('main_node_id', 'ezcontentobject_tree')
+            ->addSelect(
+                sprintf(
+                    '%s AS %s',
+                    $query->expr()->eq(
+                        't.node_id',
+                        't.main_node_id'
                     ),
                     $column = $this->getSortColumnName($number)
                 )
             );
 
-        return $column;
+        return [$column];
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Path.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Path.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing a DoctrineDatabase Location path sort clause handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,31 +27,19 @@ class Path extends SortClauseHandler
         return $sortClause instanceof SortClause\Location\Path;
     }
 
-    /**
-     * Apply selects to the query.
-     *
-     * Returns the name of the (aliased) column, which information should be
-     * used for sorting.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query,
+        SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
-                    $this->dbHandler->quoteColumn(
-                        'path_string',
-                        'ezcontentobject_tree'
-                    ),
+            ->addSelect(
+                sprintf(
+                    't.path_string AS %s',
                     $column = $this->getSortColumnName($number)
                 )
             );
 
-        return $column;
+        return [$column];
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Priority.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Priority.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing a DoctrineDatabase Location priority sort clause handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,31 +27,19 @@ class Priority extends SortClauseHandler
         return $sortClause instanceof SortClause\Location\Priority;
     }
 
-    /**
-     * Apply selects to the query.
-     *
-     * Returns the name of the (aliased) column, which information should be
-     * used for sorting.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query,
+        SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
-                    $this->dbHandler->quoteColumn(
-                        'priority',
-                        'ezcontentobject_tree'
-                    ),
+            ->addSelect(
+                sprintf(
+                    't.priority AS %s',
                     $column = $this->getSortColumnName($number)
                 )
             );
 
-        return $column;
+        return [$column];
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Visibility.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Visibility.php
@@ -1,16 +1,14 @@
 <?php
 
 /**
- * File containing a DoctrineDatabase Location visibility sort clause handler class.
- *
  * @copyright Copyright (C) eZ Systems AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location;
 
+use Doctrine\DBAL\Query\QueryBuilder;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\Core\Persistence\Database\SelectQuery;
 
 /**
  * Content locator gateway implementation using the DoctrineDatabase.
@@ -29,31 +27,19 @@ class Visibility extends SortClauseHandler
         return $sortClause instanceof SortClause\Location\Visibility;
     }
 
-    /**
-     * Apply selects to the query.
-     *
-     * Returns the name of the (aliased) column, which information should be
-     * used for sorting.
-     *
-     * @param \eZ\Publish\Core\Persistence\Database\SelectQuery $query
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\SortClause $sortClause
-     * @param int $number
-     *
-     * @return string
-     */
-    public function applySelect(SelectQuery $query, SortClause $sortClause, $number)
-    {
+    public function applySelect(
+        QueryBuilder $query,
+        SortClause $sortClause,
+        int $number
+    ): array {
         $query
-            ->select(
-                $query->alias(
-                    $this->dbHandler->quoteColumn(
-                        'is_invisible',
-                        'ezcontentobject_tree'
-                    ),
+            ->addSelect(
+                sprintf(
+                    't.is_invisible AS %s',
                     $column = $this->getSortColumnName($number)
                 )
             );
 
-        return $column;
+        return [$column];
     }
 }

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
@@ -43,31 +43,31 @@ class HandlerContentSortTest extends AbstractTestCase
      */
     protected function getContentSearchHandler(array $fullTextSearchConfiguration = [])
     {
-        $db = $this->getDatabaseHandler();
+        $connection = $this->getDatabaseConnection();
 
         return new Content\Handler(
             new Content\Gateway\DoctrineDatabase(
-                $this->getDatabaseHandler(),
+                $connection,
                 new Content\Common\Gateway\CriteriaConverter(
                     [
-                        new Content\Common\Gateway\CriterionHandler\MatchAll($db),
-                        new Content\Common\Gateway\CriterionHandler\LogicalAnd($db),
-                        new Content\Common\Gateway\CriterionHandler\SectionId($db),
+                        new Content\Common\Gateway\CriterionHandler\MatchAll($connection),
+                        new Content\Common\Gateway\CriterionHandler\LogicalAnd($connection),
+                        new Content\Common\Gateway\CriterionHandler\SectionId($connection),
                         new Content\Common\Gateway\CriterionHandler\ContentTypeIdentifier(
-                            $db,
+                            $connection,
                             $this->getContentTypeHandler()
                         ),
                     ]
                 ),
                 new Content\Common\Gateway\SortClauseConverter(
                     [
-                        new Content\Common\Gateway\SortClauseHandler\DateModified($db),
-                        new Content\Common\Gateway\SortClauseHandler\DatePublished($db),
-                        new Content\Common\Gateway\SortClauseHandler\SectionIdentifier($db),
-                        new Content\Common\Gateway\SortClauseHandler\SectionName($db),
-                        new Content\Common\Gateway\SortClauseHandler\ContentName($db),
+                        new Content\Common\Gateway\SortClauseHandler\DateModified($connection),
+                        new Content\Common\Gateway\SortClauseHandler\DatePublished($connection),
+                        new Content\Common\Gateway\SortClauseHandler\SectionIdentifier($connection),
+                        new Content\Common\Gateway\SortClauseHandler\SectionName($connection),
+                        new Content\Common\Gateway\SortClauseHandler\ContentName($connection),
                         new Content\Common\Gateway\SortClauseHandler\Field(
-                            $db,
+                            $connection,
                             $this->getLanguageHandler(),
                             $this->getContentTypeHandler()
                         ),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -8,6 +8,7 @@
  */
 namespace eZ\Publish\Core\Search\Legacy\Tests\Content;
 
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Persistence;
 use eZ\Publish\Core\Search\Legacy\Content;
 use eZ\Publish\API\Repository\Values\Content\Query;
@@ -45,81 +46,82 @@ class HandlerContentTest extends AbstractTestCase
             ),
             glob(__DIR__ . '/../../../../Persistence/Tests/TransformationProcessor/_fixtures/transformations/*.tr')
         );
+        $connection = $this->getDatabaseConnection();
         $commaSeparatedCollectionValueHandler = new Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Collection(
-            $this->getDatabaseHandler(),
+            $connection,
             $transformationProcessor,
             ','
         );
         $hyphenSeparatedCollectionValueHandler = new Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Collection(
-            $this->getDatabaseHandler(),
+            $connection,
             $transformationProcessor,
             '-'
         );
         $simpleValueHandler = new Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Simple(
-            $this->getDatabaseHandler(),
+            $connection,
             $transformationProcessor
         );
         $compositeValueHandler = new Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Composite(
-            $this->getDatabaseHandler(),
+            $connection,
             $transformationProcessor
         );
 
         return new Content\Handler(
             new Content\Gateway\DoctrineDatabase(
-                $this->getDatabaseHandler(),
+                $connection,
                 new Content\Common\Gateway\CriteriaConverter(
                     [
                         new Content\Common\Gateway\CriterionHandler\ContentId(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\LogicalNot(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\LogicalAnd(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\LogicalOr(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Gateway\CriterionHandler\Subtree(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\ContentTypeId(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\ContentTypeIdentifier(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $this->getContentTypeHandler()
                         ),
                         new Content\Common\Gateway\CriterionHandler\ContentTypeGroupId(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\DateMetadata(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Gateway\CriterionHandler\LocationId(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Gateway\CriterionHandler\ParentLocationId(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\RemoteId(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Gateway\CriterionHandler\LocationRemoteId(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\SectionId(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\FullText(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $transformationProcessor,
                             $this->getLanguageMaskGenerator(),
                             $fullTextSearchConfiguration
                         ),
                         new Content\Common\Gateway\CriterionHandler\Field(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $this->getContentTypeHandler(),
                             $this->getLanguageHandler(),
                             $this->getConverterRegistry(),
@@ -143,23 +145,23 @@ class HandlerContentTest extends AbstractTestCase
                             $transformationProcessor
                         ),
                         new Content\Common\Gateway\CriterionHandler\ObjectStateId(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\LanguageCode(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $this->getLanguageMaskGenerator()
                         ),
                         new Content\Gateway\CriterionHandler\Visibility(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\MatchAll(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\UserMetadata(
-                            $this->getDatabaseHandler()
+                            $connection
                         ),
                         new Content\Common\Gateway\CriterionHandler\FieldRelation(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $this->getContentTypeHandler(),
                             $this->getLanguageHandler()
                         ),
@@ -167,7 +169,7 @@ class HandlerContentTest extends AbstractTestCase
                 ),
                 new Content\Common\Gateway\SortClauseConverter(
                     [
-                        new Content\Common\Gateway\SortClauseHandler\ContentId($this->getDatabaseHandler()),
+                        new Content\Common\Gateway\SortClauseHandler\ContentId($connection),
                     ]
                 ),
                 $this->getLanguageHandler()
@@ -353,7 +355,7 @@ class HandlerContentTest extends AbstractTestCase
 
     public function testFindSingleWithNonSearchableField()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $locator = $this->getContentSearchHandler();
         $locator->findSingle(
@@ -367,7 +369,7 @@ class HandlerContentTest extends AbstractTestCase
 
     public function testFindContentWithNonSearchableField()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $locator = $this->getContentSearchHandler();
         $locator->findContent(
@@ -386,7 +388,7 @@ class HandlerContentTest extends AbstractTestCase
 
     public function testFindSingleTooMany()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $locator = $this->getContentSearchHandler();
         $locator->findSingle(new Criterion\ContentId([4, 10, 12, 23]));
@@ -1042,7 +1044,7 @@ class HandlerContentTest extends AbstractTestCase
 
     public function testFullTextFilterInvalidStopwordThreshold()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
 
         $this->getContentSearchHandler(
             [

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
@@ -49,39 +49,41 @@ class HandlerLocationSortTest extends AbstractTestCase
      */
     protected function getContentSearchHandler()
     {
+        $connection = $this->getDatabaseConnection();
+
         return new Content\Handler(
             $this->createMock(ContentGateway::class),
             new Content\Location\Gateway\DoctrineDatabase(
-                $this->getDatabaseHandler(),
+                $connection,
                 new CriteriaConverter(
                     [
-                        new LocationCriterionHandler\LocationId($this->getDatabaseHandler()),
-                        new LocationCriterionHandler\ParentLocationId($this->getDatabaseHandler()),
-                        new CommonCriterionHandler\LogicalAnd($this->getDatabaseHandler()),
-                        new CommonCriterionHandler\MatchAll($this->getDatabaseHandler()),
-                        new CommonCriterionHandler\SectionId($this->getDatabaseHandler()),
+                        new LocationCriterionHandler\LocationId($connection),
+                        new LocationCriterionHandler\ParentLocationId($connection),
+                        new CommonCriterionHandler\LogicalAnd($connection),
+                        new CommonCriterionHandler\MatchAll($connection),
+                        new CommonCriterionHandler\SectionId($connection),
                         new CommonCriterionHandler\ContentTypeIdentifier(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $this->getContentTypeHandler()
                         ),
                     ]
                 ),
                 new SortClauseConverter(
                     [
-                        new LocationSortClauseHandler\Location\Id($this->getDatabaseHandler()),
-                        new LocationSortClauseHandler\Location\Depth($this->getDatabaseHandler()),
-                        new LocationSortClauseHandler\Location\Path($this->getDatabaseHandler()),
-                        new LocationSortClauseHandler\Location\Priority($this->getDatabaseHandler()),
-                        new LocationSortClauseHandler\Location\Visibility($this->getDatabaseHandler()),
-                        new LocationSortClauseHandler\Location\IsMainLocation($this->getDatabaseHandler()),
-                        new CommonSortClauseHandler\ContentId($this->getDatabaseHandler()),
-                        new CommonSortClauseHandler\ContentName($this->getDatabaseHandler()),
-                        new CommonSortClauseHandler\DateModified($this->getDatabaseHandler()),
-                        new CommonSortClauseHandler\DatePublished($this->getDatabaseHandler()),
-                        new CommonSortClauseHandler\SectionIdentifier($this->getDatabaseHandler()),
-                        new CommonSortClauseHandler\SectionName($this->getDatabaseHandler()),
+                        new LocationSortClauseHandler\Location\Id($connection),
+                        new LocationSortClauseHandler\Location\Depth($connection),
+                        new LocationSortClauseHandler\Location\Path($connection),
+                        new LocationSortClauseHandler\Location\Priority($connection),
+                        new LocationSortClauseHandler\Location\Visibility($connection),
+                        new LocationSortClauseHandler\Location\IsMainLocation($connection),
+                        new CommonSortClauseHandler\ContentId($connection),
+                        new CommonSortClauseHandler\ContentName($connection),
+                        new CommonSortClauseHandler\DateModified($connection),
+                        new CommonSortClauseHandler\DatePublished($connection),
+                        new CommonSortClauseHandler\SectionIdentifier($connection),
+                        new CommonSortClauseHandler\SectionName($connection),
                         new CommonSortClauseHandler\Field(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $this->getLanguageHandler(),
                             $this->getContentTypeHandler()
                         ),

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
@@ -47,49 +47,50 @@ class HandlerLocationTest extends AbstractTestCase
             ),
             glob(__DIR__ . '/../../../../Persistence/Tests/TransformationProcessor/_fixtures/transformations/*.tr')
         );
+        $connection = $this->getDatabaseConnection();
         $commaSeparatedCollectionValueHandler = new CommonCriterionHandler\FieldValue\Handler\Collection(
-            $this->getDatabaseHandler(),
+            $connection,
             $transformationProcessor,
             ','
         );
         $hyphenSeparatedCollectionValueHandler = new CommonCriterionHandler\FieldValue\Handler\Collection(
-            $this->getDatabaseHandler(),
+            $connection,
             $transformationProcessor,
             '-'
         );
         $simpleValueHandler = new CommonCriterionHandler\FieldValue\Handler\Simple(
-            $this->getDatabaseHandler(),
+            $connection,
             $transformationProcessor
         );
         $compositeValueHandler = new CommonCriterionHandler\FieldValue\Handler\Composite(
-            $this->getDatabaseHandler(),
+            $connection,
             $transformationProcessor
         );
 
         return new Content\Handler(
             $this->createMock(ContentGateway::class),
             new Content\Location\Gateway\DoctrineDatabase(
-                $this->getDatabaseHandler(),
+                $connection,
                 new CriteriaConverter(
                     [
-                        new LocationCriterionHandler\LocationId($this->getDatabaseHandler()),
-                        new LocationCriterionHandler\ParentLocationId($this->getDatabaseHandler()),
-                        new LocationCriterionHandler\LocationRemoteId($this->getDatabaseHandler()),
-                        new LocationCriterionHandler\Subtree($this->getDatabaseHandler()),
-                        new LocationCriterionHandler\Visibility($this->getDatabaseHandler()),
-                        new LocationCriterionHandler\Location\Depth($this->getDatabaseHandler()),
-                        new LocationCriterionHandler\Location\Priority($this->getDatabaseHandler()),
-                        new LocationCriterionHandler\Location\IsMainLocation($this->getDatabaseHandler()),
-                        new CommonCriterionHandler\ContentId($this->getDatabaseHandler()),
-                        new CommonCriterionHandler\ContentTypeGroupId($this->getDatabaseHandler()),
-                        new CommonCriterionHandler\ContentTypeId($this->getDatabaseHandler()),
+                        new LocationCriterionHandler\LocationId($connection),
+                        new LocationCriterionHandler\ParentLocationId($connection),
+                        new LocationCriterionHandler\LocationRemoteId($connection),
+                        new LocationCriterionHandler\Subtree($connection),
+                        new LocationCriterionHandler\Visibility($connection),
+                        new LocationCriterionHandler\Location\Depth($connection),
+                        new LocationCriterionHandler\Location\Priority($connection),
+                        new LocationCriterionHandler\Location\IsMainLocation($connection),
+                        new CommonCriterionHandler\ContentId($connection),
+                        new CommonCriterionHandler\ContentTypeGroupId($connection),
+                        new CommonCriterionHandler\ContentTypeId($connection),
                         new CommonCriterionHandler\ContentTypeIdentifier(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $this->getContentTypeHandler()
                         ),
-                        new CommonCriterionHandler\DateMetadata($this->getDatabaseHandler()),
+                        new CommonCriterionHandler\DateMetadata($connection),
                         new CommonCriterionHandler\Field(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $this->getContentTypeHandler(),
                             $this->getLanguageHandler(),
                             $this->getConverterRegistry(),
@@ -113,39 +114,39 @@ class HandlerLocationTest extends AbstractTestCase
                             $transformationProcessor
                         ),
                         new CommonCriterionHandler\FullText(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $transformationProcessor,
                             $this->getLanguageMaskGenerator(),
                             $fullTextSearchConfiguration
                         ),
                         new CommonCriterionHandler\LanguageCode(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $this->getLanguageMaskGenerator()
                         ),
-                        new CommonCriterionHandler\LogicalAnd($this->getDatabaseHandler()),
-                        new CommonCriterionHandler\LogicalNot($this->getDatabaseHandler()),
-                        new CommonCriterionHandler\LogicalOr($this->getDatabaseHandler()),
+                        new CommonCriterionHandler\LogicalAnd($connection),
+                        new CommonCriterionHandler\LogicalNot($connection),
+                        new CommonCriterionHandler\LogicalOr($connection),
                         new CommonCriterionHandler\MapLocationDistance(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $this->getContentTypeHandler(),
                             $this->getLanguageHandler()
                         ),
-                        new CommonCriterionHandler\MatchAll($this->getDatabaseHandler()),
-                        new CommonCriterionHandler\ObjectStateId($this->getDatabaseHandler()),
+                        new CommonCriterionHandler\MatchAll($connection),
+                        new CommonCriterionHandler\ObjectStateId($connection),
                         new CommonCriterionHandler\FieldRelation(
-                            $this->getDatabaseHandler(),
+                            $connection,
                             $this->getContentTypeHandler(),
                             $this->getLanguageHandler()
                         ),
-                        new CommonCriterionHandler\RemoteId($this->getDatabaseHandler()),
-                        new CommonCriterionHandler\SectionId($this->getDatabaseHandler()),
-                        new CommonCriterionHandler\UserMetadata($this->getDatabaseHandler()),
+                        new CommonCriterionHandler\RemoteId($connection),
+                        new CommonCriterionHandler\SectionId($connection),
+                        new CommonCriterionHandler\UserMetadata($connection),
                     ]
                 ),
                 new SortClauseConverter(
                     [
-                        new LocationSortClauseHandler\Location\Id($this->getDatabaseHandler()),
-                        new CommonSortClauseHandler\ContentId($this->getDatabaseHandler()),
+                        new LocationSortClauseHandler\Location\Id($connection),
+                        new CommonSortClauseHandler\ContentId($connection),
                     ]
                 ),
                 $this->getLanguageHandler()

--- a/eZ/Publish/Core/settings/search_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy.yml
@@ -43,10 +43,10 @@ services:
     ezpublish.search.legacy.gateway.location.inner:
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\DoctrineDatabase
         arguments:
-            - "@ezpublish.api.search_engine.legacy.dbhandler"
-            - "@ezpublish.search.legacy.gateway.criteria_converter.location"
-            - "@ezpublish.search.legacy.gateway.sort_clause_converter.location"
-            - "@ezpublish.spi.persistence.language_handler"
+            $connection: "@ezpublish.persistence.connection"
+            $criteriaConverter: "@ezpublish.search.legacy.gateway.criteria_converter.location"
+            $sortClauseConverter: "@ezpublish.search.legacy.gateway.sort_clause_converter.location"
+            $languageHandler: "@ezpublish.spi.persistence.language_handler"
 
     ezpublish.search.legacy.gateway.location.exception_conversion:
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\ExceptionConversion

--- a/eZ/Publish/Core/settings/search_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy.yml
@@ -26,10 +26,10 @@ services:
     ezpublish.search.legacy.gateway.content.inner:
         class: eZ\Publish\Core\Search\Legacy\Content\Gateway\DoctrineDatabase
         arguments:
-            - "@ezpublish.api.search_engine.legacy.dbhandler"
-            - "@ezpublish.search.legacy.gateway.criteria_converter.content"
-            - "@ezpublish.search.legacy.gateway.sort_clause_converter.content"
-            - "@ezpublish.spi.persistence.language_handler"
+            $connection: '@ezpublish.persistence.connection'
+            $criteriaConverter: '@ezpublish.search.legacy.gateway.criteria_converter.content'
+            $sortClauseConverter: '@ezpublish.search.legacy.gateway.sort_clause_converter.content'
+            $languageHandler: '@ezpublish.spi.persistence.language_handler'
 
     ezpublish.search.legacy.gateway.content.exception_conversion:
         class: eZ\Publish\Core\Search\Legacy\Content\Gateway\ExceptionConversion

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -36,46 +36,52 @@ parameters:
             - "tab_search_normalize"
 
 services:
-    ezpublish.search.legacy.gateway.criterion_handler.base:
-        abstract: true
-        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
-
-    ezpublish.search.legacy.gateway.criterion_handler.field_base:
+    eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler:
         abstract: true
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.spi.persistence.content_type_handler"
-            - "@ezpublish.spi.persistence.language_handler"
+            $connection: '@ezpublish.persistence.connection'
 
-    ezpublish.search.legacy.gateway.criterion_field_value_handler.base:
+    eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldBase:
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         abstract: true
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.api.storage_engine.transformation_processor"
+            $contentTypeHandler: '@ezpublish.spi.persistence.content_type_handler'
+            $languageHandler: '@ezpublish.spi.persistence.language_handler'
+
+    eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler:
+        abstract: true
+        arguments:
+            $connection: '@ezpublish.persistence.connection'
+            $transformationProcessor: '@ezpublish.api.storage_engine.transformation_processor'
+
+    # BC
+    ezpublish.search.legacy.gateway.criterion_handler.base: '@eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler'
+    ezpublish.search.legacy.gateway.criterion_handler.field_base: '@eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldBase'
+    ezpublish.search.legacy.gateway.criterion_field_value_handler.base: '@eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler'
 
     # Criterion handlers
     eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\CompositeCriterion:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.content_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.content_type_group_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentTypeGroupId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.content_type_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentTypeId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
@@ -83,16 +89,16 @@ services:
 
     ezpublish.search.legacy.gateway.criterion_handler.common.content_type_identifier:
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ContentTypeIdentifier
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.spi.persistence.content_type_handler"
-            - "@?logger"
+            $contentTypeHandler: '@ezpublish.spi.persistence.content_type_handler'
+            $logger: '@?logger'
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.date_metadata:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\DateMetadata
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
@@ -100,142 +106,138 @@ services:
 
     ezpublish.search.legacy.gateway.criterion_handler.common.field:
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\Field
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldBase
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.spi.persistence.content_type_handler"
-            - "@ezpublish.spi.persistence.language_handler"
-            - "@ezpublish.persistence.legacy.field_value_converter.registry"
-            - "@ezpublish.search.legacy.gateway.criterion_field_value_converter"
-            - "@ezpublish.api.storage_engine.transformation_processor"
+            $fieldConverterRegistry: '@ezpublish.persistence.legacy.field_value_converter.registry'
+            $fieldValueConverter: '@ezpublish.search.legacy.gateway.criterion_field_value_converter'
+            $transformationProcessor: '@ezpublish.api.storage_engine.transformation_processor'
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.field_empty:
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldEmpty
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldBase
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.spi.persistence.content_type_handler"
-            - "@ezpublish.spi.persistence.language_handler"
-            - "@ezpublish.persistence.legacy.field_value_converter.registry"
-            - "@ezpublish.api.service.field_type"
+            $fieldConverterRegistry: '@ezpublish.persistence.legacy.field_value_converter.registry'
+            $fieldTypeService: '@ezpublish.api.service.field_type'
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.full_text:
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FullText
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.api.storage_engine.transformation_processor"
-            - "@ezpublish.persistence.legacy.language.mask_generator"
-            - "%ezpublish.search.legacy.criterion_handler.full_text.configuration%"
+            $processor: '@ezpublish.api.storage_engine.transformation_processor'
+            $languageMaskGenerator: '@ezpublish.persistence.legacy.language.mask_generator'
+            $configuration: '%ezpublish.search.legacy.criterion_handler.full_text.configuration%'
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.language_code:
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\LanguageCode
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.persistence.legacy.language.mask_generator"
+            $maskGenerator: '@ezpublish.persistence.legacy.language.mask_generator'
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.logical_and:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\LogicalAnd
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.logical_not:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\LogicalNot
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.logical_or:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\LogicalOr
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.map_location_distance:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.field_base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldBase
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\MapLocationDistance
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.match_all:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\MatchAll
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.match_none:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\MatchNone
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.object_state_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ObjectStateId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.object_state_identifier:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\ObjectStateIdentifier
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.field_relation:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.field_base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldBase
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldRelation
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.remote_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\RemoteId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.section_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\SectionId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.section_identifier:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\SectionIdentifier
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.user_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\UserId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.user_email:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\UserEmail
         arguments:
             $transformationProcessor: '@ezpublish.api.storage_engine.transformation_processor'
@@ -244,7 +246,7 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.user_login:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\UserLogin
         arguments:
             $transformationProcessor: '@ezpublish.api.storage_engine.transformation_processor'
@@ -253,21 +255,21 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.is_user_enabled:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\IsUserEnabled
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.user_metadata:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\UserMetadata
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.is_user_based:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\IsUserBased
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
@@ -287,10 +289,10 @@ services:
             - "@ezpublish.search.legacy.gateway.criterion_field_value_handler.default"
 
     ezpublish.search.legacy.gateway.criterion_field_value_handler.collection.comma_separated:
-        parent: ezpublish.search.legacy.gateway.criterion_field_value_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Collection
         arguments:
-            - ,
+            $separator: ','
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezauthor}
             - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezcountry}
@@ -303,19 +305,19 @@ services:
             - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezkeyword}
 
     ezpublish.search.legacy.gateway.criterion_field_value_handler.collection.hypen_separated:
-        parent: ezpublish.search.legacy.gateway.criterion_field_value_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Collection
         arguments:
-            - -
+            $separator: '-'
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezselection}
 
     ezpublish.search.legacy.gateway.criterion_field_value_handler.composite:
-        parent: ezpublish.search.legacy.gateway.criterion_field_value_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Composite
 
     ezpublish.search.legacy.gateway.criterion_field_value_handler.simple:
-        parent: ezpublish.search.legacy.gateway.criterion_field_value_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler\Simple
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_field_value_handler, alias: ezboolean}

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_content.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_content.yml
@@ -6,25 +6,25 @@ services:
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter
 
     ezpublish.search.legacy.gateway.criterion_handler.content.ancestor:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler\Ancestor
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
 
     ezpublish.search.legacy.gateway.criterion_handler.content.location_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler\LocationId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
 
     ezpublish.search.legacy.gateway.criterion_handler.content.location_remote_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler\LocationRemoteId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
 
     ezpublish.search.legacy.gateway.criterion_handler.content.parent_location_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler\ParentLocationId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
@@ -33,19 +33,19 @@ services:
     # Only needed for Content Search on SQL engines where applying Permissions Subtree criterion on all possible
     # locations leads to peformance issues: https://jira.ez.no/browse/EZP-23037
     ezpublish.search.legacy.gateway.criterion_handler.content.permission_subtree:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler\PermissionSubtree
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
 
     ezpublish.search.legacy.gateway.criterion_handler.content.subtree:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler\Subtree
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
 
     ezpublish.search.legacy.gateway.criterion_handler.content.visibility:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler\Visibility
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_location.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_location.yml
@@ -6,55 +6,55 @@ services:
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter
 
     ezpublish.search.legacy.gateway.criterion_handler.location.ancestor:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Ancestor
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.depth:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location\Depth
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.location_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\LocationId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.is_main_location:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location\IsMainLocation
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.parent_location_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\ParentLocationId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.priority:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location\Priority
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.location_remote_id:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\LocationRemoteId
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.subtree:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Subtree
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
 
     ezpublish.search.legacy.gateway.criterion_handler.location.visibility:
-        parent: ezpublish.search.legacy.gateway.criterion_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Visibility
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}

--- a/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_common.yml
@@ -1,65 +1,62 @@
 services:
-    ezpublish.search.legacy.gateway.sort_clause_handler.base:
+    eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler:
         abstract: true
-        arguments: ["@ezpublish.api.storage_engine.legacy.dbhandler"]
+        arguments:
+            $connection: '@ezpublish.persistence.connection'
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.content_id:
-        parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\ContentId
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.content_name:
-        parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\ContentName
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.date_modified:
-        parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\DateModified
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.date_published:
-        parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\DatePublished
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
 
-    ezpublish.search.legacy.gateway.sort_clause_handler.common.field:
-        class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Field
+    eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Field:
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.spi.persistence.language_handler"
-            - "@ezpublish.spi.persistence.content_type_handler"
+            $languageHandler: '@ezpublish.spi.persistence.language_handler'
+            $contentTypeHandler: '@ezpublish.spi.persistence.content_type_handler'
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.map_location_distance:
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\MapLocationDistance
-        arguments:
-            - "@ezpublish.api.storage_engine.legacy.dbhandler"
-            - "@ezpublish.spi.persistence.language_handler"
-            - "@ezpublish.spi.persistence.content_type_handler"
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Field
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.section_identifier:
-        parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\SectionIdentifier
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.section_name:
-        parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\SectionName
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
@@ -71,7 +68,6 @@ services:
             - !tagged ezpublish.search.legacy.gateway.sort_clause_handler.gateway.random
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.random:
-        parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
         class: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\AbstractRandom
         factory: ['@eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Factory\RandomSortClauseHandlerFactory', 'getGateway']
         tags:
@@ -79,16 +75,19 @@ services:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
 
     eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Random\MySqlRandom:
-        parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.gateway.random}
 
     eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Random\SqlLiteRandom:
-        parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.gateway.random}
 
     eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Random\PgSqlRandom:
-        parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
+        parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.gateway.random}
+    # BC
+    ezpublish.search.legacy.gateway.sort_clause_handler.base: '@eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler'
+    ezpublish.search.legacy.gateway.sort_clause_handler.common.field: '@eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Field'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31302](https://jira.ez.no/browse/EZP-31302) blocking [EZP-30921](https://jira.ez.no/browse/EZP-30921)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0`
| **BC breaks**                          | yes
| **Tests pass**                          | yes
| **Doc needed**                       | yes

### TL; DR;

This PR replaces eZc Database Handler, Query and Expression Builder with Doctrine Connection and Query Builder in Legacy Search Engine gateways, Criterion Handlers, and Sort Clauses.

### Key differences with respect to eZc Database Query Builder.

Doctrine Query Builder advocates aliasing tables when building queries. In case of joins it's even required. 
While aliasing table as itself is possible, it's error prone, redundant, and not efficient (queries sent over network are much longer).
Therefore, when doing refactoring, most of the tables were given an alias. Some tables have intentionally different aliases to avoid collisions between outer and inner nested queries.

The most common aliases are:
- `c` for `ezcontentobject` table,
- `v` for `ezcontentobject_version` table
- `f_def` for `ezcontentobject_attribute` table (stands for Field Definition, following Domain language).

I've also used named parameters for easier debugging of queries. Names cannot be literal/fixed because the same Criterion for a query can be applied multiple times with different arguments. I could generate placeholder names, but Doctrine actually does that for us when no name is given.

What could be doubtful at first sight is parameter binding for outer queries instead of sub queries. This is specific to Doctrine Query Builder. Sub-queries are used just for convenience, but in the end they're just injected as strings into outer queries. Therefore any parameter defined in sub-query needs to be actually set on the outer one. It proved to be quite error prone, so maybe we need to rethink the design of Criteria and Sort Clauses handlers in the future.

### Doc

Criterion Handlers and Sort Clauses are considered extension points, so please see the doc in the PR for breaking changes.

#### Checklist:
- [x] PR description is updated.
- [x] Tests are passing.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
