### PR TITLE
EZP-31665: Fix wrapped user serilization

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
@@ -21,7 +21,7 @@ use Symfony\Component\Security\Core\User\UserInterface as CoreUserInterface;
  *     - wrappedUser: containing the originally matched user.
  *     - apiUser: containing the API User (the one from the eZ Repository )
  */
-class UserWrapped implements UserInterface, ReferenceUserInterface, EquatableInterface
+class UserWrapped implements ReferenceUserInterface, EquatableInterface
 {
     /** @var \Symfony\Component\Security\Core\User\UserInterface */
     private $wrappedUser;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31665](https://jira.ez.no/browse/EZP-31665)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes/no
| **Doc needed**                       | no

<!-- Replace this comment with Pull Request description -->

The wrapped apiUser should be serialized as a reference.

#### Checklist:
- [x] PR description is updated.
- [ ] Tests are implemented.
- [ ] Added code follows Coding Standards (use `$ composer fix-cs`).
- [ ] PR is ready for a review.
