### PR TITLE
EZP-31542: Added PHP 7.4 support  (eZ Platform 3.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,12 @@ matrix:
     - name: 'Code Style Check'
       php: 7.3
       env: CHECK_CS=1
+# 7.4
+    - php: 7.4
+      env: TEST_CONFIG="phpunit.xml"
+    - php: 7.4
+      env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="postgresql" DATABASE="pgsql://postgres@localhost/testdb"
+
 
 # test only master, stable branches and pull requests
 branches:

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
@@ -1227,7 +1227,7 @@ abstract class SearchBaseIntegrationTest extends BaseIntegrationTest
 
         foreach ($additionalFields as $additionalField) {
             foreach ($templates as $template) {
-                $template[] = $additionalField[0];
+                $template[] = $additionalField[0] ?? null;
                 $fixture[] = $template;
             }
         }

--- a/eZ/Publish/Core/FieldType/BinaryFile/SearchField.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/SearchField.php
@@ -29,17 +29,17 @@ class SearchField implements Indexable
         return [
             new Search\Field(
                 'file_name',
-                $field->value->externalData['fileName'],
+                $field->value->externalData['fileName'] ?? null,
                 new Search\FieldType\StringField()
             ),
             new Search\Field(
                 'file_size',
-                $field->value->externalData['fileSize'],
+                $field->value->externalData['fileSize'] ?? null,
                 new Search\FieldType\IntegerField()
             ),
             new Search\Field(
                 'mime_type',
-                $field->value->externalData['mimeType'],
+                $field->value->externalData['mimeType'] ?? null,
                 new Search\FieldType\StringField()
             ),
         ];

--- a/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
@@ -29,7 +29,7 @@ class SearchField implements Indexable
         return [
             new Search\Field(
                 'value',
-                $field->value->data['timestamp'],
+                $field->value->data['timestamp'] ?? null,
                 new Search\FieldType\DateField()
             ),
         ];

--- a/eZ/Publish/Core/FieldType/Image/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Image/SearchField.php
@@ -29,22 +29,22 @@ class SearchField implements Indexable
         return [
             new Search\Field(
                 'filename',
-                $field->value->data['fileName'],
+                $field->value->data['fileName'] ?? null,
                 new Search\FieldType\StringField()
             ),
             new Search\Field(
                 'alternative_text',
-                $field->value->data['alternativeText'],
+                $field->value->data['alternativeText'] ?? null,
                 new Search\FieldType\StringField()
             ),
             new Search\Field(
                 'file_size',
-                $field->value->data['fileSize'],
+                $field->value->data['fileSize'] ?? null,
                 new Search\FieldType\IntegerField()
             ),
             new Search\Field(
                 'mime_type',
-                $field->value->data['mime'],
+                $field->value->data['mime'] ?? null,
                 new Search\FieldType\StringField()
             ),
         ];

--- a/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
@@ -29,20 +29,20 @@ class SearchField implements Indexable
         return [
             new Search\Field(
                 'value_address',
-                $field->value->externalData['address'],
+                $field->value->externalData['address'] ?? null,
                 new Search\FieldType\StringField()
             ),
             new Search\Field(
                 'value_location',
                 [
-                    'latitude' => $field->value->externalData['latitude'],
-                    'longitude' => $field->value->externalData['longitude'],
+                    'latitude' => $field->value->externalData['latitude'] ?? null,
+                    'longitude' => $field->value->externalData['longitude'] ?? null,
                 ],
                 new Search\FieldType\GeoLocationField()
             ),
             new Search\Field(
                 'fulltext',
-                $field->value->externalData['address'],
+                $field->value->externalData['address'] ?? null,
                 new Search\FieldType\FullTextField()
             ),
         ];

--- a/eZ/Publish/Core/FieldType/Media/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Media/SearchField.php
@@ -29,17 +29,17 @@ class SearchField implements Indexable
         return [
             new Search\Field(
                 'file_name',
-                $field->value->externalData['fileName'],
+                $field->value->externalData['fileName'] ?? null,
                 new Search\FieldType\StringField()
             ),
             new Search\Field(
                 'file_size',
-                $field->value->externalData['fileSize'],
+                $field->value->externalData['fileSize'] ?? null,
                 new Search\FieldType\IntegerField()
             ),
             new Search\Field(
                 'mime_type',
-                $field->value->externalData['mimeType'],
+                $field->value->externalData['mimeType'] ?? null,
                 new Search\FieldType\StringField()
             ),
         ];

--- a/eZ/Publish/Core/FieldType/Relation/Type.php
+++ b/eZ/Publish/Core/FieldType/Relation/Type.php
@@ -239,12 +239,14 @@ class Type extends FieldType
      */
     public function fromHash($hash)
     {
-        $destinationContentId = $hash['destinationContentId'];
-        if ($destinationContentId !== null) {
-            $destinationContentId = (int)$destinationContentId;
+        if ($hash !== null) {
+            $destinationContentId = $hash['destinationContentId'];
+            if ($destinationContentId !== null) {
+                return new Value((int)$destinationContentId);
+            }
         }
 
-        return new Value($destinationContentId);
+        return $this->getEmptyValue();
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
@@ -117,7 +117,7 @@ class UrlStorageTest extends TestCase
         $result = $storage->storeFieldData($versionInfo, $field, $this->getContext());
 
         $this->assertFalse($result);
-        $this->assertNull($field->value->data['urlId']);
+        $this->assertNull($field->value->data);
     }
 
     public function testGetFieldData()

--- a/eZ/Publish/Core/FieldType/Tests/UserTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/UserTest.php
@@ -9,6 +9,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 use DateTimeImmutable;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\FieldType\User\Type;
 use eZ\Publish\Core\FieldType\User\Type as UserType;
 use eZ\Publish\Core\FieldType\User\Value as UserValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
@@ -416,7 +417,14 @@ class UserTest extends FieldTypeTest
             $this->createMock(PasswordValidatorInterface::class)
         );
 
+        $fieldSettings = [
+            Type::USERNAME_PATTERN => '.*',
+            Type::REQUIRE_UNIQUE_EMAIL => false,
+        ];
+
         $fieldDefinitionMock = $this->createMock(FieldDefinition::class);
+        $fieldDefinitionMock->method('__get')->with('fieldSettings')->willReturn($fieldSettings);
+        $fieldDefinitionMock->method('getFieldSettings')->willReturn($fieldSettings);
 
         $validationErrors = $userType->validate($fieldDefinitionMock, $userValue);
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/AuthorConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/AuthorConverter.php
@@ -63,7 +63,11 @@ class AuthorConverter implements Converter
      */
     public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef)
     {
-        $storageDef->dataInt1 = (int)$fieldDef->fieldTypeConstraints->fieldSettings['defaultAuthor'];
+        $fieldSettings = $fieldDef->fieldTypeConstraints->fieldSettings;
+
+        if ($fieldSettings !== null) {
+            $storageDef->dataInt1 = (int)$fieldSettings['defaultAuthor'];
+        }
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
@@ -75,13 +75,16 @@ class DateAndTimeConverter implements Converter
      */
     public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef)
     {
-        $storageDef->dataInt2 = $fieldDef->fieldTypeConstraints->fieldSettings['useSeconds'] ? 1 : 0;
-        $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->fieldSettings['defaultType'];
+        $fieldSettings = $fieldDef->fieldTypeConstraints->fieldSettings;
+        if ($fieldSettings === null) {
+            return;
+        }
 
-        if ($fieldDef->fieldTypeConstraints->fieldSettings['defaultType'] === DateAndTimeType::DEFAULT_CURRENT_DATE_ADJUSTED) {
-            $storageDef->dataText5 = $this->generateDateIntervalXML(
-                $fieldDef->fieldTypeConstraints->fieldSettings['dateInterval']
-            );
+        $storageDef->dataInt2 = $fieldSettings['useSeconds'] ? 1 : 0;
+        $storageDef->dataInt1 = $fieldSettings['defaultType'];
+
+        if ($fieldSettings['defaultType'] === DateAndTimeType::DEFAULT_CURRENT_DATE_ADJUSTED) {
+            $storageDef->dataText5 = $this->generateDateIntervalXML($fieldSettings['dateInterval']);
         }
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateConverter.php
@@ -72,7 +72,7 @@ class DateConverter implements Converter
      */
     public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef)
     {
-        $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->fieldSettings['defaultType'];
+        $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->fieldSettings['defaultType'] ?? null;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TimeConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TimeConverter.php
@@ -70,8 +70,12 @@ class TimeConverter implements Converter
      */
     public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef)
     {
-        $storageDef->dataInt1 = $fieldDef->fieldTypeConstraints->fieldSettings['defaultType'];
-        $storageDef->dataInt2 = $fieldDef->fieldTypeConstraints->fieldSettings['useSeconds'] ? 1 : 0;
+        $fieldSettings = $fieldDef->fieldTypeConstraints->fieldSettings;
+
+        if ($fieldSettings !== null) {
+            $storageDef->dataInt1 = $fieldSettings['defaultType'];
+            $storageDef->dataInt2 = $fieldSettings['useSeconds'] ? 1 : 0;
+        }
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
@@ -226,7 +226,15 @@ class ContentHandlerTest extends TestCase
             ->with(23, 1)
             ->will(
                 $this->returnValue(
-                    new VersionInfo(['contentInfo' => new ContentInfo(['currentVersionNo' => 1])])
+                    new VersionInfo([
+                        'contentInfo' => new ContentInfo([
+                            'currentVersionNo' => 1,
+                            'mainLanguageCode' => 'eng-GB',
+                        ]),
+                        'names' => [
+                            'eng-GB' => '',
+                        ],
+                    ])
                 )
             );
 
@@ -298,7 +306,15 @@ class ContentHandlerTest extends TestCase
             ->with(23, 2)
             ->will(
                 $this->returnValue(
-                    new VersionInfo(['contentInfo' => new ContentInfo(['currentVersionNo' => 1])])
+                    new VersionInfo([
+                        'contentInfo' => new ContentInfo([
+                            'currentVersionNo' => 1,
+                            'mainLanguageCode' => 'eng-GB',
+                        ]),
+                        'names' => [
+                            'eng-GB' => '',
+                        ],
+                    ])
                 )
             );
 

--- a/eZ/Publish/Core/Persistence/TransformationProcessor/PcreCompiler.php
+++ b/eZ/Publish/Core/Persistence/TransformationProcessor/PcreCompiler.php
@@ -196,7 +196,7 @@ class PcreCompiler
      */
     protected function getTransposeClosure($operator, $value)
     {
-        $value = hexdec($value) * ($operator === '-' ? -1 : 1);
+        $value = $this->hexdec($value) * ($operator === '-' ? -1 : 1);
         $converter = $this->converter;
 
         return function ($matches) use ($value, $converter) {
@@ -270,5 +270,19 @@ class PcreCompiler
             default:
                 throw new RuntimeException("Invalid character definition: $char");
         }
+    }
+
+    /**
+     * Converts a hexadecimal string to a decimal number.
+     *
+     * In comparison to standard hexdec function it will ignore any non-hexadecimal characters
+     */
+    private function hexdec(?string $value): int
+    {
+        if ($value === null) {
+            return 0;
+        }
+
+        return hexdec(preg_replace('/[^[:xdigit:]]/', '', (string)$value));
     }
 }

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UserPreferenceTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UserPreferenceTest.php
@@ -33,12 +33,10 @@ class UserPreferenceTest extends BaseServiceMockTest
         $this->userSPIPreferenceHandler = $this->getPersistenceMockHandler('UserPreference\\Handler');
         $permissionResolverMock = $this->createMock(PermissionResolver::class);
         $permissionResolverMock
-            ->expects($this->atLeastOnce())
             ->method('getCurrentUserReference')
             ->willReturn(new UserReference(self::CURRENT_USER_ID));
         $repository = $this->getRepositoryMock();
         $repository
-            ->expects($this->atLeastOnce())
             ->method('getPermissionResolver')
             ->willReturn($permissionResolverMock);
     }

--- a/eZ/Publish/Core/Repository/UserPreferenceService.php
+++ b/eZ/Publish/Core/Repository/UserPreferenceService.php
@@ -62,14 +62,15 @@ class UserPreferenceService implements UserPreferenceServiceInterface
     {
         $spiSetStructs = [];
         foreach ($userPreferenceSetStructs as $key => $userPreferenceSetStruct) {
-            $spiSetStruct = new UserPreferenceSetStruct();
-            $spiSetStruct->userId = $this->getCurrentUserId();
-
             if (empty($userPreferenceSetStruct->name)) {
                 throw new InvalidArgumentException('name', $userPreferenceSetStruct->name . ' at index ' . $key);
             }
 
-            $spiSetStruct->name = $userPreferenceSetStruct->name;
+            $value = $userPreferenceSetStruct->value;
+
+            if (is_object($value) && !method_exists($value, '__toString')) {
+                throw new InvalidArgumentException('value', 'Cannot convert value to string at index ' . $key);
+            }
 
             try {
                 $value = (string)$userPreferenceSetStruct->value;
@@ -77,7 +78,11 @@ class UserPreferenceService implements UserPreferenceServiceInterface
                 throw new InvalidArgumentException('value', 'Cannot convert value to string at index ' . $key);
             }
 
+            $spiSetStruct = new UserPreferenceSetStruct();
+            $spiSetStruct->userId = $this->getCurrentUserId();
+            $spiSetStruct->name = $userPreferenceSetStruct->name;
             $spiSetStruct->value = $value;
+
             $spiSetStructs[] = $spiSetStruct;
         }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31542](https://jira.ez.no/browse/EZP-31542)
| **Type**                                   | improvement
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no


The most significant changes from our perspective: 

```
Trying to use values of type null, bool, int, float or resource as an array (such as $null["key"]) will now generate a notice. This does not affect array accesses performed by list(). RFC: https://wiki.php.net/rfc/notice-for-non-valid-array-container
```
```
Passing invalid characters to ''base_convert()'', ''bindec()'', ''octdec()'' and ''hexdec()'' will now generate a deprecation notice. The result will still be computed as if the invalid characters did not exist. Leading and trailing whitespace, as well as prefixes of type 0x (depending on base) continue to be allowed.
```

```
Throwing exceptions from __toString() is now permitted. Previously this resulted in a fatal error. Existing recoverable fatals in string conversions have been converted to Error exceptions. RFC: https://wiki.php.net/rfc/tostring_exceptions
```

Full upgrade notes: https://github.com/php/php-src/blob/PHP-7.4.5/UPGRADING

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
