### PR TITLE
EZP-31012: Fixed conversion to persistence value in ezuser field type (empty passwordUpdateAt)

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1789,6 +1789,13 @@ class UserServiceTest extends BaseTest
                 'enabled' => $user->enabled,
             ]
         );
+
+        // Make sure passwordUpdatedAt field has been updated together with password
+        $this->assertNotNull($user->passwordUpdatedAt);
+        $this->assertEquals(
+            (new DateTime())->format('Y-m-d H:i'),
+            $user->passwordUpdatedAt->format('Y-m-d H:i')
+        );
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/User/Type.php
+++ b/eZ/Publish/Core/FieldType/User/Type.php
@@ -259,6 +259,7 @@ class Type extends FieldType
                 $value->plainPassword,
                 $value->passwordHashType
             );
+            $value->passwordUpdatedAt = new DateTimeImmutable();
         }
 
         return new FieldValue(


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31012](https://jira.ez.no/browse/EZP-31012)
| **Type**                                   | bug
| **BC breaks**                          | no
| **Doc needed**                       | no


`\eZ\Publish\Core\FieldType\User\Value::$passwordUpdatedAt` should be updated together with `\eZ\Publish\Core\FieldType\User\Value::$passwordHashType`

Example failing build https://travis-ci.com/github/ezsystems/ezplatform-kernel/jobs/311199510)

#### Checklist:
- [X] PR description is updated.
- [X] Tests are implemented.
- [X] Added code follows Coding Standards (use `$ composer fix-cs`).
- [X] PR is ready for a review.
