### PR TITLE
EZP-31595: Parametrized embedded Content's URL generation

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed.html.twig
@@ -1,7 +1,11 @@
 {% set content_name=ez_content_name(content) %}
 
-{% if location is defined %}
-    <h3><a href="{{ ez_path(location) }}">{{ content_name }}</a></h3>
+{% if objectParameters.doNotGenerateEmbedUrl is defined and objectParameters.doNotGenerateEmbedUrl %}
+    {{ content.name }}
 {% else %}
-    <h3><a href="{{ ez_path(content) }}">{{ content_name }}</a></h3>
+    {% if location is defined %}
+        <h3><a href="{{ ez_path(location) }}">{{ content_name }}</a></h3>
+    {% else %}
+        <h3><a href="{{ ez_path(content) }}">{{ content_name }}</a></h3>
+    {% endif %}
 {% endif %}

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed.html.twig
@@ -1,7 +1,7 @@
 {% set content_name=ez_content_name(content) %}
 
 {% if objectParameters.doNotGenerateEmbedUrl is defined and objectParameters.doNotGenerateEmbedUrl %}
-    {{ content.name }}
+    <h3>{{ content.name }}</h3>
 {% else %}
     {% if location is defined %}
         <h3><a href="{{ ez_path(location) }}">{{ content_name }}</a></h3>

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed_inline.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/embed_inline.html.twig
@@ -4,8 +4,12 @@
         : ''
 %}
 
-{% if location is defined %}
-    <a href="{{ ez_path(location) }}"{% if class is defined %} class="{{ class }}"{% endif %}{{ data_attributes_str|raw }}>{{ content.name }}</a>
+{% if objectParameters.doNotGenerateEmbedUrl is defined and objectParameters.doNotGenerateEmbedUrl %}
+    <span {% if class is defined %} class="{{ class }}"{% endif %}{{ data_attributes_str|raw }}>{{ content.name }}</span>
 {% else %}
-    <a href="{{ ez_path(content) }}"{% if class is defined %} class="{{ class }}"{% endif %}{{ data_attributes_str|raw }}>{{ content.name }}</a>
+    {% if location is defined %}
+        <a href="{{ ez_path(location) }}"{% if class is defined %} class="{{ class }}"{% endif %}{{ data_attributes_str|raw }}>{{ content.name }}</a>
+    {% else %}
+        <a href="{{ ez_path(content) }}"{% if class is defined %} class="{{ class }}"{% endif %}{{ data_attributes_str|raw }}>{{ content.name }}</a>
+    {% endif %}
 {% endif %}

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -154,13 +154,12 @@ class ContentViewBuilder implements ViewBuilder
             $view->setLocation($location);
         }
 
-        if ($view->isEmbed()) {
-            if (
-                $this->permissionResolver->canUser('content', 'view_embed', $content->contentInfo)
-                && !$this->permissionResolver->canUser('content', 'read', $content->contentInfo)
-            ) {
-                $parameters['params']['objectParameters'] = ['doNotGenerateEmbedUrl' => true];
-            }
+        if (
+            $view->isEmbed()
+            && $this->permissionResolver->canUser('content', 'view_embed', $content->contentInfo)
+            && !$this->permissionResolver->canUser('content', 'read', $content->contentInfo)
+        ) {
+            $parameters['params']['objectParameters'] = ['doNotGenerateEmbedUrl' => true];
         }
 
         $this->viewParametersInjector->injectViewParameters($view, $parameters);

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -154,6 +154,15 @@ class ContentViewBuilder implements ViewBuilder
             $view->setLocation($location);
         }
 
+        if ($view->isEmbed()) {
+            if (
+                $this->permissionResolver->canUser('content', 'view_embed', $content->contentInfo)
+                && !$this->permissionResolver->canUser('content', 'read', $content->contentInfo)
+            ) {
+                $parameters['params']['objectParameters'] = ['doNotGenerateEmbedUrl' => true];
+            }
+        }
+
         $this->viewParametersInjector->injectViewParameters($view, $parameters);
         $this->viewConfigurator->configure($view);
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31595](https://jira.ez.no/browse/EZP-31595)
| **Type**                                   | bug
| **Target eZ Platform version** | v3.0
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

This PR is a direct continuation of the following PR: https://github.com/ezsystems/ezplatform-kernel/pull/57

The additional parameter has been added to embed views that checks whether the generation of embed Contents' URLs is permitted - if not, the link will not be generated and will be replaced by Content's name.

#### Checklist:
- [x] PR description is updated.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
