### PR TITLE
EZP-30465: Fixed PermissionResolver injection into commands

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -307,7 +307,7 @@ services:
         autoconfigure: true
         arguments:
             $locationService: '@ezpublish.api.service.location'
-            $permissionResolver: "@=service('ezpublish.api.repository').getPermissionResolver()"
+            $permissionResolver: '@eZ\Publish\API\Repository\PermissionResolver'
             $userService: '@ezpublish.api.service.user'
             $contentTypeService: '@ezpublish.api.service.content_type'
             $searchService: '@ezpublish.api.service.search'
@@ -322,7 +322,7 @@ services:
             $ioService: '@ezpublish.fieldType.ezimage.io_service.published'
             $imagine: '@liip_imagine'
             $filterManager: '@liip_imagine.filter.manager'
-            $permissionResolver: "@=service('ezpublish.api.repository').getPermissionResolver()"
+            $permissionResolver: '@eZ\Publish\API\Repository\PermissionResolver'
             $userService: '@ezpublish.api.service.user'
             $mimeTypes: '@mime_types'
         tags:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-30465](https://jira.ez.no/browse/EZP-30465)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.0.1`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

`CopySubtreeCommand` and `ResizeOriginalImagesCommand` Symfony commands were injected with PermissionResolver using expression language (`@=service('ezpublish.api.repository').getPermissionResolver()`). 

This might lead to an existence of two different instances of `PermissionResolver` accross the application when used with command.

#### QA
Sanities for Symfony commands:
- [x] `ezplatform:copy-subtree`
- [x] `ezplatform:images:resize-original`

#### Checklist:
- [x] PR description is updated.
- [x] Tests are passing.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
