### PR TITLE
[Composer] Set branch alias and dependencies for branch 1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/expression-language": "^5.0",
         "symfony/validator": "^5.0",
         "symfony/var-dumper": "^5.0",
-        "ezsystems/doctrine-dbal-schema": "^1.0@dev",
+        "ezsystems/doctrine-dbal-schema": "~1.0.0@dev",
         "ezsystems/routing": "^2.2",
         "guzzlehttp/guzzle": "^6.5",
         "php-http/guzzle6-adapter": "^2.0",
@@ -102,10 +102,10 @@
     "extra": {
         "_ci_branch-comment_": "Keep ci branch up-to-date with master or branch if on stable. ci is never on github but convention used for ci behat testing!",
         "_ezplatform_branch_for_behat_tests_comment_": "ezplatform branch to use to run Behat tests",
-        "_ezplatform_branch_for_behat_tests": "master",
+        "_ezplatform_branch_for_behat_tests": "3.0",
         "branch-alias": {
-            "dev-master": "1.1.x-dev",
-            "dev-tmp_ci_branch": "1.1.x-dev"
+            "dev-master": "1.0.x-dev",
+            "dev-tmp_ci_branch": "1.0.x-dev"
         },
         "thanks": {
             "name": "ezsystems/ezplatform",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Type**                                   | Composer stable branch configuration
| **Target eZ Platform version** | changes for 1.0 branch only, need to be reverted in master
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

1.0 branch has invalid branch alias set for Composer and is running tests using incorrect metareporitory and wrong dependencies. This PR fixes that.

#### Checklist:
- [x] PR description is updated.
- [x] PR is ready for a review.
