### PR TITLE
EZP-31420: Added ContentTranslationHandler for delete translation document in solr

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchService/DeleteTranslationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/DeleteTranslationTest.php
@@ -23,7 +23,6 @@ use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
  */
 class DeleteTranslationTest extends BaseTest
 {
-
     /**
      * @param array $languages
      *

--- a/eZ/Publish/API/Repository/Tests/SearchService/DeleteTranslationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/DeleteTranslationTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\SearchService;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+
+/**
+ * Test case for delete content translation with the SearchService.
+ *
+ * @see \eZ\Publish\API\Repository\SearchService
+ * @group integration
+ * @group search
+ */
+class DeleteTranslationTest extends BaseTest
+{
+
+    /**
+     * @param array $languages
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    protected function createTestContentWithLanguages(array $languages): Content
+    {
+        $repository = $this->getRepository();
+        $contentTypeService = $repository->getContentTypeService();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+
+        $contentTypeArticle = $contentTypeService->loadContentTypeByIdentifier('article');
+        $contentCreateStructArticle = $contentService->newContentCreateStruct(
+            $contentTypeArticle,
+            'eng-GB'
+        );
+
+        foreach ($languages as $langCode => $title) {
+            $contentCreateStructArticle->setField('title', $title, $langCode);
+        }
+
+        $locationCreateStructArticle = $locationService->newLocationCreateStruct(2);
+        $draftArticle = $contentService->createContent(
+            $contentCreateStructArticle,
+            [$locationCreateStructArticle]
+        );
+        $content = $contentService->publishVersion($draftArticle->getVersionInfo());
+        $this->refreshSearch($repository);
+
+        return $content;
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    protected function findContent(string $text, string $languageCode): SearchResult
+    {
+        $repository = $this->getRepository();
+        $searchService = $repository->getSearchService();
+        $query = new Query();
+        $query->query = new Criterion\FullText($text);
+        $query->limit = 0;
+        $languageFilter = [
+            'languages' => [$languageCode],
+            'useAlwaysAvailable' => true,
+            'excludeTranslationsFromAlwaysAvailable' => false,
+        ];
+
+        return $searchService->findContent($query, $languageFilter);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testDeleteContentTranslation(): void
+    {
+        $repository = $this->getRepository();
+        $testContent = $this->createTestContentWithLanguages(
+            [
+                'eng-GB' => 'Contact',
+                'ger-DE' => 'Kontakt',
+            ]
+        );
+        $contentService = $repository->getContentService();
+        $searchResult = $this->findContent('Kontakt', 'ger-DE');
+        $this->assertEquals(1, $searchResult->totalCount);
+
+        $contentService->deleteTranslation($testContent->contentInfo, 'ger-DE');
+        $this->refreshSearch($repository);
+        $searchResult = $this->findContent('Kontakt', 'ger-DE');
+        $this->assertEquals(0, $searchResult->totalCount);
+    }
+}

--- a/eZ/Publish/Core/Search/Common/EventSubscriber/ContentEventSubscriber.php
+++ b/eZ/Publish/Core/Search/Common/EventSubscriber/ContentEventSubscriber.php
@@ -13,6 +13,7 @@ use eZ\Publish\API\Repository\Events\Content\HideContentEvent;
 use eZ\Publish\API\Repository\Events\Content\PublishVersionEvent;
 use eZ\Publish\API\Repository\Events\Content\RevealContentEvent;
 use eZ\Publish\API\Repository\Events\Content\UpdateContentMetadataEvent;
+use eZ\Publish\SPI\Search\ContentTranslationHandler;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ContentEventSubscriber extends AbstractSearchEventSubscriber implements EventSubscriberInterface
@@ -65,6 +66,13 @@ class ContentEventSubscriber extends AbstractSearchEventSubscriber implements Ev
 
         if (!$contentInfo->isPublished) {
             return;
+        }
+
+        if ($this->searchHandler instanceof ContentTranslationHandler) {
+            $this->searchHandler->deleteTranslation(
+                $contentInfo->id,
+                $event->getLanguageCode()
+            );
         }
 
         $this->searchHandler->indexContent(

--- a/eZ/Publish/SPI/Search/ContentTranslationHandler.php
+++ b/eZ/Publish/SPI/Search/ContentTranslationHandler.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Search;
+
+/**
+ * The Search Content translation handler.
+ */
+interface ContentTranslationHandler
+{
+    /**
+     * Deletes a translation content object from the index.
+     */
+    public function deleteTranslation(int $contentId, string $languageCode): void;
+}


### PR DESCRIPTION

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31420](https://jira.ez.no/browse/EZP-31420)
| **Type**                                   | bug
| **Target eZ Platform version** | `v1.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This is merged up from https://github.com/ezsystems/ezpublish-kernel/pull/3013

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [ ] PR is ready for a review.
