### PR TITLE
EZP-31012: Fixed assertion for passwordUpdateAt value in UserServiceTest::testUpdateUserUpdatesExpectedProperties

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1792,9 +1792,9 @@ class UserServiceTest extends BaseTest
 
         // Make sure passwordUpdatedAt field has been updated together with password
         $this->assertNotNull($user->passwordUpdatedAt);
-        $this->assertEquals(
-            (new DateTime())->format('Y-m-d H:i'),
-            $user->passwordUpdatedAt->format('Y-m-d H:i')
+        $this->assertGreaterThanOrEqual(
+            $user->getVersionInfo()->modificationDate->getTimestamp(),
+            $user->passwordUpdatedAt->getTimestamp()
         );
     }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31012](https://jira.ez.no/browse/EZP-31012)
| **Type**                                   | bug
| **Target eZ Platform version** | `3.0.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no


Fixed assertion for `passwordUpdateAt` value in `eZ\Publish\API\Repository\Tests\UserServiceTest::testUpdateUserUpdatesExpectedProperties`. The previous approach might lead to false-negative build results (because it was time sensitive). 

Follow up for https://github.com/ezsystems/ezplatform-kernel/pull/30.

#### Checklist:
- [X] PR description is updated.
- [X] Tests are implemented.
- [X] Added code follows Coding Standards (use `$ composer fix-cs`).
- [X] PR is ready for a review.
