### PR TITLE
EZP-31519: Move app.php rejection snippet from front controller to ezpublish-kernel 

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -96,6 +96,8 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
         $loader->load('services.yml');
         // Security services
         $loader->load('security.yml');
+        // HTTP Kernel
+        $loader->load('http_kernel.yml');
 
         if (interface_exists('FOS\JsRoutingBundle\Extractor\ExposedRoutesExtractorInterface')) {
             $loader->load('routing/js_routing.yml');

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/RejectExplicitFrontControllerRequestsListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/RejectExplicitFrontControllerRequestsListener.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * This behavior is reflected in meta repository's vhost.template so it should
+ * not be triggered on recommended nginx/apache setups. It mostly applies to
+ * Platform.sh and setups not relying on recommended vhost configuration.
+ */
+class RejectExplicitFrontControllerRequestsListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => [
+                ['onKernelRequest', 255],
+            ],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event)
+    {
+        if ($event->getRequestType() !== HttpKernelInterface::MASTER_REQUEST) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        $scriptFileName = preg_quote(basename($request->server->get('SCRIPT_FILENAME')), '\\');
+        // This pattern has to match with vhost.template files in meta repository
+        $pattern = sprintf('<^/([^/]+/)?%s([/?#]|$)>', $scriptFileName);
+
+        if (1 === preg_match($pattern, $request->getRequestUri())) {
+            // Trigger generic 404 error to avoid leaking backend technology details.
+            throw new NotFoundHttpException();
+        }
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/http_kernel.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/http_kernel.yml
@@ -1,0 +1,5 @@
+services:
+    ezpublish.http_kernel.reject_explicit_front_controller_requests_listener:
+        class: eZ\Bundle\EzPublishCoreBundle\EventListener\RejectExplicitFrontControllerRequestsListener
+        tags:
+              - { name: kernel.event_subscriber }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RejectExplicitFrontControllerRequestsListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RejectExplicitFrontControllerRequestsListenerTest.php
@@ -1,0 +1,284 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;
+
+use eZ\Bundle\EzPublishCoreBundle\EventListener\RejectExplicitFrontControllerRequestsListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+use PHPUnit\Framework\TestCase;
+
+class RejectExplicitFrontControllerRequestsListenerTest extends TestCase
+{
+    /** @var \eZ\Bundle\EzPublishCoreBundle\EventListener\RejectExplicitFrontControllerRequestsListener */
+    private $eventListener;
+
+    /** @var \Symfony\Component\HttpKernel\HttpKernelInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $httpKernel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->eventListener = new RejectExplicitFrontControllerRequestsListener();
+        $this->httpKernel = $this->createMock(HttpKernelInterface::class);
+    }
+
+    public function testSubscribedEvents(): void
+    {
+        $this->assertSame(
+            [
+                KernelEvents::REQUEST => [
+                    ['onKernelRequest', 255],
+                ],
+            ],
+            RejectExplicitFrontControllerRequestsListener::getSubscribedEvents()
+        );
+    }
+
+    /**
+     * @dataProvider validRequestDataProvider
+     * @doesNotPerformAssertions
+     */
+    public function testOnKernelRequest(Request $request): void
+    {
+        $event = new RequestEvent(
+            $this->httpKernel,
+            $request,
+            HttpKernelInterface::MASTER_REQUEST
+        );
+
+        $this->eventListener->onKernelRequest($event);
+    }
+
+    /**
+     * @dataProvider prohibitedRequestDataProvider
+     */
+    public function testOnKernelRequestThrowsException(Request $request): void
+    {
+        $this->expectException(NotFoundHttpException::class);
+
+        $event = new RequestEvent(
+            $this->httpKernel,
+            $request,
+            HttpKernelInterface::MASTER_REQUEST
+        );
+
+        $this->eventListener->onKernelRequest($event);
+    }
+
+    public function validRequestDataProvider(): array
+    {
+        return [
+            [
+                Request::create(
+                    'https://example.com',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/admin/dashboard',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/admin/dashboard',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/admin/dashboard/',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/admin/dashboard/',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/Folder/Content',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/Folder/Content',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/Folder/Content/',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/Folder/Content/',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/app.php-foo',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/app.php-foo',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/app.php.foo',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php.foo',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/folder/folder/app.php',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/folder/folder/app.php',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+        ];
+    }
+
+    public function prohibitedRequestDataProvider(): array
+    {
+        return [
+            [
+                Request::create(
+                    'https://example.com/app.php',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/app.php/app.php',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/app.php',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/folder/app.php',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/folder/app.php',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/app.php/foo',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/app.php/foo',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/app.php?foo=bar',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/app.php?foo=bar',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+            [
+                Request::create(
+                    'https://example.com/app.php#foo',
+                    'GET',
+                    [],
+                    [],
+                    [],
+                    [
+                        'REQUEST_URI' => 'https://example.com/app.php/app.php#foo',
+                        'SCRIPT_FILENAME' => 'app.php',
+                    ]
+                ),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This PR merges https://github.com/ezsystems/ezpublish-kernel/pull/3010 to `master`. I need another round of QA to make sure changed implementation is working in v3.