### PR TITLE
EZP-31536: Fixed cache corruption for the ez-users-<email>-by-email key

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -54,7 +54,6 @@ class UserHandler extends AbstractInMemoryPersistenceHandler implements UserHand
                 'ez-user-' . $user->id,
                 'ez-user-' . $this->escapeForCacheKey($user->login) . '-by-login',
                 'ez-user-' . $this->escapeForCacheKey($user->email) . '-by-email',
-                'ez-users-' . $this->escapeForCacheKey($user->email) . '-by-email',
                 //'ez-user-' . $hash . '-by-account-key',
             ];
         };


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31536](https://jira.ez.no/browse/EZP-31536)
| **Type**                                   | bug
| **Target eZ Platform version** | `3.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

The following PAPI calls sequence

```
$this->repository->getUserService()->loadUserByLogin('admin');
$this->repository->getUserService()->loadUsersByEmail('nospam@ez.no');
```

will cause the error

```
Return value of eZ\Publish\Core\Persistence\Cache\UserHandler::loadUsersByEmail() must be of the type array, object returned
```

`$this->repository->getUserService()->loadUserByLogin('admin');` will save `User` instance under `ez-users-<email>-by-email` key, and `$this->repository->getUserService()->loadUsersByEmail('nospam@ez.no'` will read this value and try to return it. However exected return type for `loadUsersByEmail`  is `array`

#### Checklist:
- [X] PR description is updated.
- [ ] Tests are implemented.
- [X] Added code follows Coding Standards (use `$ composer fix-cs`).
- [X] PR is ready for a review.
