### PR TITLE
EZP-30465: Changed the way PermissionResolver is built to make it reusable

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -7,6 +7,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
 use eZ\Publish\API\Repository\LanguageResolver;
+use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\FieldType\FieldTypeRegistry;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
@@ -47,11 +48,15 @@ class RepositoryFactory implements ContainerAwareInterface
     /** @var \eZ\Publish\API\Repository\LanguageResolver */
     private $languageResolver;
 
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    private $permissionResolver;
+
     public function __construct(
         ConfigResolverInterface $configResolver,
         $repositoryClass,
         array $policyMap,
         LanguageResolver $languageResolver,
+        PermissionResolver $permissionResolver,
         LoggerInterface $logger = null
     ) {
         $this->configResolver = $configResolver;
@@ -59,6 +64,7 @@ class RepositoryFactory implements ContainerAwareInterface
         $this->policyMap = $policyMap;
         $this->languageResolver = $languageResolver;
         $this->logger = null !== $logger ? $logger : new NullLogger();
+        $this->permissionResolver = $permissionResolver;
     }
 
     /**
@@ -97,6 +103,7 @@ class RepositoryFactory implements ContainerAwareInterface
             $roleDomainMapper,
             $limitationService,
             $this->languageResolver,
+            $this->permissionResolver,
             [
                 'role' => [
                     'policyMap' => $this->policyMap,

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -7,7 +7,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
 use eZ\Publish\API\Repository\LanguageResolver;
-use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\PermissionService;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\FieldType\FieldTypeRegistry;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
@@ -48,15 +48,11 @@ class RepositoryFactory implements ContainerAwareInterface
     /** @var \eZ\Publish\API\Repository\LanguageResolver */
     private $languageResolver;
 
-    /** @var \eZ\Publish\API\Repository\PermissionResolver */
-    private $permissionResolver;
-
     public function __construct(
         ConfigResolverInterface $configResolver,
         $repositoryClass,
         array $policyMap,
         LanguageResolver $languageResolver,
-        PermissionResolver $permissionResolver,
         LoggerInterface $logger = null
     ) {
         $this->configResolver = $configResolver;
@@ -64,7 +60,6 @@ class RepositoryFactory implements ContainerAwareInterface
         $this->policyMap = $policyMap;
         $this->languageResolver = $languageResolver;
         $this->logger = null !== $logger ? $logger : new NullLogger();
-        $this->permissionResolver = $permissionResolver;
     }
 
     /**
@@ -85,7 +80,8 @@ class RepositoryFactory implements ContainerAwareInterface
         Mapper\ContentDomainMapper $contentDomainMapper,
         Mapper\ContentTypeDomainMapper $contentTypeDomainMapper,
         Mapper\RoleDomainMapper $roleDomainMapper,
-        LimitationService $limitationService
+        LimitationService $limitationService,
+        PermissionService $permissionService
     ): Repository {
         $config = $this->container->get('ezpublish.api.repository_configuration_provider')->getRepositoryConfig();
 
@@ -103,7 +99,7 @@ class RepositoryFactory implements ContainerAwareInterface
             $roleDomainMapper,
             $limitationService,
             $this->languageResolver,
-            $this->permissionResolver,
+            $permissionService,
             [
                 'role' => [
                     'policyMap' => $this->policyMap,

--- a/eZ/Publish/API/Repository/PermissionService.php
+++ b/eZ/Publish/API/Repository/PermissionService.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository;
+
+/**
+ * Marker for cached Permission Resolver.
+ */
+interface PermissionService extends PermissionResolver, PermissionCriterionResolver
+{
+}

--- a/eZ/Publish/API/Repository/PermissionService.php
+++ b/eZ/Publish/API/Repository/PermissionService.php
@@ -8,9 +8,6 @@ declare(strict_types=1);
 
 namespace eZ\Publish\API\Repository;
 
-/**
- * Marker for cached Permission Resolver.
- */
 interface PermissionService extends PermissionResolver, PermissionCriterionResolver
 {
 }

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -7,7 +7,7 @@
 namespace eZ\Publish\Core\Base\Container\ApiLoader;
 
 use eZ\Publish\API\Repository\LanguageResolver;
-use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\PermissionService;
 use eZ\Publish\Core\FieldType\FieldTypeRegistry;
 use eZ\Publish\Core\Repository\Permission\LimitationService;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
@@ -40,20 +40,14 @@ class RepositoryFactory implements ContainerAwareInterface
     /** @var \eZ\Publish\API\Repository\LanguageResolver */
     private $languageResolver;
 
-    /** @var \eZ\Publish\API\Repository\PermissionResolver */
-    private $permissionResolver;
-
     public function __construct(
         $repositoryClass,
         array $policyMap,
-        LanguageResolver $languageResolver,
-        PermissionResolver $permissionResolver
+        LanguageResolver $languageResolver
     ) {
         $this->repositoryClass = $repositoryClass;
         $this->policyMap = $policyMap;
         $this->languageResolver = $languageResolver;
-
-        $this->permissionResolver = $permissionResolver;
     }
 
     /**
@@ -77,6 +71,7 @@ class RepositoryFactory implements ContainerAwareInterface
         Mapper\ContentTypeDomainMapper $contentTypeDomainMapper,
         Mapper\RoleDomainMapper $roleDomainMapper,
         LimitationService $limitationService,
+        PermissionService $permissionService,
         array $languages
     ): Repository {
         return new $this->repositoryClass(
@@ -93,7 +88,7 @@ class RepositoryFactory implements ContainerAwareInterface
             $roleDomainMapper,
             $limitationService,
             $this->languageResolver,
-            $this->permissionResolver,
+            $permissionService,
             [
                 'role' => [
                     'policyMap' => $this->policyMap,

--- a/eZ/Publish/Core/Helper/Tests/ContentInfoLocationLoader/SudoMainLocationLoaderTest.php
+++ b/eZ/Publish/Core/Helper/Tests/ContentInfoLocationLoader/SudoMainLocationLoaderTest.php
@@ -9,6 +9,7 @@ namespace eZ\Publish\Core\Helper\Tests\ContentInfoLocationLoader;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Helper\ContentInfoLocationLoader\SudoMainLocationLoader;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\Core\Repository\Repository;
@@ -16,7 +17,6 @@ use eZ\Publish\Core\Repository\Permission\PermissionResolver;
 use eZ\Publish\Core\Repository\Mapper\RoleDomainMapper;
 use eZ\Publish\Core\Repository\Permission\LimitationService;
 use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
-use eZ\Publish\API\Repository\Values\User\UserReference;
 use PHPUnit\Framework\TestCase;
 
 class SudoMainLocationLoaderTest extends TestCase
@@ -140,6 +140,12 @@ class SudoMainLocationLoaderTest extends TestCase
      */
     private function getPermissionResolverMock()
     {
+        $configResolverMock = $this->createMock(ConfigResolverInterface::class);
+        $configResolverMock
+            ->method('getParameter')
+            ->with('anonymous_user_id')
+            ->willReturn(10);
+
         return $this
             ->getMockBuilder(PermissionResolver::class)
             ->setMethods(null)
@@ -155,9 +161,8 @@ class SudoMainLocationLoaderTest extends TestCase
                     $this
                         ->getMockBuilder(SPIUserHandler::class)
                         ->getMock(),
-                    $this
-                        ->getMockBuilder(UserReference::class)
-                        ->getMock(),
+                    $configResolverMock,
+                    [],
                 ]
             )
             ->getMock();

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/BaseTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/BaseTest.php
@@ -8,9 +8,9 @@ namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\Repository\Permission\PermissionResolver;
 use eZ\Publish\Core\Repository\Mapper\RoleDomainMapper;
-use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
 use eZ\Publish\Core\Repository\Permission\LimitationService;
 use eZ\Publish\Core\MVC\Symfony\View\Provider\Location\Configured;
@@ -94,6 +94,12 @@ abstract class BaseTest extends TestCase
 
     protected function getPermissionResolverMock()
     {
+        $configResolverMock = $this->createMock(ConfigResolverInterface::class);
+        $configResolverMock
+            ->method('getParameter')
+            ->with('anonymous_user_id')
+            ->willReturn(10);
+
         return $this
             ->getMockBuilder(PermissionResolver::class)
             ->setMethods(null)
@@ -102,7 +108,8 @@ abstract class BaseTest extends TestCase
                     $this->createMock(RoleDomainMapper::class),
                     $this->createMock(LimitationService::class),
                     $this->createMock(SPIUserHandler::class),
-                    $this->createMock(UserReference::class),
+                    $configResolverMock,
+                    [],
                 ]
             )
             ->getMock();

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -10,7 +10,6 @@ use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\URLAliasService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\URLAlias;
-use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use eZ\Publish\Core\Repository\Permission\PermissionResolver;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
@@ -447,6 +446,12 @@ class UrlAliasGeneratorTest extends TestCase
 
     protected function getPermissionResolverMock()
     {
+        $configResolverMock = $this->createMock(ConfigResolverInterface::class);
+        $configResolverMock
+            ->method('getParameter')
+            ->with('anonymous_user_id')
+            ->willReturn(10);
+
         return $this
             ->getMockBuilder(PermissionResolver::class)
             ->setMethods(null)
@@ -455,7 +460,8 @@ class UrlAliasGeneratorTest extends TestCase
                     $this->createMock(RoleDomainMapper::class),
                     $this->createMock(LimitationService::class),
                     $this->createMock(SPIUserHandler::class),
-                    $this->createMock(UserReference::class),
+                    $configResolverMock,
+                    [],
                 ]
             )
             ->getMock();

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
@@ -8,12 +8,8 @@ namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;
 
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Values\User\User as ApiUser;
-use eZ\Publish\API\Repository\Values\User\UserReference;
 use eZ\Publish\Core\MVC\Symfony\Security\Authentication\RememberMeRepositoryAuthenticationProvider;
 use eZ\Publish\Core\MVC\Symfony\Security\User;
-use eZ\Publish\Core\Repository\Permission\LimitationService;
-use eZ\Publish\Core\Repository\Mapper\RoleDomainMapper;
-use eZ\Publish\SPI\Persistence\User\Handler as UserHandler;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\RememberMeToken;
@@ -118,33 +114,5 @@ class RememberMeRepositoryAuthenticationProviderTest extends TestCase
             [$rememberMeToken->getProviderKey(), $rememberMeToken->getSecret(), $rememberMeToken->getUsername()],
             [$authenticatedToken->getProviderKey(), $authenticatedToken->getSecret(), $authenticatedToken->getUsername()]
         );
-    }
-
-    /**
-     * @return \eZ\Publish\Core\Repository\Permission\PermissionResolver|\PHPUnit\Framework\MockObject\MockObject
-     */
-    private function getPermissionResolverMock()
-    {
-        return $this
-            ->getMockBuilder(PermissionResolver::class)
-            ->setMethods(null)
-            ->setConstructorArgs(
-                [
-                    $this
-                        ->getMockBuilder(RoleDomainMapper::class)
-                        ->disableOriginalConstructor()
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder(LimitationService::class)
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder(UserHandler::class)
-                        ->getMock(),
-                    $this
-                        ->getMockBuilder(UserReference::class)
-                        ->getMock(),
-                ]
-            )
-            ->getMock();
     }
 }

--- a/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
+++ b/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
@@ -30,7 +30,7 @@ use Exception;
 class CachedPermissionService implements APIPermissionResolver, APIPermissionCriterionResolver
 {
     /** @var \eZ\Publish\API\Repository\PermissionResolver */
-    private $permissionResolver;
+    private $innerPermissionResolver;
 
     /** @var \eZ\Publish\API\Repository\PermissionCriterionResolver */
     private $permissionCriterionResolver;
@@ -64,39 +64,39 @@ class CachedPermissionService implements APIPermissionResolver, APIPermissionCri
     /**
      * CachedPermissionService constructor.
      *
-     * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
+     * @param \eZ\Publish\API\Repository\PermissionResolver $innerPermissionResolver
      * @param \eZ\Publish\API\Repository\PermissionCriterionResolver $permissionCriterionResolver
      * @param int $cacheTTL By default set to 5 seconds, should be low to avoid to many permission exceptions on long running requests / processes (even if tolerant search service should handle that)
      */
     public function __construct(
-        APIPermissionResolver $permissionResolver,
+        APIPermissionResolver $innerPermissionResolver,
         APIPermissionCriterionResolver $permissionCriterionResolver,
         int $cacheTTL = 5
     ) {
-        $this->permissionResolver = $permissionResolver;
+        $this->innerPermissionResolver = $innerPermissionResolver;
         $this->permissionCriterionResolver = $permissionCriterionResolver;
         $this->cacheTTL = $cacheTTL;
     }
 
     public function getCurrentUserReference(): UserReference
     {
-        return $this->permissionResolver->getCurrentUserReference();
+        return $this->innerPermissionResolver->getCurrentUserReference();
     }
 
     public function setCurrentUserReference(UserReference $userReference): void
     {
         $this->permissionCriterion = null;
-        $this->permissionResolver->setCurrentUserReference($userReference);
+        $this->innerPermissionResolver->setCurrentUserReference($userReference);
     }
 
     public function hasAccess(string $module, string $function, ?UserReference $userReference = null)
     {
-        return $this->permissionResolver->hasAccess($module, $function, $userReference);
+        return $this->innerPermissionResolver->hasAccess($module, $function, $userReference);
     }
 
     public function canUser(string $module, string $function, ValueObject $object, array $targets = []): bool
     {
-        return $this->permissionResolver->canUser($module, $function, $object, $targets);
+        return $this->innerPermissionResolver->canUser($module, $function, $object, $targets);
     }
 
     /**
@@ -109,7 +109,7 @@ class CachedPermissionService implements APIPermissionResolver, APIPermissionCri
         array $targets = [],
         array $limitations = []
     ): LookupLimitationResult {
-        return $this->permissionResolver->lookupLimitations($module, $function, $object, $targets, $limitations);
+        return $this->innerPermissionResolver->lookupLimitations($module, $function, $object, $targets, $limitations);
     }
 
     public function getPermissionsCriterion(string $module = 'content', string $function = 'read', ?array $targets = null)
@@ -140,7 +140,7 @@ class CachedPermissionService implements APIPermissionResolver, APIPermissionCri
     {
         ++$this->sudoNestingLevel;
         try {
-            $returnValue = $this->permissionResolver->sudo($callback, $outerRepository);
+            $returnValue = $this->innerPermissionResolver->sudo($callback, $outerRepository);
         } catch (Exception $e) {
             --$this->sudoNestingLevel;
             throw $e;

--- a/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
+++ b/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Repository\Permission;
 
 use eZ\Publish\API\Repository\PermissionResolver as APIPermissionResolver;
 use eZ\Publish\API\Repository\PermissionCriterionResolver as APIPermissionCriterionResolver;
+use eZ\Publish\API\Repository\PermissionService;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\User\LookupLimitationResult;
 use eZ\Publish\API\Repository\Values\User\UserReference;
@@ -27,7 +28,7 @@ use Exception;
  * The logic here uses a cache TTL of a few seconds, as this is in-memory cache we are not
  * able to know if any other concurrent user might be changing permissions.
  */
-class CachedPermissionService implements APIPermissionResolver, APIPermissionCriterionResolver
+class CachedPermissionService implements PermissionService
 {
     /** @var \eZ\Publish\API\Repository\PermissionResolver */
     private $innerPermissionResolver;

--- a/eZ/Publish/Core/Repository/Permission/PermissionCriterionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionCriterionResolver.php
@@ -24,7 +24,7 @@ use RuntimeException;
 class PermissionCriterionResolver implements APIPermissionCriterionResolver
 {
     /** @var \eZ\Publish\API\Repository\PermissionResolver */
-    private $permissionResolver;
+    private $innerPermissionResolver;
 
     /** @var \eZ\Publish\Core\Repository\Permission\LimitationService */
     private $limitationService;
@@ -32,14 +32,14 @@ class PermissionCriterionResolver implements APIPermissionCriterionResolver
     /**
      * Constructor.
      *
-     * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
+     * @param \eZ\Publish\API\Repository\PermissionResolver $innerPermissionResolver
      * @param \eZ\Publish\Core\Repository\Permission\LimitationService $limitationService
      */
     public function __construct(
-        PermissionResolverInterface $permissionResolver,
+        PermissionResolverInterface $innerPermissionResolver,
         LimitationService $limitationService
     ) {
-        $this->permissionResolver = $permissionResolver;
+        $this->innerPermissionResolver = $innerPermissionResolver;
         $this->limitationService = $limitationService;
     }
 
@@ -57,7 +57,7 @@ class PermissionCriterionResolver implements APIPermissionCriterionResolver
      */
     public function getPermissionsCriterion(string $module = 'content', string $function = 'read', ?array $targets = null)
     {
-        $permissionSets = $this->permissionResolver->hasAccess($module, $function);
+        $permissionSets = $this->innerPermissionResolver->hasAccess($module, $function);
         if (is_bool($permissionSets)) {
             return $permissionSets;
         }
@@ -72,7 +72,7 @@ class PermissionCriterionResolver implements APIPermissionCriterionResolver
          * If RoleAssignment has limitation then policy OR conditions are wrapped in a AND condition with the
          * role limitation, otherwise it will be merged into RoleAssignment's OR condition.
          */
-        $currentUserRef = $this->permissionResolver->getCurrentUserReference();
+        $currentUserRef = $this->innerPermissionResolver->getCurrentUserReference();
         $roleAssignmentOrCriteria = [];
         foreach ($permissionSets as $permissionSet) {
             // $permissionSet is a RoleAssignment, but in the form of role limitation & role policies hash

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -17,6 +17,8 @@ use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\API\Repository\Values\ValueObject;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 use eZ\Publish\Core\Repository\Mapper\RoleDomainMapper;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\Repository\Values\User\UserReference;
 use eZ\Publish\SPI\Limitation\Target;
 use eZ\Publish\SPI\Limitation\TargetAwareType;
 use eZ\Publish\SPI\Limitation\Type as LimitationType;
@@ -58,29 +60,34 @@ class PermissionResolver implements PermissionResolverInterface
      */
     private $policyMap;
 
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
     /**
-     * @param \eZ\Publish\Core\Repository\Mapper\RoleDomainMapper $roleDomainMapper
-     * @param \eZ\Publish\Core\Repository\Permission\LimitationService $limitationService
-     * @param \eZ\Publish\SPI\Persistence\User\Handler $userHandler
-     * @param \eZ\Publish\API\Repository\Values\User\UserReference $userReference
      * @param array $policyMap Map of system configured policies, for validation usage.
      */
     public function __construct(
         RoleDomainMapper $roleDomainMapper,
         LimitationService $limitationService,
         UserHandler $userHandler,
-        APIUserReference $userReference,
-        array $policyMap = []
+        ConfigResolverInterface $configResolver,
+        array $policyMap
     ) {
         $this->roleDomainMapper = $roleDomainMapper;
         $this->limitationService = $limitationService;
         $this->userHandler = $userHandler;
-        $this->currentUserRef = $userReference;
+        $this->configResolver = $configResolver;
         $this->policyMap = $policyMap;
     }
 
     public function getCurrentUserReference(): APIUserReference
     {
+        if (empty($this->currentUserRef)) {
+            $this->currentUserRef = new UserReference(
+                $this->configResolver->getParameter('anonymous_user_id')
+            );
+        }
+
         return $this->currentUserRef;
     }
 

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -10,7 +10,7 @@ namespace eZ\Publish\Core\Repository;
 
 use eZ\Publish\API\Repository\LanguageResolver;
 use eZ\Publish\API\Repository\PermissionCriterionResolver as PermissionCriterionResolverInterface;
-use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\PermissionService;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\NotificationService as NotificationServiceInterface;
 use eZ\Publish\API\Repository\BookmarkService as BookmarkServiceInterface;
@@ -37,9 +37,6 @@ use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperInterface;
 use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use eZ\Publish\Core\Repository\Helper\RelationProcessor;
-use eZ\Publish\Core\Repository\Permission\CachedPermissionService;
-use eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver;
-use eZ\Publish\Core\Repository\Values\User\UserReference;
 use eZ\Publish\Core\Search\Common\BackgroundIndexer;
 use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy;
@@ -223,13 +220,6 @@ class Repository implements RepositoryInterface
     /** @var \eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper */
     protected $contentTypeDomainMapper;
 
-    /**
-     * Instance of permissions-resolver and -criterion resolver.
-     *
-     * @var \eZ\Publish\API\Repository\PermissionCriterionResolver|\eZ\Publish\API\Repository\PermissionResolver
-     */
-    protected $permissionsHandler;
-
     /** @var \eZ\Publish\Core\Search\Common\BackgroundIndexer|null */
     protected $backgroundIndexer;
 
@@ -251,8 +241,8 @@ class Repository implements RepositoryInterface
     /** @var \eZ\Publish\API\Repository\LanguageResolver */
     private $languageResolver;
 
-    /** @var \eZ\Publish\API\Repository\PermissionResolver */
-    private $permissionResolver;
+    /** @var \eZ\Publish\API\Repository\PermissionService */
+    private $permissionService;
 
     public function __construct(
         PersistenceHandler $persistenceHandler,
@@ -268,7 +258,7 @@ class Repository implements RepositoryInterface
         Mapper\RoleDomainMapper $roleDomainMapper,
         LimitationService $limitationService,
         LanguageResolver $languageResolver,
-        PermissionResolver $permissionResolver,
+        PermissionService $permissionService,
         array $serviceSettings = [],
         ?LoggerInterface $logger = null
     ) {
@@ -285,6 +275,7 @@ class Repository implements RepositoryInterface
         $this->roleDomainMapper = $roleDomainMapper;
         $this->limitationService = $limitationService;
         $this->languageResolver = $languageResolver;
+        $this->permissionService = $permissionService;
 
         $this->serviceSettings = $serviceSettings + [
                 'content' => [],
@@ -312,7 +303,6 @@ class Repository implements RepositoryInterface
         }
 
         $this->logger = null !== $logger ? $logger : new NullLogger();
-        $this->permissionResolver = $permissionResolver;
     }
 
     /**
@@ -688,14 +678,9 @@ class Repository implements RepositoryInterface
         return $this->fieldTypeService;
     }
 
-    /**
-     * Get PermissionResolver.
-     *
-     * @return \eZ\Publish\API\Repository\PermissionResolver
-     */
     public function getPermissionResolver(): PermissionResolverInterface
     {
-        return $this->getCachedPermissionsResolver();
+        return $this->permissionService;
     }
 
     /**
@@ -766,22 +751,9 @@ class Repository implements RepositoryInterface
         return $this->proxyDomainMapper;
     }
 
-    /**
-     * Get PermissionCriterionResolver.
-     *
-     * @todo Move out from this & other repo instances when services becomes proper services in DIC terms using factory.
-     */
     protected function getPermissionCriterionResolver(): PermissionCriterionResolverInterface
     {
-        return $this->getCachedPermissionsResolver();
-    }
-
-    /**
-     * @return \eZ\Publish\API\Repository\PermissionCriterionResolver|\eZ\Publish\API\Repository\PermissionResolver
-     */
-    protected function getCachedPermissionsResolver()
-    {
-        return $this->permissionResolver;
+        return $this->permissionService;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Repository;
 
 use eZ\Publish\API\Repository\LanguageResolver;
 use eZ\Publish\API\Repository\PermissionCriterionResolver as PermissionCriterionResolverInterface;
+use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\NotificationService as NotificationServiceInterface;
 use eZ\Publish\API\Repository\BookmarkService as BookmarkServiceInterface;
@@ -250,6 +251,9 @@ class Repository implements RepositoryInterface
     /** @var \eZ\Publish\API\Repository\LanguageResolver */
     private $languageResolver;
 
+    /** @var \eZ\Publish\API\Repository\PermissionResolver */
+    private $permissionResolver;
+
     public function __construct(
         PersistenceHandler $persistenceHandler,
         SearchHandler $searchHandler,
@@ -264,6 +268,7 @@ class Repository implements RepositoryInterface
         Mapper\RoleDomainMapper $roleDomainMapper,
         LimitationService $limitationService,
         LanguageResolver $languageResolver,
+        PermissionResolver $permissionResolver,
         array $serviceSettings = [],
         ?LoggerInterface $logger = null
     ) {
@@ -307,6 +312,7 @@ class Repository implements RepositoryInterface
         }
 
         $this->logger = null !== $logger ? $logger : new NullLogger();
+        $this->permissionResolver = $permissionResolver;
     }
 
     /**
@@ -775,23 +781,7 @@ class Repository implements RepositoryInterface
      */
     protected function getCachedPermissionsResolver()
     {
-        if ($this->permissionsHandler === null) {
-            $this->permissionsHandler = new CachedPermissionService(
-                $permissionResolver = new Permission\PermissionResolver(
-                    $this->getRoleDomainMapper(),
-                    $this->limitationService,
-                    $this->persistenceHandler->userHandler(),
-                    new UserReference($this->serviceSettings['user']['anonymousUserID']),
-                    $this->serviceSettings['role']['policyMap']
-                ),
-                new PermissionCriterionResolver(
-                    $permissionResolver,
-                    $this->limitationService
-                )
-            );
-        }
-
-        return $this->permissionsHandler;
+        return $this->permissionResolver;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -97,6 +97,7 @@ abstract class Base extends TestCase
                 $this->getRoleDomainMapperMock(),
                 $this->getLimitationServiceMock(),
                 $this->getLanguageResolverMock(),
+                $this->getPermissionResolverMock(),
                 $serviceSettings,
             );
 

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -8,6 +8,7 @@ namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
 use eZ\Publish\API\Repository\LanguageResolver;
 use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\PermissionService;
 use eZ\Publish\Core\Repository\Mapper\ContentDomainMapper;
 use eZ\Publish\Core\Repository\Mapper\RoleDomainMapper;
 use eZ\Publish\Core\Repository\Permission\LimitationService;
@@ -42,6 +43,9 @@ abstract class Base extends TestCase
 
     /** @var \eZ\Publish\API\Repository\PermissionResolver|\PHPUnit\Framework\MockObject\MockObject */
     private $permissionResolverMock;
+
+    /** @var \eZ\Publish\API\Repository\PermissionService|\PHPUnit\Framework\MockObject\MockObject */
+    private $permissionServiceMock;
 
     /** @var \eZ\Publish\SPI\Persistence\Handler|\PHPUnit\Framework\MockObject\MockObject */
     private $persistenceMock;
@@ -97,7 +101,7 @@ abstract class Base extends TestCase
                 $this->getRoleDomainMapperMock(),
                 $this->getLimitationServiceMock(),
                 $this->getLanguageResolverMock(),
-                $this->getPermissionResolverMock(),
+                $this->getPermissionServiceMock(),
                 $serviceSettings,
             );
 
@@ -173,6 +177,18 @@ abstract class Base extends TestCase
         }
 
         return $this->permissionResolverMock;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\PermissionService|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function getPermissionServiceMock(): PermissionService
+    {
+        if (!isset($this->permissionServiceMock)) {
+            $this->permissionServiceMock = $this->createMock(PermissionService::class);
+        }
+
+        return $this->permissionServiceMock;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionTest.php
@@ -9,6 +9,7 @@ namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\User\Limitation;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\Repository\Permission\PermissionResolver;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
 use eZ\Publish\Core\Repository\Repository as CoreRepository;
@@ -104,13 +105,7 @@ class PermissionTest extends BaseServiceMockTest
     {
         /** @var $userHandlerMock \PHPUnit\Framework\MockObject\MockObject */
         $userHandlerMock = $this->getPersistenceMock()->userHandler();
-        $userReferenceMock = $this->getUserReferenceMock();
         $mockedService = $this->getPermissionResolverMock(null);
-
-        $userReferenceMock
-            ->expects($this->once())
-            ->method('getUserId')
-            ->will($this->returnValue(10));
 
         $userHandlerMock
             ->expects($this->once())
@@ -181,13 +176,7 @@ class PermissionTest extends BaseServiceMockTest
     {
         /** @var $userHandlerMock \PHPUnit\Framework\MockObject\MockObject */
         $userHandlerMock = $this->getPersistenceMock()->userHandler();
-        $userReferenceMock = $this->getUserReferenceMock();
         $service = $this->getPermissionResolverMock(null);
-
-        $userReferenceMock
-            ->expects($this->once())
-            ->method('getUserId')
-            ->will($this->returnValue(10));
 
         $userHandlerMock
             ->expects($this->once())
@@ -1007,12 +996,8 @@ class PermissionTest extends BaseServiceMockTest
     public function testGetCurrentUserReferenceReturnsAnonymousUser()
     {
         $permissionResolverMock = $this->getPermissionResolverMock(null);
-        $userReferenceMock = $this->getUserReferenceMock();
 
-        self::assertSame(
-            $userReferenceMock,
-            $permissionResolverMock->getCurrentUserReference()
-        );
+        self::assertEquals(new UserReference(10), $permissionResolverMock->getCurrentUserReference());
     }
 
     protected $permissionResolverMock;
@@ -1023,6 +1008,12 @@ class PermissionTest extends BaseServiceMockTest
     protected function getPermissionResolverMock($methods = [])
     {
         if ($this->permissionResolverMock === null) {
+            $configResolverMock = $this->createMock(ConfigResolverInterface::class);
+            $configResolverMock
+                ->method('getParameter')
+                ->with('anonymous_user_id')
+                ->willReturn(10);
+
             $this->permissionResolverMock = $this
                 ->getMockBuilder(PermissionResolver::class)
                 ->setMethods($methods)
@@ -1031,7 +1022,7 @@ class PermissionTest extends BaseServiceMockTest
                         $this->getRoleDomainMapperMock(),
                         $this->getLimitationServiceMock(),
                         $this->getPersistenceMock()->userHandler(),
-                        $this->getUserReferenceMock(),
+                        $configResolverMock,
                         [
                             'dummy-module' => [
                                 'dummy-function' => [

--- a/eZ/Publish/Core/settings/repository/autowire.yml
+++ b/eZ/Publish/Core/settings/repository/autowire.yml
@@ -18,3 +18,7 @@ services:
     eZ\Publish\API\Repository\URLWildcardService: '@ezpublish.api.service.url_wildcard'
     eZ\Publish\API\Repository\URLAliasService: '@ezpublish.api.service.url_alias'
     eZ\Publish\API\Repository\TrashService: '@ezpublish.api.service.trash'
+
+    eZ\Publish\API\Repository\PermissionService: '@eZ\Publish\Core\Repository\Permission\CachedPermissionService'
+    eZ\Publish\API\Repository\PermissionResolver: '@eZ\Publish\API\Repository\PermissionService'
+    eZ\Publish\API\Repository\PermissionCriterionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver'

--- a/eZ/Publish/Core/settings/repository/autowire.yml
+++ b/eZ/Publish/Core/settings/repository/autowire.yml
@@ -18,8 +18,3 @@ services:
     eZ\Publish\API\Repository\URLWildcardService: '@ezpublish.api.service.url_wildcard'
     eZ\Publish\API\Repository\URLAliasService: '@ezpublish.api.service.url_alias'
     eZ\Publish\API\Repository\TrashService: '@ezpublish.api.service.trash'
-
-    eZ\Publish\API\Repository\PermissionResolver:
-        class: eZ\Publish\Core\Repository\Permission\PermissionResolver
-        lazy: true
-        factory: ['@eZ\Publish\API\Repository\Repository', 'getPermissionResolver']

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -201,4 +201,4 @@ services:
     eZ\Publish\Core\Repository\Permission\CachedPermissionService:
         arguments:
             $innerPermissionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionResolver'
-            $permissionCriterionResolver: '@eZ\Publish\API\Repository\PermissionCriterionResolver'
+            $permissionCriterionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver'

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -10,6 +10,7 @@ services:
             - "%ezpublish.api.inner_repository.class%"
             - "%ezpublish.api.role.policy_map%"
             - '@eZ\Publish\API\Repository\LanguageResolver'
+            - '@eZ\Publish\API\Repository\PermissionResolver'
         calls:
             - [setContainer, ["@service_container"]]
 
@@ -29,7 +30,7 @@ services:
             - '@eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper'
             - '@eZ\Publish\Core\Repository\Mapper\RoleDomainMapper'
             - '@eZ\Publish\Core\Repository\Permission\LimitationService'
-        lazy: true
+            - '%languages%'
 
     ezpublish.api.service.inner_content:
         class: eZ\Publish\Core\Repository\ContentService
@@ -183,3 +184,28 @@ services:
     eZ\Publish\Core\Repository\Permission\LimitationService:
         arguments:
             $limitationTypes: !tagged_iterator { tag: ezpublish.limitationType, index_by: alias }
+
+    eZ\Publish\Core\Repository\Helper\RoleDomainMapper:
+        arguments:
+            $limitationService: '@eZ\Publish\Core\Repository\Permission\LimitationService'
+
+    eZ\Publish\Core\Repository\Permission\PermissionResolver:
+        arguments:
+            $roleDomainMapper: '@eZ\Publish\Core\Repository\Helper\RoleDomainMapper'
+            $limitationService: '@eZ\Publish\Core\Repository\Permission\LimitationService'
+            $userHandler: '@ezpublish.spi.persistence.legacy.user.handler'
+            $configResolver: '@ezpublish.config.resolver'
+            $policyMap: '%ezpublish.api.role.policy_map%'
+
+    eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver:
+        arguments:
+            $innerPermissionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionResolver'
+            $limitationService: '@eZ\Publish\Core\Repository\Permission\LimitationService'
+
+    eZ\Publish\Core\Repository\Permission\CachedPermissionService:
+        arguments:
+            $innerPermissionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionResolver'
+            $permissionCriterionResolver: '@eZ\Publish\API\Repository\PermissionCriterionResolver'
+
+    eZ\Publish\API\Repository\PermissionCriterionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver'
+    eZ\Publish\API\Repository\PermissionResolver: '@eZ\Publish\Core\Repository\Permission\CachedPermissionService'

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -10,7 +10,6 @@ services:
             - "%ezpublish.api.inner_repository.class%"
             - "%ezpublish.api.role.policy_map%"
             - '@eZ\Publish\API\Repository\LanguageResolver'
-            - '@eZ\Publish\API\Repository\PermissionResolver'
         calls:
             - [setContainer, ["@service_container"]]
 
@@ -30,6 +29,7 @@ services:
             - '@eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper'
             - '@eZ\Publish\Core\Repository\Mapper\RoleDomainMapper'
             - '@eZ\Publish\Core\Repository\Permission\LimitationService'
+            - '@eZ\Publish\API\Repository\PermissionService'
             - '%languages%'
 
     ezpublish.api.service.inner_content:
@@ -185,13 +185,9 @@ services:
         arguments:
             $limitationTypes: !tagged_iterator { tag: ezpublish.limitationType, index_by: alias }
 
-    eZ\Publish\Core\Repository\Helper\RoleDomainMapper:
-        arguments:
-            $limitationService: '@eZ\Publish\Core\Repository\Permission\LimitationService'
-
     eZ\Publish\Core\Repository\Permission\PermissionResolver:
         arguments:
-            $roleDomainMapper: '@eZ\Publish\Core\Repository\Helper\RoleDomainMapper'
+            $roleDomainMapper: '@eZ\Publish\Core\Repository\Mapper\RoleDomainMapper'
             $limitationService: '@eZ\Publish\Core\Repository\Permission\LimitationService'
             $userHandler: '@ezpublish.spi.persistence.legacy.user.handler'
             $configResolver: '@ezpublish.config.resolver'
@@ -206,6 +202,3 @@ services:
         arguments:
             $innerPermissionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionResolver'
             $permissionCriterionResolver: '@eZ\Publish\API\Repository\PermissionCriterionResolver'
-
-    eZ\Publish\API\Repository\PermissionCriterionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver'
-    eZ\Publish\API\Repository\PermissionResolver: '@eZ\Publish\Core\Repository\Permission\CachedPermissionService'

--- a/eZ/Publish/Core/settings/settings.yml
+++ b/eZ/Publish/Core/settings/settings.yml
@@ -9,6 +9,7 @@ parameters:
     storage_dir: var/ezdemo_site/storage
     io_root_dir: "%storage_dir%"
     ezpublish.siteaccess.list: [test]
+    ezsettings.default.anonymous_user_id: 10
 
 services:
     ezpublish.api.persistence_handler:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-30465](https://jira.ez.no/browse/EZP-30465)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no


#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
