### PR TITLE
EZP-31610 - fix php notice for PASSWORD_TTL setting access

### DIFF
--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -1289,7 +1289,7 @@ class UserService implements UserServiceInterface
         $expirationDate = null;
         $expirationWarningDate = null;
 
-        $passwordTTL = (int)$definition->fieldSettings[UserType::PASSWORD_TTL_SETTING];
+        $passwordTTL = (int)($definition->fieldSettings[UserType::PASSWORD_TTL_SETTING] ?? 0);
         if ($passwordTTL > 0) {
             if ($passwordUpdatedAt instanceof DateTime) {
                 $passwordUpdatedAt = DateTimeImmutable::createFromMutable($passwordUpdatedAt);
@@ -1297,7 +1297,7 @@ class UserService implements UserServiceInterface
 
             $expirationDate = $passwordUpdatedAt->add(new DateInterval(sprintf('P%dD', $passwordTTL)));
 
-            $passwordTTLWarning = (int)$definition->fieldSettings[UserType::PASSWORD_TTL_WARNING_SETTING];
+            $passwordTTLWarning = (int)($definition->fieldSettings[UserType::PASSWORD_TTL_WARNING_SETTING] ?? 0);
             if ($passwordTTLWarning > 0) {
                 $expirationWarningDate = $expirationDate->sub(new DateInterval(sprintf('P%dD', $passwordTTLWarning)));
             }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31610](https://jira.ez.no/browse/EZP-31610)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

If user doesn't have a preference for password ttl yet, php notice displayed on sign in.

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
