### PR TITLE
LegacyStorageFileRowReader: handle the case when statement->fetch returns false

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageFileRowReader.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageFileRowReader.php
@@ -42,7 +42,7 @@ abstract class LegacyStorageFileRowReader implements FileRowReaderInterface
     {
         $row = $this->statement->fetch();
 
-        return $this->prependMimeToPath($row['filename'], $row['mime_type']);
+        return is_array($row) ? $this->prependMimeToPath($row['filename'], $row['mime_type']) : null;
     }
 
     final public function getCount()

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageFileRowReader.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageFileRowReader.php
@@ -42,7 +42,7 @@ abstract class LegacyStorageFileRowReader implements FileRowReaderInterface
     {
         $row = $this->statement->fetch();
 
-        return is_array($row) ? $this->prependMimeToPath($row['filename'], $row['mime_type']) : null;
+        return false !== $row ? $this->prependMimeToPath($row['filename'], $row['mime_type']) : null;
     }
 
     final public function getCount()


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31748](https://jira.ez.no/browse/EZP-31748)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.0.5`, `v3.1.0`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

In some cases `ezplatform:io:migrate-files` command fails because of the following error:
```bash
bin/console ezplatform:io:migrate-files --from=default,default --to=XXX,YYY --no-interaction -vvv

...

In LegacyStorageFileRowReader.php line 45:
 
 [ErrorException] 
 Notice: Trying to access array offset on value of type bool

```
#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
