### PR TITLE
EZP-31546: Fixed ignored path prefixes for binaries and images

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -62,17 +62,25 @@ services:
         alias: ezpublish.image_alias.imagine.alias_generator.image_asset
 
     ezpublish.fieldType.ezimage.io_service.published:
-        class: eZ\Publish\Core\IO\ConfigScopeChangeAwareIOService
-        arguments:
-            $configResolver: '@ezpublish.config.resolver'
-            $innerIOService: '@ezpublish.core.io.service'
-            $prefixParameterName: 'image.published_images_dir'
+        parent: ezpublish.core.io.service
 
     ezpublish.fieldType.ezimage.io_service.draft:
+        parent: ezpublish.core.io.service
+
+    ezpublish.fieldType.ezimage.io_service.published.config_scope_change_aware:
         class: eZ\Publish\Core\IO\ConfigScopeChangeAwareIOService
+        decorates: ezpublish.fieldType.ezimage.io_service.published
         arguments:
             $configResolver: '@ezpublish.config.resolver'
-            $innerIOService: '@ezpublish.core.io.service'
+            $innerIOService: '@ezpublish.fieldType.ezimage.io_service.published.config_scope_change_aware.inner'
+            $prefixParameterName: 'image.published_images_dir'
+
+    ezpublish.fieldType.ezimage.io_service.draft.config_scope_change_aware:
+        class: eZ\Publish\Core\IO\ConfigScopeChangeAwareIOService
+        decorates: ezpublish.fieldType.ezimage.io_service.draft
+        arguments:
+            $configResolver: '@ezpublish.config.resolver'
+            $innerIOService: '@ezpublish.fieldType.ezimage.io_service.draft.config_scope_change_aware.inner'
             $prefixParameterName: 'image.versioned_images_dir'
 
     ezpublish.fieldType.ezimage.pathGenerator:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -98,10 +98,15 @@ services:
 
     # BinaryFile
     ezpublish.fieldType.ezbinaryfile.io_service:
+        parent: ezpublish.core.io.service
+
+    ezpublish.fieldType.ezbinaryfile.io_service.config_scope_change_aware:
         class: eZ\Publish\Core\IO\ConfigScopeChangeAwareIOService
+        decorates: ezpublish.fieldType.ezbinaryfile.io_service
+        lazy: true
         arguments:
             $configResolver: '@ezpublish.config.resolver'
-            $innerIOService: '@ezpublish.core.io.service'
+            $innerIOService: '@ezpublish.fieldType.ezbinaryfile.io_service.config_scope_change_aware.inner'
             $prefixParameterName: 'binary_dir'
 
     ezpublish.fieldType.ezbinaryfile.pathGenerator:

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -70,6 +70,7 @@ services:
     ezpublish.fieldType.ezimage.io_service.published.config_scope_change_aware:
         class: eZ\Publish\Core\IO\ConfigScopeChangeAwareIOService
         decorates: ezpublish.fieldType.ezimage.io_service.published
+        lazy: true
         arguments:
             $configResolver: '@ezpublish.config.resolver'
             $innerIOService: '@ezpublish.fieldType.ezimage.io_service.published.config_scope_change_aware.inner'
@@ -78,6 +79,7 @@ services:
     ezpublish.fieldType.ezimage.io_service.draft.config_scope_change_aware:
         class: eZ\Publish\Core\IO\ConfigScopeChangeAwareIOService
         decorates: ezpublish.fieldType.ezimage.io_service.draft
+        lazy: true
         arguments:
             $configResolver: '@ezpublish.config.resolver'
             $innerIOService: '@ezpublish.fieldType.ezimage.io_service.draft.config_scope_change_aware.inner'

--- a/eZ/Publish/Core/IO/ConfigScopeChangeAwareIOService.php
+++ b/eZ/Publish/Core/IO/ConfigScopeChangeAwareIOService.php
@@ -33,6 +33,9 @@ class ConfigScopeChangeAwareIOService implements IOServiceInterface, ConfigScope
         $this->configResolver = $configResolver;
         $this->innerIOService = $innerIOService;
         $this->prefixParameterName = $prefixParameterName;
+
+        // set initial prefix on inner IOService
+        $this->setPrefix($this->configResolver->getParameter($this->prefixParameterName));
     }
 
     public function setPrefix($prefix): void

--- a/eZ/Publish/Core/IO/Tests/ConfigScopeChangeAwareIOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/ConfigScopeChangeAwareIOServiceTest.php
@@ -16,7 +16,7 @@ use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use PHPUnit\Framework\TestCase;
 
-class ConfigScopeChangeAwareIOServiceTest extends TestCase
+final class ConfigScopeChangeAwareIOServiceTest extends TestCase
 {
     protected const PREFIX = 'test-prefix';
     protected const PREFIX_PARAMETER_NAME = 'param';

--- a/eZ/Publish/Core/IO/Tests/ConfigScopeChangeAwareIOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/ConfigScopeChangeAwareIOServiceTest.php
@@ -1,0 +1,320 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\IO\Tests;
+
+use eZ\Publish\Core\IO\ConfigScopeChangeAwareIOService;
+use eZ\Publish\Core\IO\IOServiceInterface;
+use eZ\Publish\Core\IO\Values\BinaryFile;
+use eZ\Publish\Core\IO\Values\BinaryFileCreateStruct;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use PHPUnit\Framework\TestCase;
+
+class ConfigScopeChangeAwareIOServiceTest extends TestCase
+{
+    protected const PREFIX = 'test-prefix';
+    protected const PREFIX_PARAMETER_NAME = 'param';
+
+    /** @var \eZ\Publish\Core\IO\ConfigScopeChangeAwareIOService */
+    protected $IOService;
+
+    /** @var \eZ\Publish\Core\IO\ConfigScopeChangeAwareIOService|\PHPUnit\Framework\MockObject\MockObject */
+    protected $innerIOService;
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
+    protected $configResolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->configResolver
+            ->method('getParameter')
+            ->with(self::PREFIX_PARAMETER_NAME, null, null)
+            ->willReturn(self::PREFIX)
+        ;
+
+        $this->innerIOService = $this->createMock(IOServiceInterface::class);
+        $this->IOService = new ConfigScopeChangeAwareIOService(
+            $this->configResolver,
+            $this->innerIOService,
+            self::PREFIX_PARAMETER_NAME
+        );
+    }
+
+    public function testConstructor(): void
+    {
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('setPrefix')
+            ->with(self::PREFIX)
+        ;
+
+        new ConfigScopeChangeAwareIOService(
+            $this->configResolver,
+            $this->innerIOService,
+            self::PREFIX_PARAMETER_NAME
+        );
+    }
+
+    public function testSetPrefix(): void
+    {
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('setPrefix')
+        ;
+
+        $this->IOService->setPrefix(self::PREFIX);
+    }
+
+    public function testGetExternalPath(): void
+    {
+        $internalId = 10;
+        $expectedExternalPath = '/example/external/path';
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('getExternalPath')
+            ->with($internalId)
+            ->willReturn($expectedExternalPath)
+        ;
+
+        $externalPath = $this->IOService->getExternalPath($internalId);
+
+        $this->assertEquals($expectedExternalPath, $externalPath);
+    }
+
+    public function testNewBinaryCreateStructFromLocalFile(): void
+    {
+        $expectedBinaryFileCreateStruct = new BinaryFileCreateStruct();
+        $localFile = '/path/to/local/file.txt';
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('newBinaryCreateStructFromLocalFile')
+            ->with($localFile)
+            ->willReturn($expectedBinaryFileCreateStruct)
+        ;
+
+        $binaryFileCreateStruct = $this->innerIOService->newBinaryCreateStructFromLocalFile($localFile);
+
+        $this->assertEquals($expectedBinaryFileCreateStruct, $binaryFileCreateStruct);
+    }
+
+    public function testExists(): void
+    {
+        $binaryFileId = 'test-id';
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('exists')
+            ->with($binaryFileId)
+            ->willReturn(true)
+        ;
+
+        $this->assertTrue($this->innerIOService->exists($binaryFileId));
+    }
+
+    public function testGetInternalPath(): void
+    {
+        $expectedInternalPath = new BinaryFileCreateStruct();
+        $externalId = 'test-id';
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('getInternalPath')
+            ->with($externalId)
+            ->willReturn($expectedInternalPath)
+        ;
+
+        $internalPath = $this->innerIOService->getInternalPath($externalId);
+
+        $this->assertEquals($expectedInternalPath, $internalPath);
+    }
+
+    public function testLoadBinaryFile(): void
+    {
+        $expectedBinaryFile = new BinaryFile();
+        $binaryFileId = 'test-id';
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('loadBinaryFile')
+            ->with($binaryFileId)
+            ->willReturn($expectedBinaryFile)
+        ;
+
+        $binaryFile = $this->innerIOService->loadBinaryFile($binaryFileId);
+
+        $this->assertEquals($expectedBinaryFile, $binaryFile);
+    }
+
+    public function testLoadBinaryFileByUri(): void
+    {
+        $expectedBinaryFile = new BinaryFile();
+        $uri = 'http://example.com/file.pdf';
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('loadBinaryFileByUri')
+            ->with($uri)
+            ->willReturn($expectedBinaryFile)
+        ;
+
+        $binaryFile = $this->innerIOService->loadBinaryFileByUri($uri);
+
+        $this->assertEquals($expectedBinaryFile, $binaryFile);
+    }
+
+    public function testGetFileContents(): void
+    {
+        $binaryFile = new BinaryFile();
+        $expectedContents = 'test';
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('getFileContents')
+            ->with($binaryFile)
+            ->willReturn($expectedContents)
+        ;
+
+        $contents = $this->innerIOService->getFileContents($binaryFile);
+
+        $this->assertEquals($expectedContents, $contents);
+    }
+
+    public function testCreateBinaryFile(): void
+    {
+        $expectedBinaryFile = new BinaryFile();
+        $binaryFileCreateStruct = new BinaryFileCreateStruct();
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('createBinaryFile')
+            ->with($binaryFileCreateStruct)
+            ->willReturn($expectedBinaryFile)
+        ;
+
+        $binaryFile = $this->innerIOService->createBinaryFile($binaryFileCreateStruct);
+
+        $this->assertEquals($expectedBinaryFile, $binaryFile);
+    }
+
+    public function testGetUri(): void
+    {
+        $expectedUri = 'http://example.com/test.pdf';
+        $binaryFileId = 'file-id';
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('getUri')
+            ->with($binaryFileId)
+            ->willReturn($expectedUri)
+        ;
+
+        $uri = $this->innerIOService->getUri($binaryFileId);
+
+        $this->assertEquals($expectedUri, $uri);
+    }
+
+    public function testGetMimeType(): void
+    {
+        $expectedMimeType = 'text/xml';
+        $binaryFileId = 'file-id';
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('getMimeType')
+            ->with($binaryFileId)
+            ->willReturn($expectedMimeType)
+        ;
+
+        $mimeType = $this->innerIOService->getMimeType($binaryFileId);
+
+        $this->assertEquals($expectedMimeType, $mimeType);
+    }
+
+    public function testGetFileInputStream(): void
+    {
+        $expectedFileInputStream = 'resource';
+        $binaryFile = new BinaryFile();
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('getFileInputStream')
+            ->with($binaryFile)
+            ->willReturn($expectedFileInputStream)
+        ;
+
+        $fileInputStream = $this->innerIOService->getFileInputStream($binaryFile);
+
+        $this->assertEquals($expectedFileInputStream, $fileInputStream);
+    }
+
+    public function testDeleteBinaryFile(): void
+    {
+        $binaryFile = new BinaryFile();
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('deleteBinaryFile')
+            ->with($binaryFile)
+        ;
+
+        $this->innerIOService->deleteBinaryFile($binaryFile);
+    }
+
+    public function testNewBinaryCreateStructFromUploadedFile(): void
+    {
+        $expectedBinaryFileCreateStruct = new BinaryFileCreateStruct();
+        $uploadedFile = [
+            'name' => 'example.jpg',
+            'type' => 'image/jpeg',
+            'tmp_name' => '/tmp/phpn3FmFr',
+            'error' => 0,
+            'size' => 15476,
+        ];
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('newBinaryCreateStructFromUploadedFile')
+            ->with($uploadedFile)
+            ->willReturn($expectedBinaryFileCreateStruct)
+        ;
+
+        $binaryFileCreateStruct = $this->innerIOService->newBinaryCreateStructFromUploadedFile($uploadedFile);
+
+        $this->assertEquals($expectedBinaryFileCreateStruct, $binaryFileCreateStruct);
+    }
+
+    public function testDeleteDirectory(): void
+    {
+        $path = '/path/to/directory';
+
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('deleteDirectory')
+            ->with($path)
+        ;
+
+        $this->innerIOService->deleteDirectory($path);
+    }
+
+    public function testOnConfigScopeChange(): void
+    {
+        $siteAccess = $this->createMock(SiteAccess::class);
+        $this->innerIOService
+            ->expects($this->once())
+            ->method('setPrefix')
+            ->with(self::PREFIX);
+
+        $this->IOService->onConfigScopeChange($siteAccess);
+    }
+}

--- a/eZ/Publish/Core/IO/Tests/ConfigScopeChangeAwareIOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/ConfigScopeChangeAwareIOServiceTest.php
@@ -22,7 +22,7 @@ final class ConfigScopeChangeAwareIOServiceTest extends TestCase
     protected const PREFIX_PARAMETER_NAME = 'param';
 
     /** @var \eZ\Publish\Core\IO\ConfigScopeChangeAwareIOService */
-    protected $IOService;
+    protected $ioService;
 
     /** @var \eZ\Publish\Core\IO\ConfigScopeChangeAwareIOService|\PHPUnit\Framework\MockObject\MockObject */
     protected $innerIOService;
@@ -42,7 +42,7 @@ final class ConfigScopeChangeAwareIOServiceTest extends TestCase
         ;
 
         $this->innerIOService = $this->createMock(IOServiceInterface::class);
-        $this->IOService = new ConfigScopeChangeAwareIOService(
+        $this->ioService = new ConfigScopeChangeAwareIOService(
             $this->configResolver,
             $this->innerIOService,
             self::PREFIX_PARAMETER_NAME
@@ -71,7 +71,7 @@ final class ConfigScopeChangeAwareIOServiceTest extends TestCase
             ->method('setPrefix')
         ;
 
-        $this->IOService->setPrefix(self::PREFIX);
+        $this->ioService->setPrefix(self::PREFIX);
     }
 
     public function testGetExternalPath(): void
@@ -86,7 +86,7 @@ final class ConfigScopeChangeAwareIOServiceTest extends TestCase
             ->willReturn($expectedExternalPath)
         ;
 
-        $externalPath = $this->IOService->getExternalPath($internalId);
+        $externalPath = $this->ioService->getExternalPath($internalId);
 
         $this->assertEquals($expectedExternalPath, $externalPath);
     }
@@ -315,6 +315,6 @@ final class ConfigScopeChangeAwareIOServiceTest extends TestCase
             ->method('setPrefix')
             ->with(self::PREFIX);
 
-        $this->IOService->onConfigScopeChange($siteAccess);
+        $this->ioService->onConfigScopeChange($siteAccess);
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31546](https://jira.ez.no/browse/EZP-31546)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.0.1`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [x] PR description is updated.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
