### PR TITLE
[Internal RFC][Composer] Proposed new Ibexa namespaces

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "EzSystems\\PlatformInstallerBundleTests\\": "eZ/Bundle/PlatformInstallerBundle/tests"
+            "EzSystems\\PlatformInstallerBundleTests\\": "eZ/Bundle/PlatformInstallerBundle/tests",
+            "Ibexa\\Platform\\Tests\\Integration\\": "tests/lib/integration"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,10 @@
     "autoload": {
         "psr-4": {
             "EzSystems\\PlatformInstallerBundle\\": "eZ/Bundle/PlatformInstallerBundle/src",
-            "eZ\\": "eZ"
+            "eZ\\": "eZ",
+            "Ibexa\\Platform\\API\\Repository\\": "src/lib/API/Repository",
+            "Ibexa\\Platform\\SPI\\Repository\\": "src/lib/SPI/Repository",
+            "Ibexa\\Platform\\Core\\Repository\\": "src/lib/Core/Repository"
         }
     },
     "autoload-dev": {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | Internal RFC
| **Target eZ Platform version** | `v3.1`
| **BC breaks**                          | no
| **Doc needed**                       | not yet

### Background

We have a namespace chaos, looking from the entire Product perspective. "Publish" is mixed with "Platform", each package provides API in its own way.

[We're Ibexa now](https://www.ibexa.co/blog/ez-systems-announces-company-name-change-to-ibexa), which is a perfect opportunity for some changes.

### Introducing `Ibexa\Platform` namespace

Instead of waiting for the good opportunity (`v4.0`) to perform namespace refactoring from `eZ\Publish` and `EzSystems\EzPlatform*` to `Ibexa\Platform`, let's start an evolution already in `3.x` instead of a revolution for `4.x`. You have to admit that a bulk upgrade of all the packages for the next major never worked for us really well. This way we could avoid increasing this technical debt.

### New convention

I'm proposing the new namespace convention, to be already included for eZ Platform `v3.1` by Ibexa (it doesn't matter that "eZ" is still with us):

* `Ibexa\Platform\API\<PackageName>` to map consumer API Services (and other "injectables") and Values,
* `Ibexa\Platform\SPI\<PackageName>` to map integrator Service Provider Interfaces (extension points and "newables"[1]),
* `Ibexa\Platform\Core\<PackageName>` to map core/internal implementation of APIs and SPIs, not to be used by 3rd party code,
* `Ibexa\Platform\Tests\` for tests (needs to be in `autoload-dev` section to avoid overlapping).

The `<PackageName>` is arbitrary - whatever makes sense for the package. For Kernel I've chosen `Repository` because this is closer to our domain and the package responsibility[2]:

So for Kernel this PR proposes accordingly:
* `Ibexa\Platform\API\Repository`,
* `Ibexa\Platform\SPI\Repository`,
* `Ibexa\Platform\Core\Repository`,

The `autoload-dev` test namespace could be:
* `Ibexa\Platform\Tests\Integration`

It would be the same or similar in every package. Since it's a dev-autoloaded namespace it should be fine.

### Bundles

Naturally, Bundles would still have their own namespaces and are still expected to be placed in `./src/bundle` directory.

### Examples

The idea for 1st party packages introducing APIs is to follow the same or similar pattern. Let's use EE SiteFactory as an example[3]:

* `Ibexa\Platform\API\SiteFactory`,
* `Ibexa\Platform\SPI\SiteFactory`,
* `Ibexa\Platform\Core\SiteFactory` (current contents of `./src/lib` there minus APIs and SPIs - if present).

**Content/Location Filtering feature practical example: #54**

### Advantages

Unified namespaces across the entire Product and unified directory structure which comes with that makes the Product more Developer friendly. 
Experienced Developer would know where to find certain things (let's start my IDE search by "API" because I'm looking for an API). 
Skilled Developer would know how to use proper parts of the Product. While A(S)PI organization of a Product is not common to PHP ecosystem, it's quite easy to explain in terms of what you can and cannot do.
For us it also provides those advantages - we should know what can be safely changed and what needs an extra attention just by looking at a file path or a class namespace.

Last but not least, we've been saying for ages, that we're API-oriented and everything is API. Let's expose that more clearly in a unified way.

### Alternatives

1. Following the currently used pattern, the namespaces could be e.g. `Ibexa\Platform\Kernel\API`, `Ibexa\Platform\SiteFactory\API`. While it would make Composer `autoload` definition simpler, it would give an impression of a separation. Since we're API-oriented, API should be one hub with different services.
2. Contracts could have its own repository which each package would require. While it would look pretty cool and light, it would be at the same time a maintenance hell. To provide new feature we would have to target Contracts repository first and link the builds to see that everything is working properly.

### Controversy

1. I admit that placing here "src" next to "eZ" will be confusing for newcomers. But this is an intermediate step to avoid bulk changes.
2. Given many packages already follow the `./src/{lib,bundle}` convention, it's gonna be a challenge. However smaller refactoring keeping portions of the namespace, but introducing API and SPI would be beneficial anyway.

---
_[1] "newable" - a class which will be used by 3rd party as `new ClassName` - it requires strict BC policy, including a guarantee a constructor would work across all minor versions._

_[2] Yeah I know Kernel has more responsibilities than simply delivering a Content Repository. Focusing here on the package essence though and future restructuring & decoupling plans._

_[3] Using existing package to provide more relatable example, but since I'm proposing evolution, this would actually be something for new packages or something slowly being introduced in the old ones, the in same way as here._