### PR TITLE
ezpublish.spi.search_engine not lazy

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -55,7 +55,6 @@ services:
         class: eZ\Publish\SPI\Search\Handler
         factory: ["@ezpublish.api.search_engine.factory", buildSearchEngine]
         public: false
-        lazy: true
 
     ezpublish.spi.search_engine.indexer:
         class: eZ\Publish\Core\Search\Common\Indexer


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31781](https://jira.ez.no/browse/EZP-31781)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.1` and probably previous versions
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

With lazy, the search engine don't tell that it implements [Capable](https://github.com/ezsystems/ezplatform-kernel/blob/master/eZ/Publish/SPI/Search/Capable.php)

#### Checklist:
- [x] PR description is updated.
- [ ] Tests are implemented.
- [ ] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
