### PR TITLE
[Tests] Fixed obsolete PHPUnit class names

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class ProxyResolverTest extends TestCase
 {
-    /** @var \PHPUnit_Framework_MockObject_MockObject|\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface */
+    /** @var \PHPUnit\Framework\MockObject\MockObject|\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface */
     private $resolver;
 
     /** @var string */

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/Resolver/RelativeResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/Resolver/RelativeResolverTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\TestCase;
 
 class RelativeResolverTest extends TestCase
 {
-    /** @var \PHPUnit_Framework_MockObject_MockObject|\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface */
+    /** @var \PHPUnit\Framework\MockObject\MockObject|\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface */
     private $liipResolver;
 
     protected function setUp(): void

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/ResolverFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/ResolverFactoryTest.php
@@ -15,10 +15,10 @@ use PHPUnit\Framework\TestCase;
 
 class ResolverFactoryTest extends TestCase
 {
-    /** @var \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\MVC\ConfigResolverInterface */
+    /** @var \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolver;
 
-    /** @var \PHPUnit_Framework_MockObject_MockObject|\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface */
+    /** @var \PHPUnit\Framework\MockObject\MockObject|\Liip\ImagineBundle\Imagine\Cache\Resolver\ResolverInterface */
     private $resolver;
 
     /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\ResolverFactory */

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/ImageAsset/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/ImageAsset/AliasGeneratorTest.php
@@ -24,13 +24,13 @@ class AliasGeneratorTest extends TestCase
     /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\ImageAsset\AliasGenerator */
     private $aliasGenerator;
 
-    /** @var \eZ\Publish\SPI\Variation\VariationHandler|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Publish\SPI\Variation\VariationHandler|\PHPUnit\Framework\MockObject\MockObject */
     private $innerAliasGenerator;
 
-    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
     private $contentService;
 
-    /** @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Publish\Core\FieldType\ImageAsset\AssetMapper|\PHPUnit\Framework\MockObject\MockObject */
     private $assetMapper;
 
     protected function setUp(): void

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderAliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderAliasGeneratorTest.php
@@ -28,16 +28,16 @@ class PlaceholderAliasGeneratorTest extends TestCase
     /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderAliasGenerator */
     private $aliasGenerator;
 
-    /** @var \eZ\Publish\SPI\Variation\VariationHandler|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Publish\SPI\Variation\VariationHandler|\PHPUnit\Framework\MockObject\MockObject */
     private $innerAliasGenerator;
 
-    /** @var \eZ\Publish\Core\IO\IOServiceInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Publish\Core\IO\IOServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $ioService;
 
-    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\IORepositoryResolver|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\IORepositoryResolver|\PHPUnit\Framework\MockObject\MockObject */
     private $ioResolver;
 
-    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider|\PHPUnit\Framework\MockObject\MockObject */
     private $placeholderProvider;
 
     /** @var array */

--- a/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
@@ -6,13 +6,13 @@
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;
 
+use eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Tests;
 use eZ\Publish\API\Repository;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
-use Exception;
-use PHPUnit_Framework_AssertionFailedError;
 
 /**
  * Integration test for legacy storage field types.
@@ -323,7 +323,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
 
         try {
             return $contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
-        } catch (Repository\Exceptions\NotFoundException $e) {
+        } catch (NotFoundException $e) {
             // Move on to creating Content Type
         }
 
@@ -483,7 +483,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
      */
     public function testCreateContentTypeFailsWithInvalidFieldSettings()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException::class);
+        $this->expectException(ContentTypeFieldDefinitionValidationException::class);
 
         $this->createContentType(
             $this->getInvalidFieldSettings(),
@@ -508,7 +508,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
      */
     public function testCreateContentTypeFailsWithInvalidValidatorConfiguration()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException::class);
+        $this->expectException(ContentTypeFieldDefinitionValidationException::class);
 
         $this->createContentType(
             $this->getValidFieldSettings(),
@@ -923,7 +923,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
      */
     public function testDeleteContent($content)
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
+        $this->expectException(NotFoundException::class);
 
         $content = $this->testPublishContent();
 
@@ -939,25 +939,13 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
      * Tests failing content creation.
      *
      * @param mixed $failingValue
-     * @param string $expectedException
      *
      * @dataProvider provideInvalidCreationFieldData
-     * @dep_ends eZ\Publish\API\Repository\Tests\ContentServiceTest::testDeleteContent
      */
-    public function testCreateContentFails($failingValue, $expectedException)
+    public function testCreateContentFails($failingValue, ?string $expectedException): void
     {
-        try {
-            $this->createContent($failingValue);
-
-            $this->fail('Expected exception not thrown.');
-        } catch (PHPUnit_Framework_AssertionFailedError $e) {
-            throw $e;
-        } catch (Exception $e) {
-            $this->assertInstanceOf(
-                $expectedException,
-                $e
-            );
-        }
+        $this->expectException($expectedException);
+        $this->createContent($failingValue);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
@@ -273,9 +273,6 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
         return [];
     }
 
-    /**
-     * @dep_ends eZ\Publish\API\Repository\Tests\ContentTypeServiceTest::testCreateContentType
-     */
     public function testCreateContentType()
     {
         $contentType = $this->createContentType(
@@ -418,7 +415,6 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     }
 
     /**
-     * @dep_ends eZ\Publish\API\Repository\Tests\ContentTypeServiceTest::testLoadContentType
      * @depends testCreateContentType
      */
     public function testLoadContentTypeField()
@@ -517,7 +513,6 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     }
 
     /**
-     * @dep_ends eZ\Publish\API\Repository\Tests\ContentServiceTest::testCreateContent;
      * @depends testLoadContentTypeField
      */
     public function testCreateContent()
@@ -614,7 +609,6 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     }
 
     /**
-     * @dep_ends eZ\Publish\API\Repository\Tests\ContentServiceTest::testPublishVersion
      * @depends testCreateContent
      */
     public function testPublishContent()
@@ -657,7 +651,6 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     }
 
     /**
-     * @dep_ends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadContent
      * @depends testCreateContent
      */
     public function testLoadField()
@@ -731,7 +724,6 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     }
 
     /**
-     * @dep_ends eZ\Publish\API\Repository\Tests\ContentServiceTest::testLoadContent
      * @depends testCreateContentWithEmptyFieldValue
      * @group xx
      */
@@ -780,7 +772,6 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     }
 
     /**
-     * @dep_ends eZ\Publish\API\Repository\Tests\ContentServiceTest::testUpdateContent
      * @depends testLoadFieldType
      */
     public function testUpdateField()
@@ -839,9 +830,7 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
     }
 
     /**
-     * Tests creeating a new version keeps the existing value.
-     *
-     * @dep_ends eZ\Publish\API\Repository\Tests\ContentServiceTest::testUpdateContent
+     * Tests creating a new Version keeps the existing value.
      */
     public function testUpdateFieldNoNewContent()
     {
@@ -872,7 +861,6 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
 
     /**
      * @depends testCreateContent
-     * @dep_ends eZ\Publish\API\Repository\Tests\ContentServiceTest::testCopyContent
      */
     public function testCopyField($content)
     {
@@ -919,7 +907,6 @@ abstract class BaseIntegrationTest extends Tests\BaseTest
 
     /**
      * @depends testCopyField
-     * @dep_ends eZ\Publish\API\Repository\Tests\ContentServiceTest::deleteContent
      */
     public function testDeleteContent($content)
     {

--- a/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
@@ -240,8 +240,10 @@ class UserIntegrationTest extends BaseIntegrationTest
         return [];
     }
 
-    public function testCreateContentFails($failingValue = null, $expectedException = null)
-    {
+    public function testCreateContentFails(
+        $failingValue = null,
+        ?string $expectedException = null
+    ): void {
         $this->markTestSkipped('Values are ignored on creation.');
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/ImageAsset/AssetMapperTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAsset/AssetMapperTest.php
@@ -28,16 +28,16 @@ class AssetMapperTest extends TestCase
 {
     const EXAMPLE_CONTENT_ID = 487;
 
-    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
     private $contentService;
 
-    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit\Framework\MockObject\MockObject */
     private $locationService;
 
-    /** @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Publish\API\Repository\ContentTypeService|\PHPUnit\Framework\MockObject\MockObject */
     private $contentTypeService;
 
-    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
     private $configResolver;
 
     /** @var array */

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/AbstractServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/AbstractServiceTest.php
@@ -30,13 +30,13 @@ abstract class AbstractServiceTest extends TestCase
      */
     const LANG_ARG = 0;
 
-    /** @var \object|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \object|\PHPUnit\Framework\MockObject\MockObject */
     protected $innerApiServiceMock;
 
     /** @var object */
     protected $service;
 
-    /** @var \eZ\Publish\API\Repository\LanguageResolver|\PHPUnit_Framework_MockObject_MockObject */
+    /** @var \eZ\Publish\API\Repository\LanguageResolver|\PHPUnit\Framework\MockObject\MockObject */
     protected $languageResolverMock;
 
     abstract public function getAPIServiceClassName();

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -52,7 +52,6 @@ use eZ\Publish\SPI\Persistence\Content\MetadataUpdateStruct as SPIMetadataUpdate
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
 use Exception;
-use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Mock test case for Content service.
@@ -151,7 +150,7 @@ class ContentTest extends BaseServiceMockTest
     {
         $permissionResolver = $this->getPermissionResolverMock();
         $contentServiceMock = $this->getPartlyMockedContentService(['loadContentInfo']);
-        /** @var \PHPUnit_Framework_MockObject_MockObject $contentHandler */
+        /** @var \PHPUnit\Framework\MockObject\MockObject $contentHandler */
         $contentHandler = $this->getPersistenceMock()->contentHandler();
         $domainMapperMock = $this->getContentDomainMapperMock();
         $versionInfoMock = $this->createMock(APIVersionInfo::class);

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlAliasTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlAliasTest.php
@@ -3389,7 +3389,7 @@ class UrlAliasTest extends BaseServiceMockTest
     }
 
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\eZ\Publish\Core\Repository\Helper\NameSchemaService
+     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Repository\Helper\NameSchemaService
      */
     protected function getNameSchemaServiceMock()
     {

--- a/eZ/Publish/SPI/FieldType/Tests/FieldTypeTest.php
+++ b/eZ/Publish/SPI/FieldType/Tests/FieldTypeTest.php
@@ -602,34 +602,19 @@ abstract class FieldTypeTest extends TestCase
 
     /**
      * @param mixed $inputValue
-     * @param \Exception $expectedException
      *
      * @dataProvider provideInvalidInputForAcceptValue
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
-    public function testAcceptValueFailsOnInvalidValues($inputValue, $expectedException)
-    {
+    public function testAcceptValueFailsOnInvalidValues(
+        $inputValue,
+        string $expectedException
+    ): void {
         $fieldType = $this->getFieldTypeUnderTest();
 
-        try {
-            $fieldType->acceptValue($inputValue);
-            $this->fail(
-                sprintf(
-                    'Expected exception of type "%s" not thrown for incorrect input to acceptValue().',
-                    $expectedException
-                )
-            );
-        } catch (Exception $e) {
-            if ($e instanceof \PHPUnit_Framework_Exception
-                 || $e instanceof \PHPUnit_Framework_Error
-                 || $e instanceof \PHPUnit_Framework_AssertionFailedError) {
-                throw $e;
-            }
-
-            $this->assertInstanceOf(
-                $expectedException,
-                $e
-            );
-        }
+        $this->expectException($expectedException);
+        $fieldType->acceptValue($inputValue);
     }
 
     /**

--- a/eZ/Publish/SPI/FieldType/Tests/FieldTypeTest.php
+++ b/eZ/Publish/SPI/FieldType/Tests/FieldTypeTest.php
@@ -7,7 +7,6 @@
 namespace eZ\Publish\SPI\FieldType\Tests;
 
 use PHPUnit\Framework\TestCase;
-use Exception;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition as APIFieldDefinition;
 use eZ\Publish\SPI\FieldType\Value as SPIValue;
 use eZ\Publish\SPI\FieldType\ValidationError;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | improvement
| **Target version** | test setup for eZ Platform Kernel 1.0
| **Doc needed**                       | no

We still had used some PHPUnit class names from `\PHPUnit_Framework_*` which were finally dropped in PHPUnit 8.

It applied to `MockObject` usage and exception expectations. For the latter one a more correct fix was due, which simplified our code a bit. While at it, some missing exception-related imports were fixed.

#### Checklist:
- [x] PR description is updated.
- [x] Tests are fixed.
- [x] Travis is passing.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
