### PR TITLE
[WIP] EZP-31682: Support Argon2 password hashes

### DIFF
--- a/eZ/Publish/API/Repository/Values/User/User.php
+++ b/eZ/Publish/API/Repository/Values/User/User.php
@@ -30,8 +30,22 @@ abstract class User extends Content implements UserReference
     /** @var int Passwords hashed by PHPs default algorithm, which may change over time */
     const PASSWORD_HASH_PHP_DEFAULT = 7;
 
+    /** @var int Passwords in Argon2i */
+    const PASSWORD_HASH_ARGON2I = 8;
+
+    /** @var int Passwords in Argon2id */
+    const PASSWORD_HASH_ARGON2ID = 9;
+
     /** @var int Default password hash, used when none is specified, may change over time */
     const DEFAULT_PASSWORD_HASH = self::PASSWORD_HASH_PHP_DEFAULT;
+
+    /** @var int[] Password hash algoritms supported by PHP's password_hash() function, may change over time */
+    const PHP_PASSWORD_HASH_ALGORITHMS = [
+        self::PASSWORD_HASH_BCRYPT,
+        self::PASSWORD_HASH_PHP_DEFAULT,
+        self::PASSWORD_HASH_ARGON2I,
+        self::PASSWORD_HASH_ARGON2ID,
+    ];
 
     /**
      * User login.

--- a/eZ/Publish/Core/Repository/User/PasswordHashService.php
+++ b/eZ/Publish/Core/Repository/User/PasswordHashService.php
@@ -40,6 +40,20 @@ final class PasswordHashService implements PasswordHashServiceInterface
             case User::PASSWORD_HASH_PHP_DEFAULT:
                 return password_hash($password, PASSWORD_DEFAULT);
 
+            case User::PASSWORD_HASH_ARGON2I:
+                if (!defined('PASSWORD_ARGON2I')) {
+                    throw new InvalidArgumentException('hashType', "Password hash algorithm 'PASSWORD_ARGON2I' is not compiled into PHP");
+                }
+
+                return password_hash($password, PASSWORD_ARGON2I);
+
+            case User::PASSWORD_HASH_ARGON2ID:
+                if (!defined('PASSWORD_ARGON2ID')) {
+                    throw new InvalidArgumentException('hashType', "Password hash algorithm 'PASSWORD_ARGON2ID' is not compiled into PHP");
+                }
+
+                return password_hash($password, PASSWORD_ARGON2ID);
+
             default:
                 throw new InvalidArgumentException('hashType', "Password hash type '$hashType' is not recognized");
         }
@@ -47,8 +61,8 @@ final class PasswordHashService implements PasswordHashServiceInterface
 
     public function isValidPassword(string $plainPassword, string $passwordHash, ?int $hashType = null): bool
     {
-        if ($hashType === User::PASSWORD_HASH_BCRYPT || $hashType === User::PASSWORD_HASH_PHP_DEFAULT) {
-            // In case of bcrypt let php's password functionality do it's magic
+        if (in_array($hashType, User::PHP_PASSWORD_HASH_ALGORITHMS, true)) {
+            // Let php's password functionality do it's magic
             return password_verify($plainPassword, $passwordHash);
         }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31682](https://jira.ez.no/browse/EZP-31682)
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | tbd
| **Doc needed**                       | yes

Add support for Argon2 password hashes, which are supported in PHP 7.2 / 7.3 but optional, PHP must be compiled with support for them.
https://www.php.net/manual/en/function.password-hash.php

Out of scope: Add support for the various cost/threads options. We could add this for bcrypt too.

#### Checklist:
- [x] PR description is updated.
- [ ] Tests are implemented.
- [ ] Added code follows Coding Standards (use `$ composer fix-cs`).
- [ ] PR is ready for a review.
- [ ] isValidPassword() also needs to check if support is compiled in, refactor to do this all in one place.