### PR TITLE
[Tests] Bumped Solr Bundle version to test using the latest one

### DIFF
--- a/bin/.travis/prepare_unittest.sh
+++ b/bin/.travis/prepare_unittest.sh
@@ -41,8 +41,9 @@ composer config -g github-oauth.github.com "d0285ed5c8644f30547572ead2ed897431c1
 if [ "$TEST_CONFIG" = "phpunit-integration-legacy-solr.xml" ] ; then
     # Install openJDK8 as default v11 is too new for SOLR
     sudo apt-get install openjdk-8-jdk
-    echo "> Require ezsystems/ezplatform-solr-search-engine:^3.0.0@dev"
-    composer require --no-update ezsystems/ezplatform-solr-search-engine:^3.0.0@dev
+    solr_require_cmd='composer require --no-update ezsystems/ezplatform-solr-search-engine:~3.0.3@dev'
+    echo "> ${solr_require_cmd}"
+    ${solr_require_cmd}
 fi
 
 # Switch to another Symfony version if asked for


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Target branch**                      | 1.0+

Bumped Solr Bundle to unreleased version `~3.0.3` to force testing on stable branch. Intentionally using tilde to avoid installing the newer tag `v3.1.0` which does not contain required changes.

### TODO
- [x] Wait for Travis
- [ ] Adjust on the merge up to `1.1` and `master`
