### PR TITLE
[Composer] Added conflict with Symfony Cache 5.0.11 and 5.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -65,6 +65,7 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1"
     },
     "conflict": {
+        "symfony/cache": "5.0.11 || 5.1.3",
         "doctrine/dbal": "2.7.0",
         "ezsystems/ezpublish-legacy": "*",
         "phpunit/phpunit": "8.4.0"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.0`+
| **Doc needed**                       | no

Merge up of ezsystems/ezpublish-kernel#3049 and adjustment for Symfony 5. Since components are split here, I've manged to narrow it down to `symfony/cache` package, thus setting conflicts with Symfony Cache [5.0.11](https://github.com/symfony/symfony/releases/tag/v5.0.11) and [5.1.3](https://github.com/symfony/symfony/releases/tag/v5.1.3)

#### Checklist:
- [x] PR description is updated.
- [x] Travis is green.