### PR TITLE
(minor) Fixed a typo in PhpDoc

### DIFF
--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
@@ -54,7 +54,7 @@ abstract class FieldDefinition extends ValueObject implements MultiLanguageName,
     protected $fieldGroup;
 
     /**
-     * the position of the field definition in the content typr.
+     * the position of the field definition in the content type.
      *
      * @var int
      */


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | bug/improvement
| **Target eZ Platform version** | `v2.5.x`/`v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | no (seems unrelated)
| **Doc needed**                       | no

Fixed a misspelled word in `$position` property's description.

Same on ezpublish-kernel (for eZ P. 2.5): https://github.com/ezsystems/ezpublish-kernel/pull/3044

#### Checklist:
- [x] PR description is updated.
- [ ] Tests are implemented.
- [ ] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
