### PR TITLE
EZP-31344: Added getFieldGroup method

### DIFF
--- a/eZ/Publish/Core/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsList.php
+++ b/eZ/Publish/Core/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsList.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\Helper\FieldsGroups;
 
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 /**
@@ -44,5 +45,25 @@ final class ArrayTranslatorFieldsGroupsList implements FieldsGroupsList
     public function getDefaultGroup()
     {
         return $this->defaultGroup;
+    }
+
+    public function getFieldGroup(FieldDefinition $fieldDefinition): string
+    {
+        if (empty($fieldDefinition->fieldGroup)) {
+            return $this->getDefaultGroup();
+        }
+
+        return $fieldDefinition->fieldGroup;
+    }
+
+    public function getFieldGroupTranslated(FieldDefinition $fieldDefinition): string
+    {
+        $groupId = $this->getFieldGroup($fieldDefinition);
+
+        if (array_key_exists($groupId, $this->groups)) {
+            return $this->groups[$groupId];
+        }
+
+        return $groupId;
     }
 }

--- a/eZ/Publish/Core/Helper/FieldsGroups/FieldsGroupsList.php
+++ b/eZ/Publish/Core/Helper/FieldsGroups/FieldsGroupsList.php
@@ -6,6 +6,8 @@
  */
 namespace eZ\Publish\Core\Helper\FieldsGroups;
 
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+
 /**
  * List of content fields groups.
  *
@@ -28,4 +30,18 @@ interface FieldsGroupsList
      * @return string
      */
     public function getDefaultGroup();
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
+     *
+     * @return string
+     */
+    public function getFieldGroup(FieldDefinition $fieldDefinition): string;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
+     *
+     * @return string
+     */
+    public function getFieldGroupTranslated(FieldDefinition $fieldDefinition): string;
 }

--- a/eZ/Publish/Core/Helper/Tests/FieldsGroups/ArrayTranslatorFieldsGroupsListTest.php
+++ b/eZ/Publish/Core/Helper/Tests/FieldsGroups/ArrayTranslatorFieldsGroupsListTest.php
@@ -6,70 +6,143 @@
  */
 namespace eZ\Publish\Core\Helper\Tests\FieldsGroups;
 
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Contracts\Translation\TranslatorInterface;
 
 class ArrayTranslatorFieldsGroupsListTest extends TestCase
 {
+    private const FIRST_GROUP_ID = 'slayer';
+    private const SECOND_GROUP_ID = 'system_of_a_down';
+    private const FIRST_GROUP_NAME = 'Slayer';
+    private const SECOND_GROUP_NAME = 'System of a down';
+
+    private const ALL_GROUPS_IDS = [self::FIRST_GROUP_ID, self::SECOND_GROUP_ID];
+    private const DEFAULT_GROUP_ID = self::SECOND_GROUP_ID;
+    private const DEFAULT_GROUP_NAME = self::SECOND_GROUP_NAME;
+
     private $translatorMock;
 
-    public function testTranslatesGroups()
+    /**
+     * @covers \eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList::getGroups
+     */
+    public function testTranslatesGroups(): void
     {
-        $groups = ['slayer', 'system_of_a_down'];
-        $default = 'system_of_a_down';
+        $this->applyTranslationsForTranslationsMock();
 
-        $this->getTranslatorMock()
-            ->expects($this->any())
-            ->method('trans')
-            ->will(
-                $this->returnValueMap([
-                    ['slayer', [], 'ezplatform_fields_groups', null, 'Slayer'],
-                    ['system_of_a_down', [], 'ezplatform_fields_groups', null, 'System of a down'],
-                ])
-            );
-
-        $list = $this->buildList($groups, $default);
+        $arrayTranslatorFieldsGroupsList = $this->getArrayTranslatorFieldsGroupsList();
 
         self::assertEquals(
             [
-                'slayer' => 'Slayer',
-                'system_of_a_down' => 'System of a down',
+                self::FIRST_GROUP_ID => self::FIRST_GROUP_NAME,
+                self::SECOND_GROUP_ID => self::SECOND_GROUP_NAME,
             ],
-            $list->getGroups()
+            $arrayTranslatorFieldsGroupsList->getGroups()
         );
     }
 
-    public function testReturnsDefault()
+    /**
+     * @covers \eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList::getDefaultGroup
+     */
+    public function testReturnsDefault(): void
     {
-        $list = $this->buildList([], 'A');
+        $list = $this->getArrayTranslatorFieldsGroupsList([]);
 
-        self::assertEquals('A', $list->getDefaultGroup());
+        self::assertEquals(self::DEFAULT_GROUP_ID, $list->getDefaultGroup());
     }
 
-    public function testUsesIdentifierIfNoTranslation()
+    /**
+     * @covers \eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList::getFieldGroup
+     */
+    public function testGetFieldGroupWhenFieldDefinitionHasGroup(): void
     {
-        $groups = ['slayer', 'system_of_a_down'];
-        $default = 'system_of_a_down';
+        $fieldDefinitionMock = $this->getFieldDefinitionMock(
+            [['fieldGroup' => self::FIRST_GROUP_ID]],
+        );
 
+        $arrayTranslatorFieldsGroupsList = $this->getArrayTranslatorFieldsGroupsList();
+
+        $this->assertSame(
+            $fieldDefinitionMock->fieldGroup,
+            $arrayTranslatorFieldsGroupsList->getFieldGroup($fieldDefinitionMock)
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList::getFieldGroup
+     */
+    public function testGetFieldGroupWhenFieldDefinitionMissingGroup(): void
+    {
+        $fieldDefinitionMock = $this->getFieldDefinitionMock();
+
+        $arrayTranslatorFieldsGroupsList = $this->getArrayTranslatorFieldsGroupsList();
+
+        $this->assertSame(
+            self::DEFAULT_GROUP_ID,
+            $arrayTranslatorFieldsGroupsList->getFieldGroup($fieldDefinitionMock)
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList::getFieldGroupTranslated
+     */
+    public function testGetFieldGroupTranslatedWhenFieldDefinitionHasGroup(): void
+    {
+        $fieldDefinitionMock = $this->getFieldDefinitionMock(
+            [['fieldGroup' => self::FIRST_GROUP_ID]],
+        );
+
+        $this->applyTranslationsForTranslationsMock();
+
+        $arrayTranslatorFieldsGroupsList = $this->getArrayTranslatorFieldsGroupsList();
+
+        $this->assertSame(
+            self::FIRST_GROUP_NAME,
+            $arrayTranslatorFieldsGroupsList->getFieldGroupTranslated($fieldDefinitionMock)
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList::getFieldGroupTranslated
+     */
+    public function testGetFieldGroupTranslatedWhenFieldDefinitionMissingGroup(): void
+    {
+        $fieldDefinitionMock = $this->getFieldDefinitionMock();
+
+        $this->applyTranslationsForTranslationsMock();
+
+        $arrayTranslatorFieldsGroupsList = $this->getArrayTranslatorFieldsGroupsList();
+
+        $this->assertSame(
+            self::DEFAULT_GROUP_NAME,
+            $arrayTranslatorFieldsGroupsList->getFieldGroupTranslated($fieldDefinitionMock)
+        );
+    }
+
+    public function testUsesIdentifierIfNoTranslation(): void
+    {
         $this->getTranslatorMock()
             ->expects($this->any())
             ->method('trans')
             ->will($this->returnArgument(0));
 
-        $list = $this->buildList($groups, $default);
+        $list = $this->getArrayTranslatorFieldsGroupsList();
 
         self::assertEquals(
             [
-                'slayer' => 'slayer',
-                'system_of_a_down' => 'system_of_a_down',
+                self::FIRST_GROUP_ID => self::FIRST_GROUP_ID,
+                self::SECOND_GROUP_ID => self::SECOND_GROUP_ID,
             ],
             $list->getGroups()
         );
     }
 
-    private function buildList($groups, $default)
-    {
+    private function getArrayTranslatorFieldsGroupsList(
+        array $groups = self::ALL_GROUPS_IDS,
+        string $default = self::DEFAULT_GROUP_ID
+    ): ArrayTranslatorFieldsGroupsList {
         return new ArrayTranslatorFieldsGroupsList(
             $this->getTranslatorMock(),
             $default,
@@ -80,12 +153,38 @@ class ArrayTranslatorFieldsGroupsListTest extends TestCase
     /**
      * @return \Symfony\Contracts\Translation\TranslatorInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function getTranslatorMock()
+    private function getTranslatorMock(): MockObject
     {
         if ($this->translatorMock === null) {
             $this->translatorMock = $this->createMock(TranslatorInterface::class);
         }
 
         return $this->translatorMock;
+    }
+
+    private function applyTranslationsForTranslationsMock(): void
+    {
+        $this->getTranslatorMock()
+            ->expects($this->any())
+            ->method('trans')
+            ->will(
+                $this->returnValueMap([
+                    [self::FIRST_GROUP_ID, [], 'ezplatform_fields_groups', null, self::FIRST_GROUP_NAME],
+                    [self::SECOND_GROUP_ID, [], 'ezplatform_fields_groups', null, self::SECOND_GROUP_NAME],
+                ])
+            );
+    }
+
+    /**
+     * @param array $constructorArgs
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function getFieldDefinitionMock(array $constructorArgs = []): MockObject
+    {
+        return $this
+            ->getMockBuilder(FieldDefinition::class)
+            ->setConstructorArgs($constructorArgs)
+            ->getMockForAbstractClass();
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | https://jira.ez.no/browse/EZP-31344
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.1`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

Added getFieldGroup method for FieldsGroupsList implementation.
Related PR: https://github.com/ezsystems/ezplatform-content-forms/pull/26

#### Checklist:
- [x] PR description is updated.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
