### PR TITLE
EZP-31588: As a Developer I want to configure search engine features with tags which follows same convention

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineFactory.php
@@ -73,7 +73,7 @@ class SearchEngineFactory
         ) {
             throw new InvalidSearchEngine(
                 "Invalid search engine '{$repositoryConfig['search']['engine']}'. " .
-                "Could not find any service tagged with 'ezpublish.searchEngine' " .
+                "Could not find any service tagged with 'ezplatform.search_engine' " .
                 "with alias '{$repositoryConfig['search']['engine']}'."
             );
         }

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineIndexerFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineIndexerFactory.php
@@ -73,7 +73,7 @@ class SearchEngineIndexerFactory
         ) {
             throw new InvalidSearchEngineIndexer(
                 "Invalid search engine '{$repositoryConfig['search']['engine']}'. " .
-                "Could not find any service tagged with 'ezpublish.searchEngineIndexer' " .
+                "Could not find any service tagged with 'ezplatform.search_engine.indexer' " .
                 "with alias '{$repositoryConfig['search']['engine']}'."
             );
         }

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/FieldTypeParameterProviderRegistryPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/FieldTypeParameterProviderRegistryPass.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
 
+use eZ\Publish\Core\Base\Container\Compiler\TaggedServiceIdsIterator\BackwardCompatibleIterator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
@@ -31,20 +32,13 @@ class FieldTypeParameterProviderRegistryPass implements CompilerPassInterface
 
         $parameterProviderRegistryDef = $container->getDefinition('ezpublish.fieldType.parameterProviderRegistry');
 
-        $deprecatedFieldTypeParameterProviderTags = $container->findTaggedServiceIds(self::DEPRECATED_FIELD_TYPE_PARAMETER_PROVIDER_SERVICE_TAG);
-        foreach ($deprecatedFieldTypeParameterProviderTags as $deprecatedFieldTypeParameterProviderTag) {
-            @trigger_error(
-                sprintf(
-                    'Service tag `%s` is deprecated and will be removed in eZ Platform 4.0. Use `%s` instead.',
-                    self::DEPRECATED_FIELD_TYPE_PARAMETER_PROVIDER_SERVICE_TAG,
-                    self::FIELD_TYPE_PARAMETER_PROVIDER_SERVICE_TAG
-                ),
-                E_USER_DEPRECATED
-            );
-        }
-        $fieldTypeParameterProviderTags = $container->findTaggedServiceIds(self::FIELD_TYPE_PARAMETER_PROVIDER_SERVICE_TAG);
-        $parameterProviderFieldTypesTags = array_merge($deprecatedFieldTypeParameterProviderTags, $fieldTypeParameterProviderTags);
-        foreach ($parameterProviderFieldTypesTags as $id => $attributes) {
+        $iterator = new BackwardCompatibleIterator(
+            $container,
+            self::FIELD_TYPE_PARAMETER_PROVIDER_SERVICE_TAG,
+            self::DEPRECATED_FIELD_TYPE_PARAMETER_PROVIDER_SERVICE_TAG
+        );
+
+        foreach ($iterator as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['alias'])) {
                     throw new \LogicException(

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterSearchEngineIndexerPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterSearchEngineIndexerPass.php
@@ -6,16 +6,20 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
 
+use eZ\Publish\Core\Base\Container\Compiler\TaggedServiceIdsIterator\BackwardCompatibleIterator;
+use LogicException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
-use LogicException;
 
 /**
  * This compiler pass registers eZ Publish search engines indexers.
  */
 class RegisterSearchEngineIndexerPass implements CompilerPassInterface
 {
+    public const SEARCH_ENGINE_INDEXER_SERVICE_TAG = 'ezplatform.search_engine.indexer';
+    public const DEPRECATED_SEARCH_ENGINE_INDEXER_SERVICE_TAG = 'ezpublish.searchEngineIndexer';
+
     /**
      * Container service id of the SearchEngineIndexerFactory.
      *
@@ -39,12 +43,23 @@ class RegisterSearchEngineIndexerPass implements CompilerPassInterface
         }
 
         $searchEngineIndexerFactoryDefinition = $container->getDefinition($this->factoryId);
-        foreach ($container->findTaggedServiceIds('ezpublish.searchEngineIndexer') as $id => $attributes) {
+
+        $iterator = new BackwardCompatibleIterator(
+            $container,
+            self::SEARCH_ENGINE_INDEXER_SERVICE_TAG,
+            self::DEPRECATED_SEARCH_ENGINE_INDEXER_SERVICE_TAG
+        );
+
+        foreach ($iterator as $serviceId => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['alias'])) {
                     throw new LogicException(
-                        'ezpublish.searchEngineIndexer service tag needs an "alias" attribute to ' .
-                        'identify the search engine.'
+                        sprintf(
+                            'Service "%s" tagged with "%s" or "%s" needs an "alias" attribute to identify the search engine',
+                            $serviceId,
+                            self::SEARCH_ENGINE_INDEXER_SERVICE_TAG,
+                            self::DEPRECATED_SEARCH_ENGINE_INDEXER_SERVICE_TAG
+                        )
                     );
                 }
 
@@ -52,7 +67,7 @@ class RegisterSearchEngineIndexerPass implements CompilerPassInterface
                 $searchEngineIndexerFactoryDefinition->addMethodCall(
                     'registerSearchEngineIndexer',
                     [
-                        new Reference($id),
+                        new Reference($serviceId),
                         $attribute['alias'],
                     ]
                 );

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterSearchEnginePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterSearchEnginePass.php
@@ -6,16 +6,20 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;
 
+use eZ\Publish\Core\Base\Container\Compiler\TaggedServiceIdsIterator\BackwardCompatibleIterator;
+use LogicException;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
-use LogicException;
 
 /**
  * This compiler pass will register eZ Publish search engines.
  */
 class RegisterSearchEnginePass implements CompilerPassInterface
 {
+    public const SEARCH_ENGINE_SERVICE_TAG = 'ezplatform.search_engine';
+    public const DEPRECATED_SEATCH_ENGINE_SERVICE_TAG = 'ezpublish.searchEngine';
+
     /**
      * Container service id of the SearchEngineFactory.
      *
@@ -40,12 +44,22 @@ class RegisterSearchEnginePass implements CompilerPassInterface
 
         $searchEngineFactoryDefinition = $container->getDefinition($this->factoryId);
 
-        foreach ($container->findTaggedServiceIds('ezpublish.searchEngine') as $id => $attributes) {
+        $iterator = new BackwardCompatibleIterator(
+            $container,
+            self::SEARCH_ENGINE_SERVICE_TAG,
+            self::DEPRECATED_SEATCH_ENGINE_SERVICE_TAG
+        );
+
+        foreach ($iterator as $serviceId => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['alias'])) {
                     throw new LogicException(
-                        'ezpublish.searchEngine service tag needs an "alias" attribute to ' .
-                        'identify the search engine.'
+                        sprintf(
+                            'Service "%s" tagged with "%s" or "%s" needs an "alias" attribute to identify the search engine',
+                            $serviceId,
+                            self::SEARCH_ENGINE_SERVICE_TAG,
+                            self::DEPRECATED_SEATCH_ENGINE_SERVICE_TAG
+                        )
                     );
                 }
 
@@ -53,7 +67,7 @@ class RegisterSearchEnginePass implements CompilerPassInterface
                 $searchEngineFactoryDefinition->addMethodCall(
                     'registerSearchEngine',
                     [
-                        new Reference($id),
+                        new Reference($serviceId),
                         $attribute['alias'],
                     ]
                 );

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/RegisterSearchEngineIndexerPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/RegisterSearchEngineIndexerPassTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RegisterSearchEngineIndexerPass;
+use LogicException;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class RegisterSearchEngineIndexerPassTest extends AbstractCompilerPassTestCase
+{
+    private const EXAMPLE_SERVICE_ID = 'app.search_engine';
+    private const EXAMPLE_ALIAS = 'foo';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setDefinition('ezpublish.api.search_engine.indexer.factory', new Definition());
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new RegisterSearchEngineIndexerPass());
+    }
+
+    /**
+     * @dataProvider tagsProvider
+     */
+    public function testRegisterSearchEngineIndexer(string $tag): void
+    {
+        $definition = new Definition();
+        $definition->addTag($tag, [
+            'alias' => self::EXAMPLE_ALIAS,
+        ]);
+
+        $this->setDefinition(self::EXAMPLE_SERVICE_ID, $definition);
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'ezpublish.api.search_engine.indexer.factory',
+            'registerSearchEngineIndexer',
+            [
+                new Reference(self::EXAMPLE_SERVICE_ID),
+                self::EXAMPLE_ALIAS,
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider tagsProvider
+     */
+    public function testRegisterSearchEngineIndexerWithoutAliasThrowsLogicException(string $tag): void
+    {
+        $this->expectException(LogicException::class);
+
+        $definition = new Definition();
+        $definition->addTag($tag);
+
+        $this->setDefinition(self::EXAMPLE_SERVICE_ID, $definition);
+        $this->compile();
+    }
+
+    public function tagsProvider(): iterable
+    {
+        return [
+            [RegisterSearchEngineIndexerPass::SEARCH_ENGINE_INDEXER_SERVICE_TAG],
+            [RegisterSearchEngineIndexerPass::DEPRECATED_SEARCH_ENGINE_INDEXER_SERVICE_TAG],
+        ];
+    }
+}

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/RegisterSearchEnginePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/RegisterSearchEnginePassTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;
+
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\RegisterSearchEnginePass;
+use LogicException;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+final class RegisterSearchEnginePassTest extends AbstractCompilerPassTestCase
+{
+    private const EXAMPLE_SERVICE_ID = 'app.search_engine';
+    private const EXAMPLE_ALIAS = 'foo';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setDefinition('ezpublish.api.search_engine.factory', new Definition());
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new RegisterSearchEnginePass());
+    }
+
+    /**
+     * @dataProvider tagsProvider
+     */
+    public function testRegisterSearchEngine(string $tag): void
+    {
+        $definition = new Definition();
+        $definition->addTag($tag, [
+            'alias' => self::EXAMPLE_ALIAS,
+        ]);
+
+        $this->setDefinition(self::EXAMPLE_SERVICE_ID, $definition);
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            'ezpublish.api.search_engine.factory',
+            'registerSearchEngine',
+            [
+                new Reference(self::EXAMPLE_SERVICE_ID),
+                self::EXAMPLE_ALIAS,
+            ]
+        );
+    }
+
+    /**
+     * @dataProvider tagsProvider
+     */
+    public function testRegisterSearchEngineWithoutAliasThrowsLogicException(string $tag): void
+    {
+        $this->expectException(LogicException::class);
+
+        $definition = new Definition();
+        $definition->addTag($tag);
+
+        $this->setDefinition(self::EXAMPLE_SERVICE_ID, $definition);
+        $this->compile();
+    }
+
+    public function tagsProvider(): iterable
+    {
+        return [
+            [RegisterSearchEnginePass::SEARCH_ENGINE_SERVICE_TAG],
+            [RegisterSearchEnginePass::DEPRECATED_SEATCH_ENGINE_SERVICE_TAG],
+        ];
+    }
+}

--- a/eZ/Publish/Core/Base/Container/Compiler/Storage/Legacy/FieldValueConverterRegistryPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Storage/Legacy/FieldValueConverterRegistryPass.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\Base\Container\Compiler\Storage\Legacy;
 
+use eZ\Publish\Core\Base\Container\Compiler\TaggedServiceIdsIterator\BackwardCompatibleIterator;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
@@ -37,22 +38,13 @@ class FieldValueConverterRegistryPass implements CompilerPassInterface
 
         $registry = $container->getDefinition(self::CONVERTER_REGISTRY_SERVICE_ID);
 
-        $deprecatedFieldTypeStorageConverterTags = $container->findTaggedServiceIds(
+        $iterator = new BackwardCompatibleIterator(
+            $container,
+            self::CONVERTER_SERVICE_TAG,
             self::DEPRECATED_CONVERTER_SERVICE_TAG
         );
-        foreach ($deprecatedFieldTypeStorageConverterTags as $deprecatedFieldTypeStorageConverterTag) {
-            @trigger_error(
-                sprintf(
-                    '`%s` service tag is deprecated and will be removed in eZ Platform 4.0. Please use `%s` instead.',
-                    self::DEPRECATED_CONVERTER_SERVICE_TAG,
-                    self::CONVERTER_SERVICE_TAG
-                ),
-                E_USER_DEPRECATED
-            );
-        }
-        $fieldTypeStorageConverterTags = $container->findTaggedServiceIds(self::CONVERTER_SERVICE_TAG);
-        $storageConverterFieldTypesTags = array_merge($deprecatedFieldTypeStorageConverterTags, $fieldTypeStorageConverterTags);
-        foreach ($storageConverterFieldTypesTags as $id => $attributes) {
+
+        foreach ($iterator as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['alias'])) {
                     throw new LogicException(

--- a/eZ/Publish/Core/Base/Container/Compiler/TaggedServiceIdsIterator/BackwardCompatibleIterator.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/TaggedServiceIdsIterator/BackwardCompatibleIterator.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Base\Container\Compiler\TaggedServiceIdsIterator;
+
+use Iterator;
+use IteratorAggregate;
+use Symfony\Component\DependencyInjection\TaggedContainerInterface;
+
+/**
+ * @internal
+ */
+final class BackwardCompatibleIterator implements IteratorAggregate
+{
+    /** @var \Symfony\Component\DependencyInjection\TaggedContainerInterface */
+    private $container;
+
+    /** @var string */
+    private $serviceTag;
+
+    /** @var string */
+    private $deprecatedServiceTag;
+
+    public function __construct(TaggedContainerInterface $container, string $serviceTag, string $deprecatedServiceTag)
+    {
+        $this->container = $container;
+        $this->serviceTag = $serviceTag;
+        $this->deprecatedServiceTag = $deprecatedServiceTag;
+    }
+
+    public function getIterator(): Iterator
+    {
+        $serviceIdsWithDeprecatedTags = $this->container->findTaggedServiceIds($this->deprecatedServiceTag);
+        foreach ($serviceIdsWithDeprecatedTags as $serviceId => $tags) {
+            @trigger_error(
+                sprintf(
+                    'Service tag `%s` is deprecated and will be removed in eZ Platform 4.0. Tag %s with `%s` instead.',
+                    $this->deprecatedServiceTag,
+                    $serviceId,
+                    $this->serviceTag
+                ),
+                E_USER_DEPRECATED
+            );
+
+            yield $serviceId => $tags;
+        }
+
+        $taggedServiceIds = $this->container->findTaggedServiceIds($this->serviceTag);
+        foreach ($taggedServiceIds as $serviceId => $tags) {
+            yield $serviceId => $tags;
+        }
+
+        yield from [];
+    }
+}

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/TaggedServiceIdsIterator/BackwardCompatibleIteratorTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/TaggedServiceIdsIterator/BackwardCompatibleIteratorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Base\Tests\Container\Compiler\TaggedServiceIdsIterator;
+
+use eZ\Publish\Core\Base\Container\Compiler\TaggedServiceIdsIterator\BackwardCompatibleIterator;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\TaggedContainerInterface;
+
+final class BackwardCompatibleIteratorTest extends TestCase
+{
+    private const EXAMPLE_SERVICE_TAG = 'current_tag';
+    private const EXAMPLE_DEPRECATED_SERVICE_TAG = 'deprecated_tag';
+
+    /** @var \eZ\Publish\Core\Base\Tests\Container\Compiler\TaggedServiceIdsIterator\DeprecationErrorCollector */
+    private $deprecationErrorCollector;
+
+    /** @var \Symfony\Component\DependencyInjection\TaggedContainerInterface */
+    private $container;
+
+    protected function setUp(): void
+    {
+        $this->container = $this->createMock(TaggedContainerInterface::class);
+        $this->container
+            ->method('findTaggedServiceIds')
+            ->willReturnMap([
+                [
+                    self::EXAMPLE_DEPRECATED_SERVICE_TAG,
+                    [
+                        'app.service.foo' => [
+                            ['alias' => 'foo'],
+                        ],
+                    ],
+                ],
+                [
+                    self::EXAMPLE_SERVICE_TAG,
+                    [
+                        'app.service.bar' => [
+                            ['alias' => 'bar'],
+                        ],
+                        'app.service.baz' => [
+                            ['alias' => 'baz'],
+                        ],
+                    ],
+                ],
+            ]);
+
+        $this->deprecationErrorCollector = new DeprecationErrorCollector();
+        $this->deprecationErrorCollector->register();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deprecationErrorCollector->unregister();
+    }
+
+    public function testGetIterator(): void
+    {
+        $iterator = new BackwardCompatibleIterator(
+            $this->container,
+            self::EXAMPLE_SERVICE_TAG,
+            self::EXAMPLE_DEPRECATED_SERVICE_TAG
+        );
+
+        $this->assertEquals([
+            'app.service.foo' => [
+                ['alias' => 'foo'],
+            ],
+            'app.service.bar' => [
+                ['alias' => 'bar'],
+            ],
+            'app.service.baz' => [
+                ['alias' => 'baz'],
+            ],
+        ], iterator_to_array($iterator));
+
+        $this->assertDeprecationError(sprintf(
+            'Service tag `%s` is deprecated and will be removed in eZ Platform 4.0. Tag %s with `%s` instead.',
+            self::EXAMPLE_DEPRECATED_SERVICE_TAG,
+            'app.service.foo',
+            self::EXAMPLE_SERVICE_TAG
+        ));
+    }
+
+    private function assertDeprecationError(string $expectedMessage): void
+    {
+        foreach ($this->deprecationErrorCollector->getErrors() as $error) {
+            if ($error['message'] === $expectedMessage) {
+                return;
+            }
+        }
+
+        $this->fail(sprintf(
+            'Failed asserting that deprecation warning with message "%s" has been triggered',
+            $expectedMessage
+        ));
+    }
+}

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/TaggedServiceIdsIterator/DeprecationErrorCollector.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/TaggedServiceIdsIterator/DeprecationErrorCollector.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Base\Tests\Container\Compiler\TaggedServiceIdsIterator;
+
+/**
+ * Captures user deprecation warnings emitted using trigger_error function.
+ *
+ * @internal
+ */
+final class DeprecationErrorCollector
+{
+    /** @var array */
+    private $errors = [];
+
+    /** @var callable|null */
+    private $previousErrorHandler;
+
+    public function register(): void
+    {
+        $this->previousErrorHandler = set_error_handler($this, E_USER_DEPRECATED);
+    }
+
+    public function unregister(): void
+    {
+        set_error_handler($this->previousErrorHandler);
+    }
+
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+
+    public function __invoke(int $code, string $message, string $file, int $line): bool
+    {
+        $this->errors[] = [
+            'code' => $code,
+            'message' => $message,
+            'file' => $file,
+            'line' => $line,
+        ];
+
+        return true;
+    }
+}

--- a/eZ/Publish/Core/settings/search_engines/legacy.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy.yml
@@ -68,7 +68,7 @@ services:
             $languageHandler: '@ezpublish.spi.persistence.language_handler'
             $mapper: '@ezpublish.search.legacy.fulltext_mapper'
         tags:
-            - {name: ezpublish.searchEngine, alias: legacy}
+            - {name: ezplatform.search_engine, alias: legacy}
         lazy: true
 
     ezpublish.spi.search.legacy.indexer:
@@ -79,5 +79,5 @@ services:
             $connection: '@ezpublish.persistence.connection'
             $searchHandler: "@ezpublish.spi.search.legacy"
         tags:
-            - {name: ezpublish.searchEngineIndexer, alias: legacy}
+            - {name: ezplatform.search_engine.indexer, alias: legacy}
         lazy: true


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31588](https://jira.ez.no/browse/EZP-31588)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.x` 
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | yes

Tags used to register Search Engine features in the dependency injection container should be consistent and follow Symfony convention (snake case).

Commits between https://github.com/ezsystems/ezplatform-kernel/commit/73ae9f70097be965563c5005bfb7022cf63ac61a - https://github.com/ezsystems/ezplatform-kernel/commit/d0ad33f8caddb031700d0ca9d880d16245fc6448 contains refactoring of existing backward compatibility layer for `ezplatform.field_type.*`  `ezplatform.query_type.*`. 

Basically duplicated logic of iteration over service ids tagged wtith current and deprecated tag has been extracted to `\eZ\Publish\Core\Base\Container\Compiler\TaggedServiceIdsIterator\BackwardCompatibleIterator`. 

Commit https://github.com/ezsystems/ezplatform-kernel/commit/76bce15df51f7642cc61b352fa0bc2b29a809b85 deprecates  `ezpublish.searchEngine` and `ezpublish.searchEngineIndexer` in favour of `ezplatform.search_engine` and `ezplatform.search_engine.indexer`

#### Checklist:
- [X] PR description is updated.
- [X] Tests are implemented.
- [X] Added code follows Coding Standards (use `$ composer fix-cs`).
- [X] PR is ready for a review.
