### PR TITLE
EZP-30465: Introduced PermissionService

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -7,7 +7,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
 use eZ\Publish\API\Repository\LanguageResolver;
-use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\PermissionService;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\FieldType\FieldTypeRegistry;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
@@ -48,15 +48,11 @@ class RepositoryFactory implements ContainerAwareInterface
     /** @var \eZ\Publish\API\Repository\LanguageResolver */
     private $languageResolver;
 
-    /** @var \eZ\Publish\API\Repository\PermissionResolver */
-    private $permissionResolver;
-
     public function __construct(
         ConfigResolverInterface $configResolver,
         $repositoryClass,
         array $policyMap,
         LanguageResolver $languageResolver,
-        PermissionResolver $permissionResolver,
         LoggerInterface $logger = null
     ) {
         $this->configResolver = $configResolver;
@@ -64,7 +60,6 @@ class RepositoryFactory implements ContainerAwareInterface
         $this->policyMap = $policyMap;
         $this->languageResolver = $languageResolver;
         $this->logger = null !== $logger ? $logger : new NullLogger();
-        $this->permissionResolver = $permissionResolver;
     }
 
     /**
@@ -84,7 +79,8 @@ class RepositoryFactory implements ContainerAwareInterface
         ProxyDomainMapperFactoryInterface $proxyDomainMapperFactory,
         Mapper\ContentDomainMapper $contentDomainMapper,
         Mapper\ContentTypeDomainMapper $contentTypeDomainMapper,
-        LimitationService $limitationService
+        LimitationService $limitationService,
+        PermissionService $permissionService
     ): Repository {
         $config = $this->container->get('ezpublish.api.repository_configuration_provider')->getRepositoryConfig();
 
@@ -101,7 +97,7 @@ class RepositoryFactory implements ContainerAwareInterface
             $contentTypeDomainMapper,
             $limitationService,
             $this->languageResolver,
-            $this->permissionResolver,
+            $permissionService,
             [
                 'role' => [
                     'policyMap' => $this->policyMap,

--- a/eZ/Publish/API/Repository/PermissionService.php
+++ b/eZ/Publish/API/Repository/PermissionService.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository;
+
+/**
+ * Marker for cached Permission Resolver.
+ */
+interface PermissionService extends PermissionResolver, PermissionCriterionResolver
+{
+}

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -7,7 +7,7 @@
 namespace eZ\Publish\Core\Base\Container\ApiLoader;
 
 use eZ\Publish\API\Repository\LanguageResolver;
-use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\PermissionService;
 use eZ\Publish\Core\FieldType\FieldTypeRegistry;
 use eZ\Publish\Core\Repository\Permission\LimitationService;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
@@ -40,20 +40,14 @@ class RepositoryFactory implements ContainerAwareInterface
     /** @var \eZ\Publish\API\Repository\LanguageResolver */
     private $languageResolver;
 
-    /** @var \eZ\Publish\API\Repository\PermissionResolver */
-    private $permissionResolver;
-
     public function __construct(
         $repositoryClass,
         array $policyMap,
-        LanguageResolver $languageResolver,
-        PermissionResolver $permissionResolver
+        LanguageResolver $languageResolver
     ) {
         $this->repositoryClass = $repositoryClass;
         $this->policyMap = $policyMap;
         $this->languageResolver = $languageResolver;
-
-        $this->permissionResolver = $permissionResolver;
     }
 
     /**
@@ -76,6 +70,7 @@ class RepositoryFactory implements ContainerAwareInterface
         Mapper\ContentDomainMapper $contentDomainMapper,
         Mapper\ContentTypeDomainMapper $contentTypeDomainMapper,
         LimitationService $limitationService,
+        PermissionService $permissionService,
         array $languages
     ): Repository {
         return new $this->repositoryClass(
@@ -91,7 +86,7 @@ class RepositoryFactory implements ContainerAwareInterface
             $contentTypeDomainMapper,
             $limitationService,
             $this->languageResolver,
-            $this->permissionResolver,
+            $permissionService,
             [
                 'role' => [
                     'policyMap' => $this->policyMap,

--- a/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
+++ b/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Repository\Permission;
 
 use eZ\Publish\API\Repository\PermissionResolver as APIPermissionResolver;
 use eZ\Publish\API\Repository\PermissionCriterionResolver as APIPermissionCriterionResolver;
+use eZ\Publish\API\Repository\PermissionService;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\User\LookupLimitationResult;
 use eZ\Publish\API\Repository\Values\User\UserReference;
@@ -27,7 +28,7 @@ use Exception;
  * The logic here uses a cache TTL of a few seconds, as this is in-memory cache we are not
  * able to know if any other concurrent user might be changing permissions.
  */
-class CachedPermissionService implements APIPermissionResolver, APIPermissionCriterionResolver
+class CachedPermissionService implements PermissionService
 {
     /** @var \eZ\Publish\API\Repository\PermissionResolver */
     private $innerPermissionResolver;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -8,6 +8,7 @@ namespace eZ\Publish\Core\Repository\Tests\Service\Mock;
 
 use eZ\Publish\API\Repository\LanguageResolver;
 use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\PermissionService;
 use eZ\Publish\Core\Repository\Mapper\ContentDomainMapper;
 use eZ\Publish\Core\Repository\Permission\LimitationService;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
@@ -41,6 +42,9 @@ abstract class Base extends TestCase
 
     /** @var \eZ\Publish\API\Repository\PermissionResolver|\PHPUnit\Framework\MockObject\MockObject */
     private $permissionResolverMock;
+
+    /** @var \eZ\Publish\API\Repository\PermissionService|\PHPUnit\Framework\MockObject\MockObject */
+    private $permissionServiceMock;
 
     /** @var \eZ\Publish\SPI\Persistence\Handler|\PHPUnit\Framework\MockObject\MockObject */
     private $persistenceMock;
@@ -92,7 +96,7 @@ abstract class Base extends TestCase
                 $this->getContentTypeDomainMapperMock(),
                 $this->getLimitationServiceMock(),
                 $this->getLanguageResolverMock(),
-                $this->getPermissionResolverMock(),
+                $this->getPermissionServiceMock(),
                 $serviceSettings,
             );
 
@@ -168,6 +172,18 @@ abstract class Base extends TestCase
         }
 
         return $this->permissionResolverMock;
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\PermissionService|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function getPermissionServiceMock(): PermissionService
+    {
+        if (!isset($this->permissionServiceMock)) {
+            $this->permissionServiceMock = $this->createMock(PermissionService::class);
+        }
+
+        return $this->permissionServiceMock;
     }
 
     /**

--- a/eZ/Publish/Core/settings/repository/autowire.yml
+++ b/eZ/Publish/Core/settings/repository/autowire.yml
@@ -18,3 +18,7 @@ services:
     eZ\Publish\API\Repository\URLWildcardService: '@ezpublish.api.service.url_wildcard'
     eZ\Publish\API\Repository\URLAliasService: '@ezpublish.api.service.url_alias'
     eZ\Publish\API\Repository\TrashService: '@ezpublish.api.service.trash'
+
+    eZ\Publish\API\Repository\PermissionService: '@eZ\Publish\Core\Repository\Permission\CachedPermissionService'
+    eZ\Publish\API\Repository\PermissionResolver: '@eZ\Publish\API\Repository\PermissionService'
+    eZ\Publish\API\Repository\PermissionCriterionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver'

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -10,7 +10,6 @@ services:
             - "%ezpublish.api.inner_repository.class%"
             - "%ezpublish.api.role.policy_map%"
             - '@eZ\Publish\API\Repository\LanguageResolver'
-            - '@eZ\Publish\API\Repository\PermissionResolver'
         calls:
             - [setContainer, ["@service_container"]]
 
@@ -29,6 +28,7 @@ services:
             - '@eZ\Publish\Core\Repository\Mapper\ContentDomainMapper'
             - '@eZ\Publish\Core\Repository\Mapper\ContentTypeDomainMapper'
             - '@eZ\Publish\Core\Repository\Permission\LimitationService'
+            - '@eZ\Publish\API\Repository\PermissionService'
             - '%languages%'
 
     ezpublish.api.service.inner_content:
@@ -180,13 +180,9 @@ services:
         arguments:
             $limitationTypes: !tagged_iterator { tag: ezpublish.limitationType, index_by: alias }
 
-    eZ\Publish\Core\Repository\Helper\RoleDomainMapper:
-        arguments:
-            $limitationService: '@eZ\Publish\Core\Repository\Permission\LimitationService'
-
     eZ\Publish\Core\Repository\Permission\PermissionResolver:
         arguments:
-            $roleDomainMapper: '@eZ\Publish\Core\Repository\Helper\RoleDomainMapper'
+            $roleDomainMapper: '@eZ\Publish\Core\Repository\Mapper\RoleDomainMapper'
             $limitationService: '@eZ\Publish\Core\Repository\Permission\LimitationService'
             $userHandler: '@ezpublish.spi.persistence.legacy.user.handler'
             $configResolver: '@ezpublish.config.resolver'
@@ -201,6 +197,3 @@ services:
         arguments:
             $innerPermissionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionResolver'
             $permissionCriterionResolver: '@eZ\Publish\API\Repository\PermissionCriterionResolver'
-
-    eZ\Publish\API\Repository\PermissionCriterionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver'
-    eZ\Publish\API\Repository\PermissionResolver: '@eZ\Publish\Core\Repository\Permission\CachedPermissionService'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **~JIRA~ issue**                          | Part of  #44 
| **Type**                                   | improvement

Introducing API `PermissionService` to avoid types mismatch in `Repository`. It extends `PermissionResolver` and `PermissionCriterionResolver` interfaces as this is what is actually returned by injecting `CachedPermissionService`.