### PR TITLE
Allowed LogicalOr/LogicalNot/MatchAll/MatchNone criteria be used as part of the Trash query

### DIFF
--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -1149,6 +1149,42 @@ class TrashServiceTest extends BaseTrashServiceTest
                 ],
                 0,
             ],
+            [
+                [
+                    new Criterion\MatchNone(),
+                ],
+                0,
+            ],
+            [
+                [
+                    new Criterion\MatchAll(),
+                ],
+                2,
+            ],
+            [
+                [
+                    new Criterion\LogicalNot(new Criterion\SectionId(2)),
+                ],
+                1,
+            ],
+            [
+                [
+                    new Criterion\LogicalOr([
+                        new Criterion\SectionId(1),
+                        new Criterion\ContentTypeId(4),
+                    ]),
+                ],
+                2,
+            ],
+            [
+                [
+                    new Criterion\LogicalAnd([
+                        new Criterion\SectionId(2),
+                        new Criterion\ContentTypeId(4),
+                    ]),
+                ],
+                1,
+            ],
         ];
     }
 

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalNot.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalNot.php
@@ -10,11 +10,12 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\SPI\Repository\Values\Filter\FilteringCriterion;
+use eZ\Publish\SPI\Repository\Values\Trash\Query\Criterion as TrashCriterion;
 
 /**
  * A NOT logical criterion.
  */
-class LogicalNot extends LogicalOperator implements FilteringCriterion
+class LogicalNot extends LogicalOperator implements FilteringCriterion, TrashCriterion
 {
     /**
      * Creates a new NOT logic criterion.

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOr.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOr.php
@@ -9,11 +9,12 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\SPI\Repository\Values\Filter\FilteringCriterion;
+use eZ\Publish\SPI\Repository\Values\Trash\Query\Criterion as TrashCriterion;
 
 /**
  * This criterion implements a logical OR criterion and will only match
  * if AT LEAST ONE of the given criteria match.
  */
-class LogicalOr extends LogicalOperator implements FilteringCriterion
+class LogicalOr extends LogicalOperator implements FilteringCriterion, TrashCriterion
 {
 }

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchAll.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchAll.php
@@ -10,11 +10,12 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\SPI\Repository\Values\Filter\FilteringCriterion;
+use eZ\Publish\SPI\Repository\Values\Trash\Query\Criterion as TrashCriterion;
 
 /**
  * A criterion that just matches everything.
  */
-class MatchAll extends Criterion implements FilteringCriterion
+class MatchAll extends Criterion implements FilteringCriterion, TrashCriterion
 {
     /**
      * Creates a new MatchAll criterion.

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchNone.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchNone.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\SPI\Repository\Values\Filter\FilteringCriterion;
+use eZ\Publish\SPI\Repository\Values\Trash\Query\Criterion as TrashCriterion;
 
 /**
  * A criterion that just matches nothing.
@@ -17,7 +18,7 @@ use eZ\Publish\SPI\Repository\Values\Filter\FilteringCriterion;
  * Useful for BlockingLimitation type, where a limitation is typically missing and needs to
  * tell the system should block everything within the OR conditions it might be part of.
  */
-class MatchNone extends Criterion implements FilteringCriterion
+class MatchNone extends Criterion implements FilteringCriterion, TrashCriterion
 {
     public function __construct()
     {

--- a/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
+++ b/eZ/Publish/Core/settings/search_engines/legacy/criterion_handlers_common.yml
@@ -161,6 +161,7 @@ services:
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.logical_or:
         parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
@@ -168,6 +169,7 @@ services:
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.map_location_distance:
         parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldBase
@@ -182,6 +184,7 @@ services:
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.match_none:
         parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler
@@ -189,6 +192,7 @@ services:
         tags:
             - {name: ezpublish.search.legacy.gateway.criterion_handler.content}
             - {name: ezpublish.search.legacy.gateway.criterion_handler.location}
+            - {name: ezplatform.trash.search.legacy.gateway.criterion_handler}
 
     ezpublish.search.legacy.gateway.criterion_handler.common.object_state_id:
         parent: eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler

--- a/eZ/Publish/SPI/Repository/Values/Trash/Query/Criterion.php
+++ b/eZ/Publish/SPI/Repository/Values/Trash/Query/Criterion.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 
 namespace eZ\Publish\SPI\Repository\Values\Trash\Query;
 
+/**
+ * Marker for Content & Location trash Criterion.
+ */
 interface Criterion
 {
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.1`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | yes

Allowed the following criteria be used as part of the Trash query:

* `eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalNot`
* `eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOr`
* `eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchAll`
* `eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchNone`

Follow up for https://github.com/ezsystems/ezplatform-kernel/pull/80. 

#### Checklist:
- [X] PR description is updated.
- [x] Tests are implemented.
- [X] Added code follows Coding Standards (use `$ composer fix-cs`).
- [X] PR is ready for a review.
