### PR TITLE
EZP-31650: Aligned tag names of Trash filtering Sort Clauses

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentName.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentName.php
@@ -11,11 +11,12 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\SPI\Repository\Values\Filter\FilteringSortClause;
+use eZ\Publish\SPI\Repository\Values\Trash\Query\SortClause as TrashSortClause;
 
 /**
  * Sets sort direction on Content name for a content query.
  */
-class ContentName extends SortClause implements FilteringSortClause
+class ContentName extends SortClause implements FilteringSortClause, TrashSortClause
 {
     /**
      * Constructs a new ContentName SortClause.

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Depth.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Depth.php
@@ -11,11 +11,12 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
 use eZ\Publish\SPI\Repository\Values\Filter\FilteringSortClause;
+use eZ\Publish\SPI\Repository\Values\Trash\Query\SortClause as TrashSortClause;
 
 /**
  * Sets sort direction on the Location depth for a Location query.
  */
-class Depth extends Location implements FilteringSortClause
+class Depth extends Location implements FilteringSortClause, TrashSortClause
 {
     /**
      * Constructs a new LocationDepth SortClause.

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Path.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Path.php
@@ -11,11 +11,12 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
 use eZ\Publish\SPI\Repository\Values\Filter\FilteringSortClause;
+use eZ\Publish\SPI\Repository\Values\Trash\Query\SortClause as TrashSortClause;
 
 /**
  * Sets sort direction on the Location path for a Location query.
  */
-class Path extends Location implements FilteringSortClause
+class Path extends Location implements FilteringSortClause, TrashSortClause
 {
     /**
      * Constructs a new LocationPath SortClause.

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Priority.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Priority.php
@@ -11,11 +11,12 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Location;
 use eZ\Publish\SPI\Repository\Values\Filter\FilteringSortClause;
+use eZ\Publish\SPI\Repository\Values\Trash\Query\SortClause as TrashSortClause;
 
 /**
  * Sets sort direction on the Location priority for a Location query.
  */
-class Priority extends Location implements FilteringSortClause
+class Priority extends Location implements FilteringSortClause, TrashSortClause
 {
     /**
      * Constructs a new LocationPriority SortClause.

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/SectionName.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/SectionName.php
@@ -11,11 +11,12 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
 use eZ\Publish\SPI\Repository\Values\Filter\FilteringSortClause;
+use eZ\Publish\SPI\Repository\Values\Trash\Query\SortClause as TrashSortClause;
 
 /**
  * Sets sort direction on Section name for a content query.
  */
-class SectionName extends SortClause implements FilteringSortClause
+class SectionName extends SortClause implements FilteringSortClause, TrashSortClause
 {
     /**
      * Constructs a new SectionName SortClause.

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/ContentTypeName.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/ContentTypeName.php
@@ -10,8 +10,9 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Trash;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\SPI\Repository\Values\Trash\Query\SortClause as TrashSortClause;
 
-class ContentTypeName extends SortClause
+class ContentTypeName extends SortClause implements TrashSortClause
 {
     public function __construct(string $sortDirection = Query::SORT_ASC)
     {

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/DateTrashed.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/DateTrashed.php
@@ -10,11 +10,9 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Trash;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\SPI\Repository\Values\Trash\Query\SortClause as TrashSortClause;
 
-/**
- * Sets sort direction on the Trashed Location date for a Location query.
- */
-class DateTrashed extends SortClause
+class DateTrashed extends SortClause implements TrashSortClause
 {
     public function __construct(string $sortDirection = Query::SORT_ASC)
     {

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/UserLogin.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/UserLogin.php
@@ -10,8 +10,9 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Trash;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\SPI\Repository\Values\Trash\Query\SortClause as TrashSortClause;
 
-class UserLogin extends SortClause
+class UserLogin extends SortClause implements TrashSortClause
 {
     public function __construct(string $sortDirection = Query::SORT_ASC)
     {

--- a/eZ/Publish/Core/Base/Container/Compiler/Search/Legacy/SortClauseConverterPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Search/Legacy/SortClauseConverterPass.php
@@ -48,7 +48,7 @@ class SortClauseConverterPass implements CompilerPassInterface
         if ($container->hasDefinition('ezplatform.trash.search.legacy.gateway.sort_clause_converter')) {
             $sortClauseConverterTrash = $container->getDefinition('ezplatform.trash.search.legacy.gateway.sort_clause_converter');
 
-            $trashHandlers = $container->findTaggedServiceIds('ezpublish.search.legacy.gateway.sort_clause_handler.trash');
+            $trashHandlers = $container->findTaggedServiceIds('ezpublish.trash.search.legacy.gateway.sort_clause_handler');
 
             $this->addHandlers($sortClauseConverterTrash, $trashHandlers);
         }

--- a/eZ/Publish/Core/Base/Container/Compiler/Search/Legacy/SortClauseConverterPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Search/Legacy/SortClauseConverterPass.php
@@ -48,7 +48,7 @@ class SortClauseConverterPass implements CompilerPassInterface
         if ($container->hasDefinition('ezplatform.trash.search.legacy.gateway.sort_clause_converter')) {
             $sortClauseConverterTrash = $container->getDefinition('ezplatform.trash.search.legacy.gateway.sort_clause_converter');
 
-            $trashHandlers = $container->findTaggedServiceIds('ezpublish.trash.search.legacy.gateway.sort_clause_handler');
+            $trashHandlers = $container->findTaggedServiceIds('ezplatform.trash.search.legacy.gateway.sort_clause_handler');
 
             $this->addHandlers($sortClauseConverterTrash, $trashHandlers);
         }

--- a/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_common.yml
@@ -17,7 +17,7 @@ services:
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.trash}
+            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.date_modified:
         parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
@@ -62,7 +62,7 @@ services:
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.trash}
+            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
 
     eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Factory\RandomSortClauseHandlerFactory:
         arguments:
@@ -94,17 +94,17 @@ services:
     eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Trash\ContentTypeName:
         parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.trash}
+            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
 
     eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Trash\UserLogin:
         parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.trash}
+            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
 
     eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Trash\DateTrashed:
         parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.trash}
+            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
 
     # BC
     ezpublish.search.legacy.gateway.sort_clause_handler.base: '@eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler'

--- a/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_common.yml
@@ -17,7 +17,7 @@ services:
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.common.date_modified:
         parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
@@ -62,7 +62,7 @@ services:
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.content}
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
 
     eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Factory\RandomSortClauseHandlerFactory:
         arguments:
@@ -94,17 +94,17 @@ services:
     eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Trash\ContentTypeName:
         parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
-            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
 
     eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Trash\UserLogin:
         parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
-            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
 
     eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler\Trash\DateTrashed:
         parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler
         tags:
-            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
 
     # BC
     ezpublish.search.legacy.gateway.sort_clause_handler.base: '@eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler'

--- a/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_location.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_location.yml
@@ -16,14 +16,14 @@ services:
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location\Depth
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.trash}
+            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.location.path:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location\Path
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.trash}
+            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.location.is_main_location:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
@@ -36,7 +36,7 @@ services:
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location\Priority
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezpublish.search.legacy.gateway.sort_clause_handler.trash}
+            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.location.visibility:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base

--- a/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_location.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/sort_clause_handlers_location.yml
@@ -16,14 +16,14 @@ services:
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location\Depth
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.location.path:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location\Path
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.location.is_main_location:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base
@@ -36,7 +36,7 @@ services:
         class: eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location\Priority
         tags:
             - {name: ezpublish.search.legacy.gateway.sort_clause_handler.location}
-            - {name: ezpublish.trash.search.legacy.gateway.sort_clause_handler}
+            - {name: ezplatform.trash.search.legacy.gateway.sort_clause_handler}
 
     ezpublish.search.legacy.gateway.sort_clause_handler.location.visibility:
         parent: ezpublish.search.legacy.gateway.sort_clause_handler.base


### PR DESCRIPTION
Complement for https://github.com/ezsystems/ezplatform-kernel/pull/80

Unification of tag names
Implemented interface eZ\Publish\SPI\Repository\Values\Trash\Query\SortClause for Trash SortClauses