### PR TITLE
EZEE-3091: Used twig dump to display object arguments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "symfony/console": "^5.0",
         "symfony/expression-language": "^5.0",
         "symfony/validator": "^5.0",
+        "symfony/var-dumper": "^5.0",
         "ezsystems/doctrine-dbal-schema": "^1.0@dev",
         "ezsystems/routing": "^2.2",
         "guzzlehttp/guzzle": "^6.5",

--- a/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/persistence/panel.html.twig
+++ b/eZ/Bundle/EzPublishDebugBundle/Resources/views/Profiler/persistence/panel.html.twig
@@ -50,13 +50,9 @@
                     </p>
                 </td>
                 <td>
-                    {% for key, argument  in call.arguments %}
-                        {{ key }}:
-                        {% if argument is iterable %}
-                           {{  argument|join(', ') }}
-                        {% else %}
-                            {{  argument }}
-                        {% endif %}
+
+                    {% for key, argument in call.arguments %}
+                        {{ key }}:{{ dump(argument) }}
                         <br>
                     {% endfor %}
                 </td>


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZEE-3091](https://jira.ez.no/browse/EZEE-3091)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

Before SiteAccess factory, there were only scalar values used in `$arguments` array in `\eZ\Publish\Core\Persistence\Cache\PersistenceLogger::logCall` method.
When object was used it unsuccessfully tried to cast it to string.

#### Checklist:
- [x] PR description is updated.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
