### PR TITLE
[Composer] Restored required Behat dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,8 +55,10 @@
         "psr/event-dispatcher": "^1.0"
     },
     "require-dev": {
+        "behat/behat": "^3.6.1",
         "brianium/paratest": "^4.0",
         "jenner/simple_fork": "^1.2",
+        "friends-of-behat/mink-extension": "^2.4",
         "friendsofphp/php-cs-fixer": "^2.16.2",
         "ezsystems/ezplatform-code-style": "^0.1",
         "phpunit/phpunit": "^8.2",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | bug
| **Target eZ Platform version** | Behat setup of `v3.0`
| **Doc needed**                       | no

When moving our own BehatBundle out of Kernel, we've missed the fact that it installed dependencies providing `Behat\*` namespaces. Since Kernel defines its own Behat contexts, it's reasonable to `require-dev` the minimum set of dependencies:
* `behat/behat` providing `Behat\Behat`, used in all Contexts, e.g. in [BasicContentContext](https://github.com/ezsystems/ezplatform-kernel/blob/v1.0.2/eZ/Bundle/EzPublishCoreBundle/Features/Context/BasicContentContext.php#L9)
* `friends-of-behat/mink-extension` providing `Behat\MinkExtension` and via dependency `Behat\Mink`, used in some cases, e.g. in [QueryControllerContext](https://github.com/ezsystems/ezplatform-kernel/blob/v1.0.2/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryControllerContext.php#L12-L13)

Detected by static analysis via phpstan.

### Alternative

As an alternative we could move Contexts out of Kernel, but not sure if semantically it makes sense. If so, then where?

#### Checklist:
- [x] PR is ready for a review.
