### PR TITLE
EZP-31665: Serialize WrappedUser::apiUser as a reference.

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
@@ -100,7 +100,7 @@ class UserWrappedTest extends TestCase
         $this->assertFalse($user->isEqualTo($otherUser));
     }
 
-    public function testNotSerializeApiUser()
+    public function testNotSerializeApiUser(): void
     {
         $originalUser = $this->createMock(UserInterface::class);
         $user = new UserWrapped($originalUser, $this->apiUser);

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
@@ -99,6 +99,16 @@ class UserWrappedTest extends TestCase
             ->will($this->returnValue(false));
         $this->assertFalse($user->isEqualTo($otherUser));
     }
+
+    public function testNotSerializeApiUser()
+    {
+        $originalUser = $this->createMock(UserInterface::class);
+        $user = new UserWrapped($originalUser, $this->apiUser);
+        $serialized = serialize($user);
+        $unserializedUser = unserialize($serialized);
+        $this->expectException(\LogicException::class);
+        $unserializedUser->getApiUser();
+    }
 }
 
 /**

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
@@ -129,7 +129,7 @@ class UserWrapped implements ReferenceUserInterface, EquatableInterface
     public function isEqualTo(CoreUserInterface $user)
     {
         if ($user instanceof self) {
-            return $this->wrappedUser instanceof EquatableInterface ? $this->wrappedUser->isEqualTo($user->wrappedUser) : true;
+            $user = $user->wrappedUser;
         }
 
         return $this->wrappedUser instanceof EquatableInterface ? $this->wrappedUser->isEqualTo($user) : true;

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
@@ -7,9 +7,10 @@
 namespace eZ\Publish\Core\MVC\Symfony\Security;
 
 use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\Core\Repository\Values\User\UserReference;
+use InvalidArgumentException;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\UserInterface as CoreUserInterface;
-use InvalidArgumentException;
 
 /**
  * This class represents a UserWrapped object.
@@ -20,7 +21,7 @@ use InvalidArgumentException;
  *     - wrappedUser: containing the originally matched user.
  *     - apiUser: containing the API User (the one from the eZ Repository )
  */
-class UserWrapped implements UserInterface, EquatableInterface
+class UserWrapped implements ReferenceUserInterface, EquatableInterface
 {
     /** @var \Symfony\Component\Security\Core\User\UserInterface */
     private $wrappedUser;
@@ -28,10 +29,14 @@ class UserWrapped implements UserInterface, EquatableInterface
     /** @var \eZ\Publish\API\Repository\Values\User\User */
     private $apiUser;
 
+    /** @var \eZ\Publish\API\Repository\Values\User\UserReference */
+    private $apiUserReference;
+
     public function __construct(CoreUserInterface $wrappedUser, APIUser $apiUser)
     {
         $this->setWrappedUser($wrappedUser);
         $this->apiUser = $apiUser;
+        $this->apiUserReference = new UserReference($apiUser->getUserId());
     }
 
     public function __toString()
@@ -45,6 +50,7 @@ class UserWrapped implements UserInterface, EquatableInterface
     public function setAPIUser(APIUser $apiUser)
     {
         $this->apiUser = $apiUser;
+        $this->apiUserReference = new UserReference($apiUser->getUserId());
     }
 
     /**
@@ -52,13 +58,29 @@ class UserWrapped implements UserInterface, EquatableInterface
      */
     public function getAPIUser()
     {
+        if (!$this->apiUser instanceof APIUser) {
+            throw new \LogicException(
+                'Attempted to get APIUser before it has been set by UserProvider, APIUser is not serialized to session'
+            );
+        }
+
         return $this->apiUser;
     }
 
     /**
-     * @throws InvalidArgumentException If $wrappedUser is instance of self or User to avoid duplicated APIUser in session.
-     *
+     * @return \eZ\Publish\API\Repository\Values\User\UserReference
+     */
+    public function getAPIUserReference()
+    {
+        return $this->apiUserReference;
+    }
+
+    /**
      * @param \Symfony\Component\Security\Core\User\UserInterface $wrappedUser
+     *
+     * @throws InvalidArgumentException If $wrappedUser is instance of self or User to avoid duplicated APIUser in
+     *     session.
+     *
      */
     public function setWrappedUser(CoreUserInterface $wrappedUser)
     {
@@ -106,6 +128,22 @@ class UserWrapped implements UserInterface, EquatableInterface
 
     public function isEqualTo(CoreUserInterface $user)
     {
+        if ($user instanceof self) {
+            return $this->wrappedUser instanceof EquatableInterface ? $this->wrappedUser->isEqualTo($user->wrappedUser) : true;
+        }
+
         return $this->wrappedUser instanceof EquatableInterface ? $this->wrappedUser->isEqualTo($user) : true;
+    }
+
+    /*
+    * Make sure we don't serialize the whole API user object given it's a full fledged api content object. We set
+    * (& either way refresh) the user object in \eZ\Publish\Core\MVC\Symfony\Security\User\Provider->refreshUser()
+    * when object wakes back up from session.
+    *
+    * @return array
+    */
+    public function __sleep()
+    {
+        return ['wrappedUser', 'apiUserReference'];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
@@ -142,7 +142,7 @@ class UserWrapped implements ReferenceUserInterface, EquatableInterface
     *
     * @return array
     */
-    public function __sleep()
+    public function __sleep(): array
     {
         return ['wrappedUser', 'apiUserReference'];
     }

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
@@ -80,7 +80,6 @@ class UserWrapped implements ReferenceUserInterface, EquatableInterface
      *
      * @throws InvalidArgumentException If $wrappedUser is instance of self or User to avoid duplicated APIUser in
      *     session.
-     *
      */
     public function setWrappedUser(CoreUserInterface $wrappedUser)
     {

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
@@ -7,6 +7,7 @@
 namespace eZ\Publish\Core\MVC\Symfony\Security;
 
 use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\API\Repository\Values\User\UserReference as APIUserReference;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
 use InvalidArgumentException;
 use Symfony\Component\Security\Core\User\EquatableInterface;
@@ -70,7 +71,7 @@ class UserWrapped implements ReferenceUserInterface, EquatableInterface
     /**
      * @return \eZ\Publish\API\Repository\Values\User\UserReference
      */
-    public function getAPIUserReference()
+    public function getAPIUserReference(): APIUserReference
     {
         return $this->apiUserReference;
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31665](https://jira.ez.no/browse/EZP-31665)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

<!-- Replace this comment with Pull Request description -->

The wrapped apiUser should be serialized as a reference.

#### Checklist:
- [x] PR description is updated.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
