### PR TITLE
EZP-31701: Marked ezpublish.spi.search_engine as lazy

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -55,6 +55,7 @@ services:
         class: eZ\Publish\SPI\Search\Handler
         factory: ["@ezpublish.api.search_engine.factory", buildSearchEngine]
         public: false
+        lazy: true
 
     ezpublish.spi.search_engine.indexer:
         class: eZ\Publish\Core\Search\Common\Indexer


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31701](https://jira.ez.no/browse/EZP-31701)
| **Type**                                   | bug
| **Target eZ Platform version** | `3.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

`ez publish.api.search engine` depends on repository configuration
https://github.com/ezsystems/ezplatform-kernel/blob/b79252a6040048e826e085fbed099b942c693a39/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineFactory.php#L66
but service is instantiated before site access matching. As result it always created with configuration for default siteaccess.

More details (including steps to reproduce) in JIRA issue. 

#### Checklist:
- [X] PR description is updated.
- [ ] ~Tests are implemented.~
- [X] Added code follows Coding Standards (use `$ composer fix-cs`).
- [X] PR is ready for a review.
