### PR TITLE
EZP-31344: Removed one unused method (unused after front refactor)

### DIFF
--- a/eZ/Publish/Core/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsList.php
+++ b/eZ/Publish/Core/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsList.php
@@ -55,15 +55,4 @@ final class ArrayTranslatorFieldsGroupsList implements FieldsGroupsList
 
         return $fieldDefinition->fieldGroup;
     }
-
-    public function getFieldGroupTranslated(FieldDefinition $fieldDefinition): string
-    {
-        $groupId = $this->getFieldGroup($fieldDefinition);
-
-        if (array_key_exists($groupId, $this->groups)) {
-            return $this->groups[$groupId];
-        }
-
-        return $groupId;
-    }
 }

--- a/eZ/Publish/Core/Helper/FieldsGroups/FieldsGroupsList.php
+++ b/eZ/Publish/Core/Helper/FieldsGroups/FieldsGroupsList.php
@@ -37,11 +37,4 @@ interface FieldsGroupsList
      * @return string
      */
     public function getFieldGroup(FieldDefinition $fieldDefinition): string;
-
-    /**
-     * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition
-     *
-     * @return string
-     */
-    public function getFieldGroupTranslated(FieldDefinition $fieldDefinition): string;
 }

--- a/eZ/Publish/Core/Helper/Tests/FieldsGroups/ArrayTranslatorFieldsGroupsListTest.php
+++ b/eZ/Publish/Core/Helper/Tests/FieldsGroups/ArrayTranslatorFieldsGroupsListTest.php
@@ -85,42 +85,6 @@ class ArrayTranslatorFieldsGroupsListTest extends TestCase
         );
     }
 
-    /**
-     * @covers \eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList::getFieldGroupTranslated
-     */
-    public function testGetFieldGroupTranslatedWhenFieldDefinitionHasGroup(): void
-    {
-        $fieldDefinitionMock = $this->getFieldDefinitionMock(
-            [['fieldGroup' => self::FIRST_GROUP_ID]],
-        );
-
-        $this->applyTranslationsForTranslationsMock();
-
-        $arrayTranslatorFieldsGroupsList = $this->getArrayTranslatorFieldsGroupsList();
-
-        $this->assertSame(
-            self::FIRST_GROUP_NAME,
-            $arrayTranslatorFieldsGroupsList->getFieldGroupTranslated($fieldDefinitionMock)
-        );
-    }
-
-    /**
-     * @covers \eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList::getFieldGroupTranslated
-     */
-    public function testGetFieldGroupTranslatedWhenFieldDefinitionMissingGroup(): void
-    {
-        $fieldDefinitionMock = $this->getFieldDefinitionMock();
-
-        $this->applyTranslationsForTranslationsMock();
-
-        $arrayTranslatorFieldsGroupsList = $this->getArrayTranslatorFieldsGroupsList();
-
-        $this->assertSame(
-            self::DEFAULT_GROUP_NAME,
-            $arrayTranslatorFieldsGroupsList->getFieldGroupTranslated($fieldDefinitionMock)
-        );
-    }
-
     public function testUsesIdentifierIfNoTranslation(): void
     {
         $this->getTranslatorMock()


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | https://jira.ez.no/browse/EZP-31344
| **Type**                                   | improvement/clean
| **Target eZ Platform version** | `v3.1`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

Complement for:
https://github.com/ezsystems/ezplatform-kernel/pull/73 / https://github.com/ezsystems/ezplatform-content-forms/pull/28

Removed one unused method (after content-forms refactor)

#### Checklist:
- [x] PR description is updated.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.