### PR TITLE
EZP-31591: Farsi (Persian) language is missing in internal locale conversion map

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/locale.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/locale.yml
@@ -20,6 +20,7 @@ parameters:
         epo-EO: eo
         esl-ES: es_ES
         esl-MX: es_MX
+        fas-IR: fa_IR
         fin-FI: fi_FI
         fre-BE: fr_BE
         fre-CA: fr_CA
@@ -65,6 +66,7 @@ parameters:
         en: ['eng-GB', 'eng-US']
         en_us: ['eng-US']
         es: ['esl-ES']
+        fa: ['fas-IR']
         fi: ['fin-FI']
         fr: ['fre-FR']
         gb: ['eng-GB']

--- a/eZ/Publish/Core/MVC/Symfony/Locale/LocaleConverterInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Locale/LocaleConverterInterface.php
@@ -8,7 +8,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Locale;
 
 /**
  * Interface for locale converters.
- * eZ Publish uses <ISO639-2/B>-<ISO3166-Alpha2> locale format (mostly, some supported locales being out of this format, e.g. cro-HR).
+ * eZ Platform uses <ISO639-2/B>-<ISO3166-Alpha2> locale format (mostly, some supported locales being out of this format, e.g. cro-HR).
  * Symfony uses the standard POSIX locale format (<ISO639-1>_<ISO3166-Alpha2>), which is supported by Intl PHP extension.
  *
  * Locale converters are meant to convert in those 2 formats back and forth.


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31591](https://jira.ez.no/browse/EZP-31591)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This PR adds missing support for Farsi (Persian) language. 

- [x] PR description is updated.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
