### PR TITLE
EZP-31789: Fixed invalid array type returned for getFieldErrors

### DIFF
--- a/eZ/Publish/Core/Repository/Strategy/ContentValidator/ContentValidatorStrategy.php
+++ b/eZ/Publish/Core/Repository/Strategy/ContentValidator/ContentValidatorStrategy.php
@@ -48,7 +48,7 @@ final class ContentValidatorStrategy implements ContentValidator
             if ($contentValidator->supports($object)) {
                 $validatorFound = true;
 
-                $fieldErrors = array_merge_recursive(
+                $fieldErrors = $this->mergeErrors(
                     $fieldErrors,
                     $contentValidator->validate($object, $context, $fieldIdentifiers)
                 );
@@ -62,5 +62,23 @@ final class ContentValidatorStrategy implements ContentValidator
         throw new InvalidArgumentException('$object', sprintf(
             'Validator for %s type not found.', get_class($object)
         ));
+    }
+
+    private function mergeErrors(
+        array $fieldErrors,
+        array $foundErrors
+    ): array {
+        foreach ($foundErrors as $fieldId => $errors) {
+            if (!empty($fieldErrors[$fieldId])) {
+                $fieldErrors[$fieldId] = array_merge(
+                    $fieldErrors[$fieldId],
+                    $errors
+                );
+            } else {
+                $fieldErrors[$fieldId] = $errors;
+            }
+        }
+
+        return $fieldErrors;
     }
 }

--- a/eZ/Publish/Core/Repository/Strategy/ContentValidator/ContentValidatorStrategy.php
+++ b/eZ/Publish/Core/Repository/Strategy/ContentValidator/ContentValidatorStrategy.php
@@ -69,8 +69,8 @@ final class ContentValidatorStrategy implements ContentValidator
         array $foundErrors
     ): array {
         foreach ($foundErrors as $fieldId => $errors) {
-            $fieldErrors[$fieldId] = empty($fieldErrors[$fieldId]) 
-                ? $errors 
+            $fieldErrors[$fieldId] = empty($fieldErrors[$fieldId])
+                ? $errors
                 : array_merge(
                     $fieldErrors[$fieldId],
                     $errors

--- a/eZ/Publish/Core/Repository/Strategy/ContentValidator/ContentValidatorStrategy.php
+++ b/eZ/Publish/Core/Repository/Strategy/ContentValidator/ContentValidatorStrategy.php
@@ -69,14 +69,12 @@ final class ContentValidatorStrategy implements ContentValidator
         array $foundErrors
     ): array {
         foreach ($foundErrors as $fieldId => $errors) {
-            if (!empty($fieldErrors[$fieldId])) {
-                $fieldErrors[$fieldId] = array_merge(
+            $fieldErrors[$fieldId] = empty($fieldErrors[$fieldId]) 
+                ? $errors 
+                : array_merge(
                     $fieldErrors[$fieldId],
                     $errors
                 );
-            } else {
-                $fieldErrors[$fieldId] = $errors;
-            }
         }
 
         return $fieldErrors;

--- a/eZ/Publish/Core/Repository/Tests/ContentValidator/ContentValidatorStrategyTest.php
+++ b/eZ/Publish/Core/Repository/Tests/ContentValidator/ContentValidatorStrategyTest.php
@@ -101,7 +101,7 @@ class ContentValidatorStrategyTest extends TestCase
 
             public function supports(ValueObject $object): bool
             {
-                return is_a($object, $this->classSupport);
+                return $object instanceof $this->classSupport;
             }
 
             public function validate(

--- a/eZ/Publish/Core/Repository/Tests/ContentValidator/ContentValidatorStrategyTest.php
+++ b/eZ/Publish/Core/Repository/Tests/ContentValidator/ContentValidatorStrategyTest.php
@@ -27,22 +27,7 @@ class ContentValidatorStrategyTest extends TestCase
     public function testKnownValidationObject(): void
     {
         $contentValidatorStrategy = new ContentValidatorStrategy([
-            new class() implements ContentValidator {
-                public function supports(ValueObject $object): bool
-                {
-                    return $object instanceof ObjectState;
-                }
-
-                public function validate(
-                    ValueObject $object,
-                    array $context = [],
-                    ?array $fieldIdentifiers = null
-                ): array {
-                    return [
-                        'test',
-                    ];
-                }
-            },
+            $this->buildContentValidator(ObjectState::class, ['test']),
         ]);
 
         $errors = $contentValidatorStrategy->validate(new ObjectState());
@@ -60,26 +45,72 @@ class ContentValidatorStrategyTest extends TestCase
     public function testSuportsKnownValidationObject(): void
     {
         $contentValidatorStrategy = new ContentValidatorStrategy([
-            new class() implements ContentValidator {
-                public function supports(ValueObject $object): bool
-                {
-                    return $object instanceof ObjectState;
-                }
-
-                public function validate(
-                    ValueObject $object,
-                    array $context = [],
-                    ?array $fieldIdentifiers = null
-                ): array {
-                    return [
-                        'test',
-                    ];
-                }
-            },
+            $this->buildContentValidator(ObjectState::class, ['test']),
         ]);
 
         $supports = $contentValidatorStrategy->supports(new ObjectState());
 
         $this->assertTrue($supports);
+    }
+
+    public function testMergeValidationErrors(): void
+    {
+        $contentValidatorStrategy = new ContentValidatorStrategy([
+            $this->buildContentValidator(ObjectState::class, [
+                123 => ['eng-GB' => '123-eng-GB'],
+                456 => ['pol-PL' => '456-pol-PL'],
+            ]),
+            $this->buildContentValidator(ObjectState::class, []),
+            $this->buildContentValidator(ObjectState::class, [
+                321 => ['pol-PL' => '321-pol-PL'],
+            ]),
+            $this->buildContentValidator(ObjectState::class, [
+                2345 => ['eng-GB' => '2345-eng-GB'],
+                456 => ['eng-GB' => '456-eng-GB'],
+            ]),
+        ]);
+
+        $errors = $contentValidatorStrategy->validate(new ObjectState());
+        $this->assertEquals([
+            123 => ['eng-GB' => '123-eng-GB'],
+            321 => ['pol-PL' => '321-pol-PL'],
+            456 => [
+                'pol-PL' => '456-pol-PL',
+                'eng-GB' => '456-eng-GB',
+            ],
+            2345 => ['eng-GB' => '2345-eng-GB'],
+        ], $errors);
+    }
+
+    private function buildContentValidator(string $classSupport, array $validationReturn): ContentValidator
+    {
+        return new class($classSupport, $validationReturn) implements ContentValidator {
+            /** @var string */
+            private $classSupport;
+
+            /** @var array */
+            private $validationReturn;
+
+            public function __construct(
+                string $classSupport,
+                array $validationReturn
+            ) {
+                $this->classSupport = $classSupport;
+                $this->validationReturn = $validationReturn;
+            }
+
+            public function supports(ValueObject $object): bool
+            {
+                return is_a($object, $this->classSupport);
+            }
+
+            public function validate(
+                ValueObject $object,
+                array $context = [],
+                ?array $fieldIdentifiers = null
+            ): array {
+                return $this->validationReturn;
+            }
+        };
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31789](https://jira.ez.no/browse/EZP-31789)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.1`
| **BC breaks**                          | yes (this is regression fix)
| **Tests pass**                          | yes
| **Doc needed**                       | no


Unfortunately `array_merge_recursive` reindexes numeric keys and we use numeric field ID as a first level key for field validations errors. 


#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
