### PR TITLE
EZEE-3191: Fixed wrong array key used in Version validation

### DIFF
--- a/eZ/Publish/Core/Repository/Validator/VersionValidator.php
+++ b/eZ/Publish/Core/Repository/Validator/VersionValidator.php
@@ -69,7 +69,7 @@ final class VersionValidator implements ContentValidator
 
                 if ($fieldType->isEmptyValue($fieldValue)) {
                     if ($fieldDefinition->isRequired) {
-                        $allFieldErrors[$fieldDefinition->id][$languageCode] = new ValidationError(
+                        $allFieldErrors[$fieldDefinition->identifier][$languageCode] = new ValidationError(
                             "Value for required field definition '%identifier%' with language '%languageCode%' is empty",
                             null,
                             ['%identifier%' => $fieldDefinition->identifier, '%languageCode%' => $languageCode],


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZEE-3191](https://jira.ez.no/browse/EZEE-3191)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.1`
| **BC breaks**                          | yes
| **Tests pass**                          | yes
| **Doc needed**                       | no

## Required by: https://github.com/ezsystems/ezplatform-workflow/pull/142

#### Checklist:
- [x] PR description is updated.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.