### PR TITLE
EZP-31671: Fix getRootLocation access to  private service

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -106,6 +106,7 @@ services:
         alias: ezpublish.templating.global_helper.core
 
     ezpublish.templating.global_helper:
+        public: true
         alias: ezpublish.templating.global_helper.core
 
     ezpublish.twig.extension.core:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31671](https://jira.ez.no/browse/EZP-31671)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes/no
| **Doc needed**                       | no

`eZ\Bundle\EzPublishCoreBundle\Controller::getGlobalHelper` tries to get `ezpublish.templating.global_helper` but this service is private.

#### Checklist:
- [x] PR description is updated.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
