### PR TITLE
EZP-27458: Provided Aggregation API

### DIFF
--- a/eZ/Publish/API/Repository/SearchService.php
+++ b/eZ/Publish/API/Repository/SearchService.php
@@ -108,6 +108,13 @@ interface SearchService
     public const CAPABILITY_ADVANCED_FULLTEXT = 64;
 
     /**
+     * Capability flag for aggregation feature for use with {@see ::supports()}.
+     *
+     * @since eZ Platform 3.2
+     */
+    public const CAPABILITY_AGGREGATIONS = 128;
+
+    /**
      * Finds content objects for the given query.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if query is not valid

--- a/eZ/Publish/API/Repository/Tests/SearchServiceAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceAggregationTest.php
@@ -1,0 +1,890 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests;
+
+use DateTime;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ContentTypeGroupTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ContentTypeTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\DateMetadataRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CheckboxTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CountryTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\DateRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\DateTimeRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\FloatRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\FloatStatsAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\IntegerRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\IntegerStatsAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\KeywordTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\SelectionTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\TimeRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\LanguageTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ObjectStateTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawStatsAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\SectionTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\UserMetadataTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\VisibilityTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeIdentifier;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchAll;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\RangeAggregationResult;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\RangeAggregationResultEntry;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\StatsAggregationResult;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\TermAggregationResult;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
+use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
+use eZ\Publish\Core\FieldType\Checkbox\Value as CheckboxValue;
+use eZ\Publish\Core\FieldType\Time\Value as TimeValue;
+
+/**
+ * Test case for aggregations in the SearchService.
+ *
+ * @see \eZ\Publish\API\Repository\SearchService
+ * @group integration
+ * @group search
+ * @group aggregations
+ */
+final class SearchServiceAggregationTest extends BaseTest
+{
+    private const EXAMPLE_COUNTRY_FIELD_VALUES = [
+        ['PL', 'US'],
+        ['FR', 'US'],
+        ['US'],
+        ['GA', 'PL', 'FR'],
+        ['FR', 'BE', 'US'],
+    ];
+
+    private const EXAMPLE_KEYWORD_FIELD_VALUES = [
+        ['foo'],
+        ['foo', 'bar'],
+        ['foo', 'bar', 'baz'],
+    ];
+
+    private const EXAMPLE_SELECTION_FIELD_VALUES = [
+        [0],
+        [0, 1],
+        [0, 1, 2],
+    ];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $searchService = $this->getRepository()->getSearchService();
+        if (!$searchService->supports(SearchService::CAPABILITY_AGGREGATIONS)) {
+            self::markTestSkipped("Search engine doesn't support aggregations");
+        }
+    }
+
+    /**
+     * @dataProvider dataProviderForTestAggregation
+     */
+    public function testFindContentWithAggregation(
+        Aggregation $aggregation,
+        AggregationResult $expectedResult
+    ): void {
+        $searchService = $this->getRepository()->getSearchService();
+
+        $query = new Query();
+        $query->aggregations[] = $aggregation;
+        $query->filter = new MatchAll();
+        $query->limit = 0;
+
+        self::assertEquals(
+            $expectedResult,
+            $searchService->findContent($query)->aggregations->first()
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderForTestAggregation
+     */
+    public function testFindLocationWithAggregation(
+        Aggregation $aggregation,
+        AggregationResult $expectedResult
+    ): void {
+        $searchService = $this->getRepository()->getSearchService();
+
+        $query = new LocationQuery();
+        $query->aggregations[] = $aggregation;
+        $query->filter = new MatchAll();
+        $query->limit = 0;
+
+        self::assertEquals(
+            $expectedResult,
+            $searchService->findLocations($query)->aggregations->first()
+        );
+    }
+
+    public function dataProviderForTestAggregation(): iterable
+    {
+        $contentTypeService = $this->getRepository()->getContentTypeService();
+
+        yield ContentTypeTermAggregation::class => $this->createTermAggregationTestCase(
+            new ContentTypeTermAggregation('content_type'),
+            [
+                'folder' => 6,
+                'user_group' => 6,
+                'user' => 2,
+                'common_ini_settings' => 1,
+                'template_look' => 1,
+                'feedback_form' => 1,
+                'landing_page' => 1,
+            ],
+            [$contentTypeService, 'loadContentTypeByIdentifier']
+        );
+
+        yield ContentTypeGroupTermAggregation::class => $this->createTermAggregationTestCase(
+            new ContentTypeGroupTermAggregation('content_type_group'),
+            [
+                'Content' => 8,
+                'Users' => 8,
+                'Setup' => 2,
+            ],
+            [$contentTypeService, 'loadContentTypeGroupByIdentifier']
+        );
+
+        yield DateMetadataRangeAggregation::class . '::MODIFIED' => [
+            new DateMetadataRangeAggregation(
+                'modification_date',
+                DateMetadataRangeAggregation::MODIFIED,
+                [
+                    new Range(null, new DateTime('2003-01-01')),
+                    new Range(new DateTime('2003-01-01'), new DateTime('2004-01-01')),
+                    new Range(new DateTime('2004-01-01'), null),
+                ]
+            ),
+            new RangeAggregationResult(
+                'modification_date',
+                [
+                    new RangeAggregationResultEntry(
+                        new Range(null, new DateTime('2003-01-01')),
+                        3
+                    ),
+                    new RangeAggregationResultEntry(
+                        new Range(new DateTime('2003-01-01'), new DateTime('2004-01-01')),
+                        3
+                    ),
+                    new RangeAggregationResultEntry(
+                        new Range(new DateTime('2004-01-01'), null),
+                        12
+                    ),
+                ]
+            ),
+        ];
+
+        yield DateMetadataRangeAggregation::class . '::PUBLISHED' => [
+            new DateMetadataRangeAggregation(
+                'publication_date',
+                DateMetadataRangeAggregation::PUBLISHED,
+                [
+                    new Range(null, new DateTime('2003-01-01')),
+                    new Range(new DateTime('2003-01-01'), new DateTime('2004-01-01')),
+                    new Range(new DateTime('2004-01-01'), null),
+                ]
+            ),
+            new RangeAggregationResult(
+                'publication_date',
+                [
+                    new RangeAggregationResultEntry(
+                        new Range(null, new DateTime('2003-01-01')),
+                        6
+                    ),
+                    new RangeAggregationResultEntry(
+                        new Range(new DateTime('2003-01-01'), new DateTime('2004-01-01')),
+                        2
+                    ),
+                    new RangeAggregationResultEntry(
+                        new Range(new DateTime('2004-01-01'), null),
+                        10
+                    ),
+                ]
+            ),
+        ];
+
+        yield LanguageTermAggregation::class => $this->createTermAggregationTestCase(
+            new LanguageTermAggregation('language'),
+            [
+                'eng-US' => 16,
+                'eng-GB' => 2,
+            ],
+            [$this->getRepository()->getContentLanguageService(), 'loadLanguage']
+        );
+
+        yield ObjectStateTermAggregation::class => $this->createTermAggregationTestCase(
+            new ObjectStateTermAggregation('object_state', 'ez_lock'),
+            [
+                // TODO: Change the state of some content objects to have better test data
+                'not_locked' => 18,
+            ],
+            function (string $identifier): ObjectState {
+                $objectStateService = $this->getRepository()->getObjectStateService();
+
+                static $objectStateGroup = null;
+                if ($objectStateGroup === null) {
+                    $objectStateGroup = $objectStateService->loadObjectStateGroupByIdentifier('ez_lock');
+                }
+
+                return $objectStateService->loadObjectStateByIdentifier($objectStateGroup, $identifier);
+            }
+        );
+
+        yield SectionTermAggregation::class => $this->createTermAggregationTestCase(
+            new SectionTermAggregation('section'),
+            [
+                'users' => 8,
+                'media' => 4,
+                'standard' => 2,
+                'setup' => 2,
+                'design' => 2,
+            ],
+            [$this->getRepository()->getSectionService(), 'loadSectionByIdentifier']
+        );
+
+        $userService = $this->getRepository()->getUserService();
+
+        yield UserMetadataTermAggregation::class . '::OWNER' => $this->createTermAggregationTestCase(
+            new UserMetadataTermAggregation('owner', UserMetadataTermAggregation::OWNER),
+            [
+                'admin' => 18,
+            ],
+            [$userService, 'loadUserByLogin']
+        );
+
+        yield UserMetadataTermAggregation::class . '::GROUP' => $this->createTermAggregationTestCase(
+            new UserMetadataTermAggregation('user_group', UserMetadataTermAggregation::GROUP),
+            [
+                12 => 18,
+                14 => 18,
+                4 => 18,
+            ],
+            [$userService, 'loadUserGroup']
+        );
+
+        yield UserMetadataTermAggregation::class . '::MODIFIER' => $this->createTermAggregationTestCase(
+            new UserMetadataTermAggregation('modifier', UserMetadataTermAggregation::MODIFIER),
+            [
+                'admin' => 18,
+            ],
+            [$userService, 'loadUserByLogin']
+        );
+
+        yield VisibilityTermAggregation::class => $this->createTermAggregationTestCase(
+            new VisibilityTermAggregation('visibility'),
+            [
+                true => 18,
+            ]
+        );
+
+        yield RawRangeAggregation::class => [
+            new RawRangeAggregation(
+                'raw_range',
+                'content_version_no_i',
+                [
+                    new Range(null, 2),
+                    new Range(2, 3),
+                    new Range(3, null),
+                ]
+            ),
+            new RangeAggregationResult(
+                'raw_range',
+                [
+                    new RangeAggregationResultEntry(new Range(null, 2), 14),
+                    new RangeAggregationResultEntry(new Range(2, 3), 3),
+                    new RangeAggregationResultEntry(new Range(3, null), 1),
+                ]
+            ),
+        ];
+
+        yield RawStatsAggregation::class => [
+            new RawStatsAggregation(
+                'raw_stats',
+                'content_version_no_i'
+            ),
+            new StatsAggregationResult(
+                'raw_stats',
+                18,
+                1.0,
+                4.0,
+                1.3333333333333333,
+                24.0
+            ),
+        ];
+
+        yield RawTermAggregation::class => [
+            new RawTermAggregation(
+                'raw_term',
+                'content_section_identifier_id'
+            ),
+            new TermAggregationResult('raw_term', [
+                new TermAggregationResultEntry('users', 8),
+                new TermAggregationResultEntry('media', 4),
+                new TermAggregationResultEntry('design', 2),
+                new TermAggregationResultEntry('setup', 2),
+                new TermAggregationResultEntry('standard', 2),
+            ]),
+        ];
+    }
+
+    /**
+     * @dataProvider dataProviderForTestFieldAggregation
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation|\eZ\Publish\API\Repository\Values\Content\Query\Aggregation\FieldAggregation $aggregation
+     */
+    public function testFindContentWithFieldAggregation(
+        Aggregation $aggregation,
+        string $fieldTypeIdentifier,
+        iterable $fieldValues,
+        AggregationResult $expectedResult,
+        ?callable $configureFieldDefinitionCreateStruct = null
+    ): void {
+        $this->createFieldAggregationFixtures(
+            $this->createContentTypeForFieldAggregation(
+                $aggregation->getContentTypeIdentifier(),
+                $aggregation->getFieldDefinitionIdentifier(),
+                $fieldTypeIdentifier,
+                $configureFieldDefinitionCreateStruct
+            ),
+            $aggregation->getFieldDefinitionIdentifier(),
+            $fieldValues
+        );
+
+        $searchService = $this->getRepository()->getSearchService();
+
+        $query = new Query();
+        $query->aggregations[] = $aggregation;
+        $query->filter = new ContentTypeIdentifier($aggregation->getContentTypeIdentifier());
+        $query->limit = 0;
+
+        self::assertEquals(
+            $expectedResult,
+            $searchService->findContent($query)->aggregations->first()
+        );
+    }
+
+    /**
+     * @dataProvider dataProviderForTestFieldAggregation
+     *
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Aggregation|\eZ\Publish\API\Repository\Values\Content\Query\Aggregation\FieldAggregation $aggregation
+     */
+    public function testFindLocationWithFieldAggregation(
+        Aggregation $aggregation,
+        string $fieldTypeIdentifier,
+        iterable $fieldValues,
+        AggregationResult $expectedResult,
+        ?callable $configureFieldDefinitionCreateStruct = null
+    ): void {
+        $this->createFieldAggregationFixtures(
+            $this->createContentTypeForFieldAggregation(
+                $aggregation->getContentTypeIdentifier(),
+                $aggregation->getFieldDefinitionIdentifier(),
+                $fieldTypeIdentifier,
+                $configureFieldDefinitionCreateStruct
+            ),
+            $aggregation->getFieldDefinitionIdentifier(),
+            $fieldValues
+        );
+
+        $searchService = $this->getRepository()->getSearchService();
+
+        $query = new LocationQuery();
+        $query->aggregations[] = $aggregation;
+        $query->filter = new ContentTypeIdentifier($aggregation->getContentTypeIdentifier());
+        $query->limit = 0;
+
+        self::assertEquals(
+            $expectedResult,
+            $searchService->findLocations($query)->aggregations->first()
+        );
+    }
+
+    public function dataProviderForTestFieldAggregation(): iterable
+    {
+        yield CheckboxTermAggregation::class => [
+            new CheckboxTermAggregation('checkbox_term', 'content_type', 'boolean'),
+            'ezboolean',
+            [
+                new CheckboxValue(true),
+                new CheckboxValue(true),
+                new CheckboxValue(true),
+                new CheckboxValue(false),
+                new CheckboxValue(false),
+            ],
+            new TermAggregationResult(
+                'checkbox_term',
+                [
+                    new TermAggregationResultEntry(true, 3),
+                    new TermAggregationResultEntry(false, 2),
+                ]
+            ),
+        ];
+
+        yield CountryTermAggregation::class . '::TYPE_NAME' => [
+            new CountryTermAggregation(
+                'country_term',
+                'content_type',
+                'country',
+                CountryTermAggregation::TYPE_NAME
+            ),
+            'ezcountry',
+            self::EXAMPLE_COUNTRY_FIELD_VALUES,
+            new TermAggregationResult(
+                'country_term',
+                [
+                    new TermAggregationResultEntry('Canada', 4),
+                    new TermAggregationResultEntry('France', 3),
+                    new TermAggregationResultEntry('Poland', 2),
+                    new TermAggregationResultEntry('Belgium', 1),
+                    new TermAggregationResultEntry('Gabon', 1),
+                ]
+            ),
+            static function (FieldDefinitionCreateStruct $createStruct): void {
+                $createStruct->fieldSettings = [
+                    'isMultiple' => true,
+                ];
+            },
+        ];
+
+        yield CountryTermAggregation::class . '::TYPE_ALPHA_2' => [
+            new CountryTermAggregation(
+                'country_term',
+                'content_type',
+                'country',
+                CountryTermAggregation::TYPE_ALPHA_2
+            ),
+            'ezcountry',
+            self::EXAMPLE_COUNTRY_FIELD_VALUES,
+            new TermAggregationResult(
+                'country_term',
+                [
+                    new TermAggregationResultEntry('CA', 4),
+                    new TermAggregationResultEntry('FR', 3),
+                    new TermAggregationResultEntry('PL', 2),
+                    new TermAggregationResultEntry('BE', 1),
+                    new TermAggregationResultEntry('GA', 1),
+                ]
+            ),
+            static function (FieldDefinitionCreateStruct $createStruct): void {
+                $createStruct->fieldSettings = [
+                    'isMultiple' => true,
+                ];
+            },
+        ];
+
+        yield CountryTermAggregation::class . '::TYPE_ALPHA_3' => [
+            new CountryTermAggregation(
+                'country_term',
+                'content_type',
+                'country',
+                CountryTermAggregation::TYPE_ALPHA_3
+            ),
+            'ezcountry',
+            self::EXAMPLE_COUNTRY_FIELD_VALUES,
+            new TermAggregationResult(
+                'country_term',
+                [
+                    new TermAggregationResultEntry('CAN', 4),
+                    new TermAggregationResultEntry('FRA', 3),
+                    new TermAggregationResultEntry('POL', 2),
+                    new TermAggregationResultEntry('BEL', 1),
+                    new TermAggregationResultEntry('GAB', 1),
+                ]
+            ),
+            static function (FieldDefinitionCreateStruct $createStruct): void {
+                $createStruct->fieldSettings = [
+                    'isMultiple' => true,
+                ];
+            },
+        ];
+
+        yield CountryTermAggregation::class . '::TYPE_IDC' => [
+            new CountryTermAggregation(
+                'country_term',
+                'content_type',
+                'country',
+                CountryTermAggregation::TYPE_IDC
+            ),
+            'ezcountry',
+            self::EXAMPLE_COUNTRY_FIELD_VALUES,
+            new TermAggregationResult(
+                'country_term',
+                [
+                    new TermAggregationResultEntry(1, 4),
+                    new TermAggregationResultEntry(33, 3),
+                    new TermAggregationResultEntry(48, 2),
+                    new TermAggregationResultEntry(32, 1),
+                    new TermAggregationResultEntry(241, 1),
+                ]
+            ),
+            static function (FieldDefinitionCreateStruct $createStruct): void {
+                $createStruct->fieldSettings = [
+                    'isMultiple' => true,
+                ];
+            },
+        ];
+
+        yield DateRangeAggregation::class => [
+            new DateRangeAggregation(
+                'date_range',
+                'content_type',
+                'date_field',
+                [
+                    new Range(
+                        null,
+                        new DateTime('2020-07-01 00:00:00')
+                    ),
+                    new Range(
+                        new DateTime('2020-07-01 00:00:00'),
+                        new DateTime('2020-08-01T00:00:00')
+                    ),
+                    new Range(
+                        new DateTime('2020-08-01T00:00:00'),
+                        null
+                    ),
+                ]
+            ),
+            'ezdate',
+            [
+                new DateTime('2020-05-01T00:00:00Z'),
+                new DateTime('2020-06-30T00:00:00Z'),
+                new DateTime('2020-06-30T12:00:00Z'),
+                new DateTime('2020-07-01T00:00:00Z'),
+                new DateTime('2020-07-01T12:00:00Z'),
+                new DateTime('2020-07-30T12:00:00Z'),
+                new DateTime('2020-08-01T00:00:01Z'),
+                new DateTime('2020-08-01T00:00:02Z'),
+                new DateTime('2020-08-01T00:00:03Z'),
+            ],
+            new RangeAggregationResult(
+                'date_range',
+                [
+                    new RangeAggregationResultEntry(
+                        new Range(
+                            null,
+                            new DateTime('2020-07-01 00:00:00')
+                        ),
+                        3,
+                    ),
+                    new RangeAggregationResultEntry(
+                        new Range(
+                            new DateTime('2020-07-01 00:00:00'),
+                            new DateTime('2020-08-01T00:00:00')
+                        ),
+                        3
+                    ),
+                    new RangeAggregationResultEntry(
+                        new Range(
+                            new DateTime('2020-08-01T00:00:00'),
+                            null
+                        ),
+                        3
+                    ),
+                ]
+            ),
+        ];
+
+        yield DateTimeRangeAggregation::class => [
+            new DateTimeRangeAggregation(
+                'datetime_range',
+                'content_type',
+                'datetime_field',
+                [
+                    new Range(null, new DateTime('2020-06-30 00:00:01')),
+                    new Range(new DateTime('2020-06-30 12:00:00'), new DateTime('2020-07-30 00:00:00')),
+                    new Range(new DateTime('2020-07-30 00:00:01'), new DateTime('2020-08-01 00:00:03')),
+                ]
+            ),
+            'ezdatetime',
+            [
+                new DateTime('2020-05-01 00:00:00'),
+                new DateTime('2020-06-30 00:00:00'),
+                new DateTime('2020-06-30 12:00:00'),
+                new DateTime('2020-07-01 00:00:00'),
+                new DateTime('2020-07-01 12:00:00'),
+                new DateTime('2020-07-30 00:00:00'),
+                new DateTime('2020-07-30 12:00:00'),
+                new DateTime('2020-08-01 00:00:01'),
+                new DateTime('2020-08-01 00:00:02'),
+                new DateTime('2020-08-01 00:00:03'),
+            ],
+            new RangeAggregationResult(
+                'datetime_range',
+                [
+                    new RangeAggregationResultEntry(
+                        new Range(null, new DateTime('2020-06-30 00:00:01')),
+                        2,
+                    ),
+                    new RangeAggregationResultEntry(
+                        new Range(new DateTime('2020-06-30 12:00:00'), new DateTime('2020-07-30 00:00:00')),
+                        3
+                    ),
+                    new RangeAggregationResultEntry(
+                        new Range(new DateTime('2020-07-30 00:00:01'), new DateTime('2020-08-01 00:00:03')),
+                        3
+                    ),
+                ]
+            ),
+        ];
+
+        yield FloatStatsAggregation::class => [
+            new FloatStatsAggregation('float_stats', 'content_type', 'float'),
+            'ezfloat',
+            [1.0, 2.5, 2.5, 5.25, 7.75],
+            new StatsAggregationResult(
+                'float_stats',
+                5,
+                1.0,
+                7.75,
+                3.8,
+                19.0
+            ),
+        ];
+
+        yield FloatRangeAggregation::class => [
+            new IntegerRangeAggregation('float_range', 'content_type', 'integer', [
+                new Range(null, 10.0),
+                new Range(10.0, 25.0),
+                new Range(25.0, 50.0),
+                new Range(50.0, null),
+            ]),
+            'ezfloat',
+            range(1.0, 100.0, 2.5),
+            new RangeAggregationResult(
+                'float_range',
+                [
+                    new RangeAggregationResultEntry(new Range(null, 10.0), 4),
+                    new RangeAggregationResultEntry(new Range(10.0, 25.0), 6),
+                    new RangeAggregationResultEntry(new Range(25, 50), 10),
+                    new RangeAggregationResultEntry(new Range(50, null), 20),
+                ]
+            ),
+        ];
+
+        yield IntegerStatsAggregation::class => [
+            new IntegerStatsAggregation('integer_stats', 'content_type', 'integer'),
+            'ezinteger',
+            [1, 2, 3, 5, 8, 13, 21],
+            new StatsAggregationResult(
+                'integer_stats',
+                7,
+                1,
+                21,
+                7.571428571428571,
+                53
+            ),
+        ];
+
+        yield IntegerRangeAggregation::class => [
+            new IntegerRangeAggregation('integer_range', 'content_type', 'integer', [
+                new Range(null, 10),
+                new Range(10, 25),
+                new Range(25, 50),
+                new Range(50, null),
+            ]),
+            'ezinteger',
+            range(1, 100),
+            new RangeAggregationResult(
+                'integer_range',
+                [
+                    new RangeAggregationResultEntry(new Range(null, 10), 9),
+                    new RangeAggregationResultEntry(new Range(10, 25), 15),
+                    new RangeAggregationResultEntry(new Range(25, 50), 25),
+                    new RangeAggregationResultEntry(new Range(50, null), 51),
+                ]
+            ),
+        ];
+
+        yield KeywordTermAggregation::class => [
+            new KeywordTermAggregation(
+                'keyword_term',
+                'content_type',
+                'keyword'
+            ),
+            'ezkeyword',
+            self::EXAMPLE_KEYWORD_FIELD_VALUES,
+            new TermAggregationResult(
+                'keyword_term',
+                [
+                    new TermAggregationResultEntry('foo', 3),
+                    new TermAggregationResultEntry('bar', 2),
+                    new TermAggregationResultEntry('baz', 1),
+                ]
+            ),
+        ];
+
+        yield SelectionTermAggregation::class => [
+            new SelectionTermAggregation(
+                'selection_term',
+                'content_type',
+                'selection'
+            ),
+            'ezselection',
+            self::EXAMPLE_SELECTION_FIELD_VALUES,
+            new TermAggregationResult(
+                'selection_term',
+                [
+                    new TermAggregationResultEntry('foo', 3),
+                    new TermAggregationResultEntry('bar', 2),
+                    new TermAggregationResultEntry('baz', 1),
+                ]
+            ),
+            static function (FieldDefinitionCreateStruct $createStruct): void {
+                $createStruct->fieldSettings = [
+                    'isMultiple' => true,
+                    'options' => [
+                        0 => 'foo',
+                        1 => 'bar',
+                        2 => 'baz',
+                    ],
+                ];
+            },
+        ];
+
+        yield TimeRangeAggregation::class => [
+            new TimeRangeAggregation(
+                'time_term',
+                'content_type',
+                'time',
+                [
+                    new Range(null, mktime(7, 0, 0, 0, 0, 0)),
+                    new Range(
+                        mktime(7, 0, 0, 0, 0, 0),
+                        mktime(12, 0, 0, 0, 0, 0)
+                    ),
+                    new Range(mktime(12, 0, 0, 0, 0, 0), null),
+                ]
+            ),
+            'eztime',
+            [
+                new TimeValue(mktime(6, 45, 0, 0, 0, 0)),
+                new TimeValue(mktime(7, 0, 0, 0, 0, 0)),
+                new TimeValue(mktime(6, 30, 0, 0, 0, 0)),
+                new TimeValue(mktime(11, 45, 0, 0, 0, 0)),
+                new TimeValue(mktime(16, 00, 0, 0, 0, 0)),
+                new TimeValue(mktime(17, 00, 0, 0, 0, 0)),
+                new TimeValue(mktime(17, 30, 0, 0, 0, 0)),
+            ],
+            new RangeAggregationResult(
+                'time_term',
+                [
+                    new RangeAggregationResultEntry(
+                        new Range(null, mktime(7, 0, 0, 0, 0, 0)),
+                        2
+                    ),
+                    new RangeAggregationResultEntry(
+                        new Range(
+                            mktime(7, 0, 0, 0, 0, 0),
+                            mktime(12, 0, 0, 0, 0, 0)
+                        ),
+                        2
+                    ),
+                    new RangeAggregationResultEntry(
+                        new Range(mktime(12, 0, 0, 0, 0, 0), null),
+                        3
+                    ),
+                ]
+            ),
+        ];
+    }
+
+    private function createTermAggregationTestCase(
+        Aggregation $aggregation,
+        iterable $expectedEntries,
+        ?callable $mapper = null
+    ): array {
+        if ($mapper === null) {
+            $mapper = function ($key) {
+                return $key;
+            };
+        }
+
+        $entries = [];
+        foreach ($expectedEntries as $key => $count) {
+            $entries[] = new TermAggregationResultEntry($mapper($key), $count);
+        }
+
+        $expectedResult = TermAggregationResult::createForAggregation($aggregation, $entries);
+
+        return [$aggregation, $expectedResult];
+    }
+
+    private function createFieldAggregationFixtures(
+        ContentType $contentType,
+        string $fieldDefinitionIdentifier,
+        iterable $values
+    ): void {
+        $contentService = $this->getRepository()->getContentService();
+        $locationService = $this->getRepository()->getLocationService();
+
+        foreach ($values as $value) {
+            $contentCreateStruct = $contentService->newContentCreateStruct($contentType, 'eng-GB');
+            $contentCreateStruct->setField($fieldDefinitionIdentifier, $value);
+
+            $contentService->publishVersion(
+                $contentService->createContent(
+                    $contentCreateStruct,
+                    [
+                        $locationService->newLocationCreateStruct(2),
+                    ]
+                )->versionInfo
+            );
+        }
+
+        $this->refreshSearch($this->getRepository());
+    }
+
+    private function createContentTypeForFieldAggregation(
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier,
+        string $fieldTypeIdentifier,
+        ?callable $configureFieldDefinitionCreateStruct = null
+    ): ContentType {
+        $contentTypeService = $this->getRepository()->getContentTypeService();
+
+        $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct($contentTypeIdentifier);
+        $contentTypeCreateStruct->mainLanguageCode = 'eng-GB';
+        $contentTypeCreateStruct->names = [
+            'eng-GB' => 'Field aggregation',
+        ];
+
+        $fieldDefinitionCreateStruct = $contentTypeService->newFieldDefinitionCreateStruct(
+            $fieldDefinitionIdentifier,
+            $fieldTypeIdentifier
+        );
+        $fieldDefinitionCreateStruct->names = [
+            'eng-GB' => 'Aggregated field',
+        ];
+        $fieldDefinitionCreateStruct->isSearchable = true;
+
+        if ($configureFieldDefinitionCreateStruct !== null) {
+            $configureFieldDefinitionCreateStruct($fieldDefinitionCreateStruct);
+        }
+
+        $contentTypeCreateStruct->addFieldDefinition($fieldDefinitionCreateStruct);
+
+        $contentTypeDraft = $contentTypeService->createContentType(
+            $contentTypeCreateStruct,
+            [
+                $contentTypeService->loadContentTypeGroupByIdentifier('Content'),
+            ]
+        );
+
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+
+        return $contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Values/Content/Query/Aggregation/RangeTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/Query/Aggregation/RangeTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Values\Content\Query\Aggregation;
+
+use DateTimeImmutable;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range;
+use PHPUnit\Framework\TestCase;
+
+final class RangeTest extends TestCase
+{
+    /**
+     * @dataProvider dataProviderForTestToString
+     */
+    public function testToString(Range $range, string $expected): void
+    {
+        $this->assertEquals($expected, (string)$range);
+    }
+
+    public function dataProviderForTestToString(): iterable
+    {
+        yield 'empty' => [
+            new Range(null, null),
+            '[*;*)',
+        ];
+
+        yield 'int' => [
+            new Range(1, 10),
+            '[1;10)',
+        ];
+
+        yield 'float' => [
+            new Range(0.25, 3.25),
+            '[0.25;3.25)',
+        ];
+
+        yield 'datetime' => [
+            new Range(
+                new DateTimeImmutable('2020-01-01T00:00:00+0000'),
+                new DateTimeImmutable('2020-12-31T23:59:59+0000'),
+            ),
+            '[2020-01-01T00:00:00+0000;2020-12-31T23:59:59+0000)',
+        ];
+    }
+
+    public function testOfInt(): void
+    {
+        $this->assertEquals(new Range(null, 10), Range::ofInt(null, 10));
+        $this->assertEquals(new Range(1, 10), Range::ofInt(1, 10));
+        $this->assertEquals(new Range(1, null), Range::ofInt(1, null));
+    }
+
+    public function testOfFloat(): void
+    {
+        $this->assertEquals(new Range(null, 10.0), Range::ofFloat(null, 10.0));
+        $this->assertEquals(new Range(1.0, 10.0), Range::ofFloat(1.0, 10.0));
+        $this->assertEquals(new Range(1.0, null), Range::ofFloat(1.0, null));
+    }
+
+    public function testOfDateTime(): void
+    {
+        $a = new DateTimeImmutable('2020-01-01T00:00:00+0000');
+        $b = new DateTimeImmutable('2020-12-31T23:59:59+0000');
+
+        $this->assertEquals(new Range(null, $b), Range::ofDateTime(null, $b));
+        $this->assertEquals(new Range($a, $b), Range::ofDateTime($a, $b));
+        $this->assertEquals(new Range($a, null), Range::ofDateTime($a, null));
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -67,6 +67,11 @@ class Query extends ValueObject
     public $facetBuilders = [];
 
     /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Query\Aggregation[]
+     */
+    public $aggregations = [];
+
+    /**
      * Query offset.
      *
      * Sets the offset for search hits, used for paging the results.

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query;
+
+interface Aggregation
+{
+    public function getName(): string;
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/AbstractRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/AbstractRangeAggregation.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+abstract class AbstractRangeAggregation implements Aggregation
+{
+    /**
+     * The name of the aggregation.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range[] */
+    protected $ranges;
+
+    public function __construct(string $name, array $ranges = [])
+    {
+        $this->name = $name;
+        $this->ranges = $ranges;
+    }
+
+    public function getRanges(): array
+    {
+        return $this->ranges;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/AbstractStatsAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/AbstractStatsAggregation.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+abstract class AbstractStatsAggregation implements Aggregation
+{
+    /**
+     * The name of the aggregation.
+     *
+     * @var string
+     */
+    protected $name;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/AbstractTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/AbstractTermAggregation.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+abstract class AbstractTermAggregation implements Aggregation
+{
+    public const DEFAULT_LIMIT = 10;
+    public const DEFAULT_MIN_COUNT = 1;
+
+    /**
+     * The name of the aggregation.
+     *
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * Number of facets (terms) returned.
+     *
+     * @var int
+     */
+    protected $limit = self::DEFAULT_LIMIT;
+
+    /**
+     * Specifies the minimum count. Only facet groups with more or equal results are returned.
+     *
+     * @var int
+     */
+    protected $minCount = self::DEFAULT_MIN_COUNT;
+
+    public function __construct(string $name)
+    {
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getLimit(): int
+    {
+        return $this->limit;
+    }
+
+    public function setLimit(int $limit): self
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
+    public function getMinCount(): int
+    {
+        return $this->minCount;
+    }
+
+    public function setMinCount(int $minCount): self
+    {
+        $this->minCount = $minCount;
+
+        return $this;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/ContentTypeGroupTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/ContentTypeGroupTermAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class ContentTypeGroupTermAggregation extends AbstractTermAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/ContentTypeTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/ContentTypeTermAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class ContentTypeTermAggregation extends AbstractTermAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/DateMetadataRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/DateMetadataRangeAggregation.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class DateMetadataRangeAggregation extends AbstractRangeAggregation
+{
+    public const MODIFIED = 'modified';
+    public const CREATED = 'created';
+    public const PUBLISHED = 'published';
+
+    /** @var string */
+    private $type;
+
+    public function __construct(string $name, string $type, array $ranges = [])
+    {
+        parent::__construct($name, $ranges);
+        $this->type = $type;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldRangeAggregation.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\FieldAggregation;
+
+abstract class AbstractFieldRangeAggregation extends AbstractRangeAggregation implements FieldAggregation
+{
+    use FieldAggregationTrait;
+
+    public function __construct(
+        string $name,
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier,
+        array $ranges = []
+    ) {
+        parent::__construct($name, $ranges);
+
+        $this->contentTypeIdentifier = $contentTypeIdentifier;
+        $this->fieldDefinitionIdentifier = $fieldDefinitionIdentifier;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldStatsAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldStatsAggregation.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractStatsAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\FieldAggregation;
+
+abstract class AbstractFieldStatsAggregation extends AbstractStatsAggregation implements FieldAggregation
+{
+    use FieldAggregationTrait;
+
+    public function __construct(
+        string $name,
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier
+    ) {
+        parent::__construct($name);
+
+        $this->contentTypeIdentifier = $contentTypeIdentifier;
+        $this->fieldDefinitionIdentifier = $fieldDefinitionIdentifier;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldTermAggregation.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\FieldAggregation;
+
+abstract class AbstractFieldTermAggregation extends AbstractTermAggregation implements FieldAggregation
+{
+    use FieldAggregationTrait;
+
+    public function __construct(
+        string $name,
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier
+    ) {
+        parent::__construct($name);
+
+        $this->contentTypeIdentifier = $contentTypeIdentifier;
+        $this->fieldDefinitionIdentifier = $fieldDefinitionIdentifier;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AuthorTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AuthorTermAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+final class AuthorTermAggregation extends AbstractFieldTermAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/CheckboxTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/CheckboxTermAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+final class CheckboxTermAggregation extends AbstractFieldTermAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/CountryTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/CountryTermAggregation.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+final class CountryTermAggregation extends AbstractFieldTermAggregation
+{
+    public const TYPE_NAME = 1;
+    public const TYPE_IDC = 2;
+    public const TYPE_ALPHA_2 = 4;
+    public const TYPE_ALPHA_3 = 8;
+
+    /** @var int */
+    private $type;
+
+    public function __construct(
+        string $name,
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier,
+        int $type = self::TYPE_ALPHA_3
+    ) {
+        parent::__construct($name, $contentTypeIdentifier, $fieldDefinitionIdentifier);
+
+        $this->type = $type;
+    }
+
+    public function getType(): int
+    {
+        return $this->type;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/DateRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/DateRangeAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+final class DateRangeAggregation extends AbstractFieldRangeAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/DateTimeRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/DateTimeRangeAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+final class DateTimeRangeAggregation extends AbstractFieldRangeAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/FieldAggregationTrait.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/FieldAggregationTrait.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+trait FieldAggregationTrait
+{
+    /** @var string */
+    public $contentTypeIdentifier;
+
+    /** @var string */
+    public $fieldDefinitionIdentifier;
+
+    public function getContentTypeIdentifier(): string
+    {
+        return $this->contentTypeIdentifier;
+    }
+
+    public function getFieldDefinitionIdentifier(): string
+    {
+        return $this->fieldDefinitionIdentifier;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/FloatRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/FloatRangeAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+final class FloatRangeAggregation extends AbstractFieldRangeAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/FloatStatsAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/FloatStatsAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+final class FloatStatsAggregation extends AbstractFieldStatsAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/IntegerRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/IntegerRangeAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+final class IntegerRangeAggregation extends AbstractFieldRangeAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/IntegerStatsAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/IntegerStatsAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+final class IntegerStatsAggregation extends AbstractFieldStatsAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/KeywordTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/KeywordTermAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+final class KeywordTermAggregation extends AbstractFieldTermAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/SelectionTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/SelectionTermAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+final class SelectionTermAggregation extends AbstractFieldTermAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/TimeRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/TimeRangeAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field;
+
+final class TimeRangeAggregation extends AbstractFieldRangeAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/FieldAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/FieldAggregation.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+interface FieldAggregation
+{
+    public function getContentTypeIdentifier(): string;
+
+    public function getFieldDefinitionIdentifier(): string;
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/LanguageTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/LanguageTermAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class LanguageTermAggregation extends AbstractTermAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Location/SubtreeTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Location/SubtreeTermAggregation.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Location;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\LocationAggregation;
+
+final class SubtreeTermAggregation extends AbstractTermAggregation implements LocationAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/LocationAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/LocationAggregation.php
@@ -1,0 +1,16 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+/**
+ * Marker interface for location based aggregation.
+ */
+interface LocationAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/ObjectStateTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/ObjectStateTermAggregation.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class ObjectStateTermAggregation extends AbstractTermAggregation
+{
+    /** @var string */
+    private $objectStateGroupIdentifier;
+
+    public function __construct(
+        string $name,
+        string $objectStateGroupIdentifier
+    ) {
+        parent::__construct($name);
+
+        $this->objectStateGroupIdentifier = $objectStateGroupIdentifier;
+    }
+
+    public function getObjectStateGroupIdentifier(): string
+    {
+        return $this->objectStateGroupIdentifier;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Range.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Range.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+use DateTimeInterface;
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+final class Range extends ValueObject
+{
+    /**
+     * Beginning of the range (included).
+     *
+     * @var int|float|\DateTimeInterface|null
+     */
+    private $from;
+
+    /**
+     * End of the range (excluded).
+     *
+     * @var int|float|\DateTimeInterface|null
+     */
+    private $to;
+
+    public function __construct($from, $to)
+    {
+        parent::__construct();
+
+        $this->from = $from;
+        $this->to = $to;
+    }
+
+    public function getFrom()
+    {
+        return $this->from;
+    }
+
+    public function getTo()
+    {
+        return $this->to;
+    }
+
+    public function __toString(): string
+    {
+        return sprintf(
+            '[%s;%s)',
+            $this->getRangeValueAsString($this->from),
+            $this->getRangeValueAsString($this->to)
+        );
+    }
+
+    private function getRangeValueAsString($value): string
+    {
+        if ($value === null) {
+            return '*';
+        }
+
+        if ($value instanceof DateTimeInterface) {
+            return $value->format(DateTimeInterface::ISO8601);
+        }
+
+        return (string)$value;
+    }
+
+    public static function ofInt(?int $from, ?int $to): self
+    {
+        return new self($from, $to);
+    }
+
+    public static function ofFloat(?float $from, ?float $to): self
+    {
+        return new self($from, $to);
+    }
+
+    public static function ofDateTime(?DateTimeInterface $from, ?DateTimeInterface $to): self
+    {
+        return new self($from, $to);
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawAggregation.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+interface RawAggregation
+{
+    public function getFieldName(): string;
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawRangeAggregation.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class RawRangeAggregation extends AbstractRangeAggregation implements RawAggregation
+{
+    /** @var string */
+    private $fieldName;
+
+    public function __construct(string $name, string $fieldName, array $ranges = [])
+    {
+        parent::__construct($name, $ranges);
+
+        $this->fieldName = $fieldName;
+    }
+
+    public function getFieldName(): string
+    {
+        return $this->fieldName;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawStatsAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawStatsAggregation.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class RawStatsAggregation extends AbstractStatsAggregation implements RawAggregation
+{
+    /** @var string */
+    private $fieldName;
+
+    public function __construct(string $name, string $fieldName)
+    {
+        parent::__construct($name);
+
+        $this->fieldName = $fieldName;
+    }
+
+    public function getFieldName(): string
+    {
+        return $this->fieldName;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawTermAggregation.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class RawTermAggregation extends AbstractTermAggregation implements RawAggregation
+{
+    /** @var string */
+    private $fieldName;
+
+    public function __construct(
+        string $name,
+        string $fieldName
+    ) {
+        parent::__construct($name);
+
+        $this->fieldName = $fieldName;
+    }
+
+    public function getFieldName(): string
+    {
+        return $this->fieldName;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/SectionTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/SectionTermAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class SectionTermAggregation extends AbstractTermAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/UserMetadataTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/UserMetadataTermAggregation.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class UserMetadataTermAggregation extends AbstractTermAggregation
+{
+    /**
+     * Owner user.
+     */
+    public const OWNER = 'owner';
+
+    /**
+     * Owner user group.
+     */
+    public const GROUP = 'group';
+
+    /**
+     * Modifier.
+     */
+    public const MODIFIER = 'modifier';
+
+    /**
+     * The type of the user facet.
+     *
+     * @var string
+     */
+    private $type;
+
+    public function __construct(
+        string $name,
+        string $type = self::OWNER
+    ) {
+        parent::__construct($name);
+
+        $this->type = $type;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/VisibilityTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/VisibilityTermAggregation.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+
+final class VisibilityTermAggregation extends AbstractTermAggregation
+{
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder.php
@@ -12,6 +12,8 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 
 /**
  * This class is the base class for facet builders.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 abstract class FacetBuilder extends ValueObject
 {

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/ContentTypeFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/ContentTypeFacetBuilder.php
@@ -14,6 +14,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
  * Building a content type facet.
  *
  * If provided the search service returns a ContentTypeFacet
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class ContentTypeFacetBuilder extends FacetBuilder
 {

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/CriterionFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/CriterionFacetBuilder.php
@@ -15,6 +15,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
  *
  * If provided the search service returns a CriterionFacet based on the criterion provided
  * in the FacetBuilder class.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class CriterionFacetBuilder extends FacetBuilder
 {

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/DateRangeFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/DateRangeFacetBuilder.php
@@ -13,6 +13,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
  *
  * If provided the search service returns a DateRangeFacet depending on the provided
  * type (PUBLISHED, CREATED, MODIFIED)
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 abstract class DateRangeFacetBuilder extends FacetBuilder
 {

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/FieldFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/FieldFacetBuilder.php
@@ -16,6 +16,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
  * If provided the search service returns a FieldFacet for the provided field path.
  * A field path starts with a field identifier and may contain a subpath in the case
  * of complex field types (e.g. author/name)
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class FieldFacetBuilder extends FacetBuilder
 {

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/FieldRangeFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/FieldRangeFacetBuilder.php
@@ -16,6 +16,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
  * If provided the search service returns a FieldRangeFacet for the given field path.
  * A field path starts with a field identifier and may contain a subpath in the case
  * of complex field types
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 abstract class FieldRangeFacetBuilder extends FacetBuilder
 {

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/Location.php
@@ -12,6 +12,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
 
 /**
  * This is the base class for Location facet builders.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 abstract class Location extends FacetBuilder
 {

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/Location/LocationFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/Location/LocationFacetBuilder.php
@@ -17,6 +17,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder\Location;
  * contains the counts for all Locations below the child Locations.
  *
  * @todo: check hierarchical facets
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class LocationFacetBuilder extends Location
 {

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/LocationFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/LocationFacetBuilder.php
@@ -17,6 +17,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
  * which contains the counts for all content objects below the child locations.
  *
  * @todo: check hierarchical facets
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class LocationFacetBuilder extends FacetBuilder
 {

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/SectionFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/SectionFacetBuilder.php
@@ -15,6 +15,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
  *
  * If provided the search service returns a SectionFacet. Which contains the counts for
  * content in the existing sections.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class SectionFacetBuilder extends FacetBuilder
 {

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/TermFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/TermFacetBuilder.php
@@ -15,6 +15,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
  *
  * If provided the search service returns a TermFacet which contains the counts for
  * content containing terms in arbitrary fields
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class TermFacetBuilder extends FacetBuilder
 {

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/UserFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/UserFacetBuilder.php
@@ -14,6 +14,8 @@ use eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;
  * Build a user facet.
  *
  * If provided the search service returns a UserFacet for the given type.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class UserFacetBuilder extends FacetBuilder
 {

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Search;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+abstract class AggregationResult extends ValueObject
+{
+    /**
+     * The name of the aggregation.
+     *
+     * @var string
+     */
+    private $name;
+
+    public function __construct(string $name)
+    {
+        parent::__construct();
+
+        $this->name = $name;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/RangeAggregationResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/RangeAggregationResult.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+
+use ArrayIterator;
+use Countable;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+use Iterator;
+use IteratorAggregate;
+
+final class RangeAggregationResult extends AggregationResult implements IteratorAggregate, Countable
+{
+    /** @var \eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\RangeAggregationResultEntry[] */
+    private $entries;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\RangeAggregationResultEntry[] $entries
+     */
+    public function __construct(string $name, iterable $entries = [])
+    {
+        parent::__construct($name);
+
+        $this->entries = $entries;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->entries);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\RangeAggregationResultEntry[]
+     */
+    public function getEntries(): iterable
+    {
+        return $this->entries;
+    }
+
+    public function getEntry(Range $key): ?RangeAggregationResultEntry
+    {
+        foreach ($this->entries as $entry) {
+            if ($entry->getKey() == $key) {
+                return $entry;
+            }
+        }
+
+        return null;
+    }
+
+    public function hasEntry(Range $key): bool
+    {
+        return $this->getEntry($key) !== null;
+    }
+
+    public function count(): int
+    {
+        return count($this->entries);
+    }
+
+    public function getIterator(): Iterator
+    {
+        if (empty($this->entries)) {
+            return new ArrayIterator();
+        }
+
+        foreach ($this->entries as $entry) {
+            yield $entry->getKey() => $entry->getCount();
+        }
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/RangeAggregationResultEntry.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/RangeAggregationResultEntry.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range;
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+final class RangeAggregationResultEntry extends ValueObject
+{
+    /** @var \eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range */
+    private $key;
+
+    /** @var int */
+    private $count;
+
+    public function __construct(Range $key, int $count)
+    {
+        parent::__construct();
+
+        $this->key = $key;
+        $this->count = $count;
+    }
+
+    public function getKey(): Range
+    {
+        return $this->key;
+    }
+
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/StatsAggregationResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/StatsAggregationResult.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+
+final class StatsAggregationResult extends AggregationResult
+{
+    /** @var float|null */
+    public $sum;
+
+    /** @var int|null */
+    private $count;
+
+    /** @var float|null */
+    private $min;
+
+    /** @var float|null */
+    private $max;
+
+    /** @var float|null */
+    private $avg;
+
+    public function __construct(string $name, ?int $count, ?float $min, ?float $max, ?float $avg, ?float $sum)
+    {
+        parent::__construct($name);
+
+        $this->count = $count;
+        $this->min = $min;
+        $this->max = $max;
+        $this->avg = $avg;
+        $this->sum = $sum;
+    }
+
+    public function getCount(): ?int
+    {
+        return $this->count;
+    }
+
+    public function getMin(): ?float
+    {
+        return $this->min;
+    }
+
+    public function getMax(): ?float
+    {
+        return $this->max;
+    }
+
+    public function getAvg(): ?float
+    {
+        return $this->avg;
+    }
+
+    public function getSum(): ?float
+    {
+        return $this->sum;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/TermAggregationResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/TermAggregationResult.php
@@ -1,0 +1,85 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+
+use ArrayIterator;
+use Countable;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+use Iterator;
+use IteratorAggregate;
+
+class TermAggregationResult extends AggregationResult implements IteratorAggregate, Countable
+{
+    /** @var \eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry[] */
+    private $entries;
+
+    public function __construct(string $name, iterable $entries = [])
+    {
+        parent::__construct($name);
+
+        $this->entries = $entries;
+    }
+
+    public function isEmpty(): bool
+    {
+        return empty($this->entries);
+    }
+
+    /**
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry[]
+     */
+    public function getEntries(): iterable
+    {
+        return $this->entries;
+    }
+
+    /**
+     * @param object|string|int $key
+     */
+    public function getEntry($key): ?TermAggregationResultEntry
+    {
+        foreach ($this->entries as $entry) {
+            if ($entry->getKey() == $key) {
+                return $entry;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param object|string|int $key
+     */
+    public function hasEntry($key): bool
+    {
+        return $this->getEntry($key) !== null;
+    }
+
+    public function count(): int
+    {
+        return count($this->entries);
+    }
+
+    public function getIterator(): Iterator
+    {
+        if (empty($this->entries)) {
+            return new ArrayIterator();
+        }
+
+        foreach ($this->entries as $entry) {
+            yield $entry->getKey() => $entry->getCount();
+        }
+    }
+
+    public static function createForAggregation(Aggregation $aggregation, iterable $entries = []): self
+    {
+        return new self($aggregation->getName(), $entries);
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/TermAggregationResultEntry.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/TermAggregationResultEntry.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Search\AggregationResult;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+
+final class TermAggregationResultEntry extends ValueObject
+{
+    /** @var mixed */
+    private $key;
+
+    /** @var int */
+    private $count;
+
+    public function __construct($key, int $count)
+    {
+        parent::__construct();
+
+        $this->key = $key;
+        $this->count = $count;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getKey()
+    {
+        return $this->key;
+    }
+
+    public function getCount(): int
+    {
+        return $this->count;
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResultCollection.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResultCollection.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Search;
+
+use ArrayIterator;
+use eZ\Publish\API\Repository\Exceptions\OutOfBoundsException;
+use Iterator;
+use IteratorAggregate;
+use Countable;
+
+final class AggregationResultCollection implements Countable, IteratorAggregate
+{
+    /** @var \eZ\Publish\API\Repository\Values\Content\Search\AggregationResult[] */
+    private $entries;
+
+    /**
+     * @param \eZ\Publish\API\Repository\Values\Content\Search\AggregationResult[] $results
+     */
+    public function __construct(iterable $results = [])
+    {
+        $this->entries = [];
+        foreach ($results as $result) {
+            $this->entries[$result->getName()] = $result;
+        }
+    }
+
+    /**
+     * This method returns the aggregation result for the given aggregation name.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\OutOfBoundsException
+     */
+    public function get(string $name): AggregationResult
+    {
+        if ($this->has($name)) {
+            return $this->entries[$name];
+        }
+
+        throw new OutOfBoundsException(
+            sprintf("Collection does not contain element with identifier '%s'", $name)
+        );
+    }
+
+    /**
+     * This method returns true if the aggregation result for the given aggregation name exists.
+     */
+    public function has(string $name): bool
+    {
+        return array_key_exists($name, $this->entries);
+    }
+
+    /**
+     * Return first element of collection.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\OutOfBoundsException
+     */
+    public function first(): AggregationResult
+    {
+        if (($result = reset($this->entries)) !== false) {
+            return $result;
+        }
+
+        throw new OutOfBoundsException('Collection is empty');
+    }
+
+    /**
+     * Return last element of collection.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\OutOfBoundsException
+     */
+    public function last(): AggregationResult
+    {
+        if (($result = end($this->entries)) !== false) {
+            return $result;
+        }
+
+        throw new OutOfBoundsException('Collection is empty');
+    }
+
+    /**
+     * Checks whether the collection is empty (contains no elements).
+     *
+     * @return bool TRUE if the collection is empty, FALSE otherwise.
+     */
+    public function isEmpty(): bool
+    {
+        return empty($this->entries);
+    }
+
+    /**
+     * Gets a native PHP array representation of the collection.
+     *
+     * @return \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition[]
+     */
+    public function toArray(): array
+    {
+        return $this->entries;
+    }
+
+    public function getIterator(): Iterator
+    {
+        return new ArrayIterator($this->entries);
+    }
+
+    public function count(): int
+    {
+        return count($this->entries);
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet.php
@@ -12,6 +12,8 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 
 /**
  * Base class for facets.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 abstract class Facet extends ValueObject
 {

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/ContentTypeFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/ContentTypeFacet.php
@@ -12,6 +12,8 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
  * This class holds counts of content with content type.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class ContentTypeFacet extends Facet
 {

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/CriterionFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/CriterionFacet.php
@@ -12,6 +12,8 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
  * This class holds the count of content matching the criterion.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class CriterionFacet extends Facet
 {

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/DateRangeFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/DateRangeFacet.php
@@ -12,6 +12,8 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
  * This class represents a date range facet holding counts for content in the built date ranges.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class DateRangeFacet extends Facet
 {

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/FieldFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/FieldFacet.php
@@ -14,6 +14,8 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
  * This class represents a field facet which holds the collected terms for one or more fields.
  *
  * @author christianbacher
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class FieldFacet extends Facet
 {

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/FieldRangeFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/FieldRangeFacet.php
@@ -12,6 +12,8 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
  * This class represents a field range facet.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class FieldRangeFacet extends Facet
 {

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/LocationFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/LocationFacet.php
@@ -12,6 +12,8 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
  * Facet containing counts for content below child locations.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class LocationFacet extends Facet
 {

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/RangeFacetEntry.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/RangeFacetEntry.php
@@ -10,6 +10,8 @@ namespace eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
  * This class holds statistical data for value ranges.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class RangeFacetEntry
 {

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/SectionFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/SectionFacet.php
@@ -12,6 +12,8 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
  * this class hold counts for content in sections.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class SectionFacet extends Facet
 {

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/TermFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/TermFacet.php
@@ -12,6 +12,8 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
  * this class hold counts for content in sections.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class TermFacet extends Facet
 {

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/UserFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/UserFacet.php
@@ -12,6 +12,8 @@ use eZ\Publish\API\Repository\Values\Content\Search\Facet;
 
 /**
  * This class holds counts for content owned, created or modified by users.
+ *
+ * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
  */
 class UserFacet extends Facet
 {

--- a/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
@@ -22,8 +22,15 @@ class SearchResult extends ValueObject implements IteratorAggregate
      * The facets for this search.
      *
      * @var \eZ\Publish\API\Repository\Values\Content\Search\Facet[]
+     *
+     * @deprecated since eZ Platform 3.2.0, to be removed in eZ Platform 4.0.0.
      */
     public $facets = [];
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\Search\AggregationResultCollection
+     */
+    public $aggregations;
 
     /**
      * The value objects found for the query.
@@ -69,6 +76,15 @@ class SearchResult extends ValueObject implements IteratorAggregate
      * @var int|null
      */
     public $totalCount;
+
+    public function __construct(array $properties = [])
+    {
+        if (!isset($properties['aggregations'])) {
+            $properties['aggregations'] = new AggregationResultCollection();
+        }
+
+        parent::__construct($properties);
+    }
 
     public function getIterator(): Traversable
     {

--- a/eZ/Publish/Core/Search/Common/FieldNameResolver.php
+++ b/eZ/Publish/Core/Search/Common/FieldNameResolver.php
@@ -280,4 +280,30 @@ class FieldNameResolver
 
         return [$field => $indexDefinition[$name]];
     }
+
+    public function getAggregationFieldName(
+        string $contentTypeIdentifier,
+        string $fieldDefinitionIdentifier,
+        string $name
+    ): ?string {
+        $fieldMap = $this->getSearchableFieldMap();
+
+        // First check if field exists in type, there is nothing to do if it doesn't
+        if (!isset($fieldMap[$contentTypeIdentifier][$fieldDefinitionIdentifier])) {
+            return null;
+        }
+
+        $fieldName = array_keys(
+            $this->getIndexFieldName(
+                null,
+                $contentTypeIdentifier,
+                $fieldDefinitionIdentifier,
+                $fieldMap[$contentTypeIdentifier][$fieldDefinitionIdentifier]['field_type_identifier'],
+                $name,
+                true
+            )
+        );
+
+        return reset($fieldName);
+    }
 }

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/IdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/IdentifierMapper.php
@@ -36,6 +36,10 @@ class IdentifierMapper extends FieldValueMapper
      */
     public function map(Field $field)
     {
+        if ($field->type->raw) {
+            return $field->value;
+        }
+
         return $this->convert($field->value);
     }
 

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleIdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleIdentifierMapper.php
@@ -38,7 +38,11 @@ class MultipleIdentifierMapper extends IdentifierMapper
         $values = [];
 
         foreach ($field->value as $value) {
-            $values[] = $this->convert($value);
+            if (!$field->type->raw) {
+                $value = $this->convert($value);
+            }
+
+            $values[] = $value;
         }
 
         return $values;

--- a/eZ/Publish/SPI/Search/FieldType/IdentifierField.php
+++ b/eZ/Publish/SPI/Search/FieldType/IdentifierField.php
@@ -19,4 +19,11 @@ class IdentifierField extends FieldType
      * @var string
      */
     protected $type = 'ez_id';
+
+    /**
+     * Indicates that value will not be normalized.
+     *
+     * @var bool
+     */
+    protected $raw = false;
 }

--- a/eZ/Publish/SPI/Search/FieldType/MultipleIdentifierField.php
+++ b/eZ/Publish/SPI/Search/FieldType/MultipleIdentifierField.php
@@ -19,4 +19,11 @@ class MultipleIdentifierField extends FieldType
      * @var string
      */
     protected $type = 'ez_mid';
+
+    /**
+     * Indicates that values will not be normalized.
+     *
+     * @var bool
+     */
+    protected $raw = false;
 }

--- a/phpunit-integration-legacy-solr.xml
+++ b/phpunit-integration-legacy-solr.xml
@@ -58,6 +58,7 @@
             <file>eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php</file>
+            <file>eZ/Publish/API/Repository/Tests/SearchServiceAggregationTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php</file>
             <file>eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php</file>
         </testsuite>


### PR DESCRIPTION
| Question | Answer |
| --- | --- |
| **JIRA issue** | [EZP-27458](https://jira.ez.no/browse/EZP-27458) |
| **Type** | feature |
| **Target eZ Platform version** | `v3.2` |
| **BC breaks** | no |
| **Tests pass** | ? |
| **Doc needed** | yes |

### Introduction

Aggregation API is successor of Facet API, however aggregation is wider concept then facet.

### Description

Aggregation MUST implement `\eZ\Publish\API\Repository\Values\Content\Query\AggregationInterface` interface

```php
<?php

/**
 * @copyright Copyright (C) eZ Systems AS. All rights reserved.
 * @license For full copyright and license information view LICENSE file distributed with this source code.
 */
declare(strict_types=1);

namespace eZ\Publish\API\Repository\Values\Content\Query;

interface AggregationInterface
{
    public function getName(): string;
} 
```

Method `getName()` SHOULD return identifier specified by API user and unique across query e.g. `price_stats`, `availability`, `content_type_facet`.

One or more aggregations could be added using `\eZ\Publish\API\Repository\Values\Content\Query::$aggregations` property in exact same way as in case of sort clauses:

```php
<?php 

use eZ\Publish\API\Repository\Values\Content\Query;
use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ContentTypeTermAggregation;
use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\SectionTermAggregation;

$query = new Query();
$query->aggregations[] = new ContentTypeTermAggregation('content_type_facet');
$query->aggregations[] = new SectionTermAggregation('section_facet');

$results = $this->searchService->findContent($query);

// ... 
```

Aggregation Result MUST extends `\eZ\Publish\API\Repository\Values\Content\Search\AggregationResult` class

```php
abstract class AggregationResult extends ValueObject
{
    /**
     * The name of the related aggregation.
     *
     * @var string
     */
    private $name;

    public function __construct(string $name)
    {
        parent::__construct();

        $this->name = $name;
    }

    public function getName(): string
    {
        return $this->name;
    }
}
```

Collection of aggregation results is accessible via `\eZ\Publish\API\Repository\Values\Content\Search\SearchResult::$aggregations` property.

```php
// ...

foreach ($results->aggregations as $aggregation) {
    // Iterate over aggregations results
}
```

`\eZ\Publish\API\Repository\Values\Content\Search\SearchResult::$aggregations` property is `\eZ\Publish\API\Repository\Values\Content\Search\AggregationResultCollection` which offers the following API

Aggregations which are not supported by search engine MUST be ignored.

Aggregation results are limited to objects which match criteria specified in `\eZ\Publish\API\Repository\Values\Content\Query::$filter` and `\eZ\Publish\API\Repository\Values\Content\Query::$query`.

### Supported aggregations

Aggregations could be classified by type of result:

*   **Term aggregation**: group by value and count object in each group
*   **Range aggregation**: count values in specified ranges
*   **Stats aggregation:** computes stats over numeric fields: minimum, average and maximum value, count and sum of values

or by aggregation subject:

*   **Content aggregation**
*   **Location aggregation**

with subset of **Field Type specific** aggregations.

#### Content aggregations

<table><tbody><tr><td>Name</td><td>Comment</td></tr><tr><td><code>ContentTypeTermAggregation</code></td><td>Term aggregation based on content type &nbsp;</td></tr><tr><td><code>ContentTypeGroupTermAggregation</code></td><td>Term aggregation based on content type group&nbsp;</td></tr><tr><td><code>DateMetadataRangeAggregation</code></td><td>Range aggregation based on content creation/modification/publication date</td></tr><tr><td><code>LanguageTermAggregation</code></td><td>Term aggregation based on content language</td></tr><tr><td><code>ObjectStateTermAggregation</code></td><td>Term aggregation based on object state</td></tr><tr><td><code>SectionTermAggregation</code></td><td>Term aggregation based on section</td></tr><tr><td><code>UserMetadataTermAggregation</code></td><td>Term aggregation based on content owner/owner group or modifier</td></tr><tr><td><code>VisibilityTermAggregation</code></td><td>Term aggregation based on content/location visibility</td></tr></tbody></table>

#### Location aggregations

Location specific aggregations should implement `\eZ\Publish\API\Repository\Values\Content\Query\Aggregation\LocationAggregationInterface` marker interface.

#### Field type specific aggregations

Field type specific aggregations should implement `\eZ\Publish\API\Repository\Values\Content\Query\Aggregation\FieldAggregationInterface` interface

```php
<?php

/**
 * @copyright Copyright (C) eZ Systems AS. All rights reserved.
 * @license For full copyright and license information view LICENSE file distributed with this source code.
 */
declare(strict_types=1);

namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation;

interface FieldAggregationInterface
{
    public function getContentTypeIdentifier(): string;

    public function getFieldDefinitionIdentifier(): string;
}
```

> Class naming convention:
> 
> *   Field type identifier without vendor prefix (\`ez\` in our case)
> *   Type of aggregation
> *   `Aggregation` suffix

The following aggregations are field type specific

<table><tbody><tr><td>Name</td><td>Comment</td></tr><tr><td><code>CheckboxTermAggregation</code></td><td>-</td></tr><tr><td><code>CountryTermAggregation</code></td><td>-</td></tr><tr><td><code>DateRangeAggregation</code></td><td>-</td></tr><tr><td><code>DateTimeRangeAggregation</code></td><td>-</td></tr><tr><td><code>FloatRangeAggregation</code></td><td>-</td></tr><tr><td><code>FloatStatsAggregation</code></td><td>-</td></tr><tr><td><code>IntegerRangeAggregation</code></td><td>-</td></tr><tr><td><code>IntegerStatsAggregation</code></td><td>-</td></tr><tr><td><code>KeywordTermAggregation</code></td><td>-</td></tr><tr><td><code>SelectionTermAggregation</code></td><td>-</td></tr><tr><td><code>TimeRangeAggregation</code></td><td>-</td></tr></tbody></table>

Usage example:

```
<?php

$query = new Query();
$query->aggregations[] = new CheckboxTermAggregation('availability', 'product', 'is_available');
$query->aggregations[] = new KeywordTermAggregation('tags', 'product', 'tags');
$query->aggregations[] = new SelectionTermAggregation('categories', 'product', 'category');
```

#### Raw aggregations

Raw aggregations allows to compute aggregation for specified search index field name.

*   `\eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawRangeAggregation`
*   `\eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawStatsAggregation`
*   `\eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawTermAggregation`

```php
$query = new LocationQuery();
$query->filter = new MatchAll();
$query->aggregations[] = new RawRangeAggregation('priority', 'priority_id', [
    new Range(1, 10),  // low priority locations
    new Range(10, 100) // high priority
]);
$query->aggregations[] = new RawStatsAggregation('location_depth_stats', 'depth_i');
$query->aggregations[] = new RawTermAggregation('content_per_content_type', 'content_type_id_id');
```

#### TODO

*   [x] Initial implementaion
*   [x] Deprecate Facet API
*   [x] Introduce `\eZ\Publish\Core\Search\Common\FieldNameResolver::getAggregationFieldName`
*   [x] Consider to intoroduce `AggregationCollection` and `AggregationResultCollection` (similar to `\eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCollection`)
*   [x] Impl. `\eZ\Publish\Core\FieldType\Float\Type::isSearchable` (#103)
*   [x] Impl. ElasticSearch (ezsystems/ezplatform-elastic-search-engine#13)
*   [x] Impl. Solr support (ezsystems/ezplatform-solr-search-engine#192)
*   [x] Rename UserTermAggregation to UserMetadataTermAggregation
*   [x] Rename DateRangeAggregation to DateMetadataRangeAggregation
*   [x] Remove $limit and $minCount from \`\\eZ\\Publish\\API\\Repository\\Values\\Content\\Query\\Aggregation\\AbstractTermAggregation::\_\_construct\`
*   [x] Fix https://jira.ez.no/browse/EZP-31741 

#### Checklist:

*   [x] PR description is updated.
*   [x] Tests are implemented.
*   [x] Added code follows Coding Standards (use `$ composer fix-cs`).
*   [x] PR is ready for a review.