### PR TITLE
EZP-31793: Moved Image FieldType XML processing to ImageStorage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ branches:
   only:
     - master
     - /^\d.\d+$/
+    - merge-up-master/ezp-30857-image-storage-fixes
 
 # setup requirements for running unit/integration/behat tests
 before_install:

--- a/doc/upgrade/1.1.md
+++ b/doc/upgrade/1.1.md
@@ -1,0 +1,30 @@
+# Upgrade steps from ezplatform-kernel v1.1 to v1.2
+
+## Internal changes
+
+Changes to parts on which there's no strict backward compatibility promise.
+
+### Image (`ezimage`) External Storage
+
+* The method `\eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway::extractFilesFromXml` has been
+  deprecated in favor of `\eZ\Publish\Core\FieldType\Image\ImageStorage::extractOriginalFilePathFromXML`.
+
+  The latter one returns a single path of an original file or null if not found. Legacy Image Variations
+  (aliases) are no longer returned since they are generated on the fly and are not stored in that XML
+  anymore.
+
+* The protected method `\eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway\DoctrineStorage::canRemoveImageReference`
+  has been dropped.
+
+* The responsibility of checking if an image reference can be removed was shifted from Image
+  Doctrine gateway to its External Storage. The method
+  `\eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway::removeImageReferences`
+  now performs removal only, without any prior checks.
+
+* Introduced the method
+  `eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway::getImageXMLForOtherVersions`
+
+* `\eZ\Publish\Core\FieldType\Image\ImageStorage` constructor signature has changed:
+  * Dropped injection of unused Services `\eZ\Publish\Core\IO\MetadataHandler` and
+    `\eZ\Publish\Core\Base\Utils\DeprecationWarnerInterface`,
+  * Injected `\eZ\Publish\Core\IO\UrlRedecoratorInterface` and `\Psr\Log\LoggerInterface`.

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -10,11 +10,9 @@ use DOMDocument;
 use DOMXPath;
 use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException as APIInvalidArgumentException;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
-use eZ\Publish\Core\Base\Utils\DeprecationWarnerInterface as DeprecationWarner;
 use eZ\Publish\Core\IO\UrlRedecoratorInterface;
 use eZ\Publish\SPI\FieldType\GatewayBasedStorage;
 use eZ\Publish\Core\IO\IOServiceInterface;
-use eZ\Publish\Core\IO\MetadataHandler;
 use eZ\Publish\SPI\FieldType\StorageGateway;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
@@ -32,12 +30,6 @@ class ImageStorage extends GatewayBasedStorage
     /** @var \eZ\Publish\Core\FieldType\Image\PathGenerator */
     protected $pathGenerator;
 
-    /** @var \eZ\Publish\Core\IO\MetadataHandler */
-    protected $imageSizeMetadataHandler;
-
-    /** @var \eZ\Publish\Core\Base\Utils\DeprecationWarnerInterface */
-    private $deprecationWarner;
-
     /** @var \eZ\Publish\Core\FieldType\Image\AliasCleanerInterface */
     protected $aliasCleaner;
 
@@ -54,8 +46,6 @@ class ImageStorage extends GatewayBasedStorage
         StorageGateway $gateway,
         IOServiceInterface $ioService,
         PathGenerator $pathGenerator,
-        MetadataHandler $imageSizeMetadataHandler,
-        DeprecationWarner $deprecationWarner,
         AliasCleanerInterface $aliasCleaner,
         UrlRedecoratorInterface $urlRedecorator,
         LoggerInterface $logger
@@ -63,8 +53,6 @@ class ImageStorage extends GatewayBasedStorage
         parent::__construct($gateway);
         $this->ioService = $ioService;
         $this->pathGenerator = $pathGenerator;
-        $this->imageSizeMetadataHandler = $imageSizeMetadataHandler;
-        $this->deprecationWarner = $deprecationWarner;
         $this->aliasCleaner = $aliasCleaner;
         $this->gateway = $gateway;
         $this->urlRedecorator = $urlRedecorator;

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
@@ -61,6 +61,15 @@ abstract class Gateway extends StorageGateway
 
     /**
      * Returns the public uris for the images stored in $xml.
+     *
+     * @param string $xml
+     *
+     * @return array|null
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     *
+     * @deprecated since eZ Platform 3.2. Use
+     * {@see \eZ\Publish\Core\FieldType\Image\ImageStorage::extractOriginalFilePathFromXML} instead.
      */
     abstract public function extractFilesFromXml($xml);
 

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
@@ -63,4 +63,11 @@ abstract class Gateway extends StorageGateway
      * Returns the public uris for the images stored in $xml.
      */
     abstract public function extractFilesFromXml($xml);
+
+    /**
+     * Get Image XML for the given path and the given field, but NOT matching the given Version no.
+     *
+     * @param int $versionNo a Version NOT to be matched
+     */
+    abstract public function getImageXMLForOtherVersions(int $versionNo, int $fieldId): array;
 }

--- a/eZ/Publish/Core/FieldType/Tests/Image/ImageStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Image/ImageStorageTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\FieldType\Tests\Image;
+
+use eZ\Publish\Core\FieldType\Image\AliasCleanerInterface;
+use eZ\Publish\Core\FieldType\Image\ImageStorage;
+use eZ\Publish\Core\FieldType\Image\PathGenerator;
+use eZ\Publish\Core\IO\IOServiceInterface;
+use eZ\Publish\Core\IO\UrlRedecoratorInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+
+/**
+ * @internal
+ */
+final class ImageStorageTest extends TestCase
+{
+    /** @var \eZ\Publish\Core\FieldType\Image\ImageStorage */
+    private $imageStorage;
+
+    /** @var \eZ\Publish\Core\IO\UrlRedecoratorInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $urlRedecoratorMock;
+
+    public function getDataForTestExtractOriginalFilePathsFromXML(): iterable
+    {
+        yield 'Correct image XML' => [
+            <<<XML
+<?xml version="1.0" encoding="utf-8"?>
+<ezimage serial_number="1" is_valid="1" filename="foo.png"
+    suffix="png" basename="foo" dirpath="var/site/storage/images/3/9/1/0/193-1-eng-GB" url="var/site/storage/images/3/9/1/0/193-1-eng-GB/foo.png"
+    original_filename="foo.png" mime_type="image/png" width="1487"
+    height="1105" alternative_text="" alias_key="1293033771" timestamp="1596794011">
+  <original attribute_id="193" attribute_version="1" attribute_language="eng-GB"/>
+  <information Height="1105" Width="1487" IsColor="1"/>
+</ezimage>
+XML,
+            '/var/site/storage/images/3/9/1/0/193-1-eng-GB/foo.png',
+        ];
+
+        yield 'No XML' => [
+            '',
+            null,
+        ];
+
+        yield 'Image XML without URI' => [
+            <<<XML
+<?xml version="1.0" encoding="utf-8"?>
+<ezimage>
+  <original attribute_id="193" attribute_version="1" attribute_language="eng-GB"/>
+  <information Height="1105" Width="1487" IsColor="1"/>
+</ezimage>
+XML,
+            null,
+        ];
+    }
+
+    protected function setUp(): void
+    {
+        $this->imageStorage = new ImageStorage(
+            $this->createMock(ImageStorage\Gateway::class),
+            $this->createMock(IOServiceInterface::class),
+            $this->createMock(PathGenerator::class),
+            $this->createMock(AliasCleanerInterface::class),
+            $this->getUrlRedecoratorMock(),
+            new NullLogger()
+        );
+    }
+
+    /**
+     * @dataProvider getDataForTestExtractOriginalFilePathsFromXML
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    public function testExtractOriginalFilePathsFromXML(string $xml, ?string $expectedURI): void
+    {
+        $this
+            ->getUrlRedecoratorMock()
+            ->method('redecorateFromTarget')
+            ->willReturnCallback(
+                // AbsolutePrefix mock
+                static function (string $url) {
+                    return "/{$url}";
+                }
+            );
+
+        self::assertEquals(
+            $expectedURI,
+            $this->imageStorage->extractOriginalFilePathFromXML($xml),
+        );
+    }
+
+    /**
+     * @return \eZ\Publish\Core\IO\UrlRedecoratorInterface|\PHPUnit\Framework\MockObject\MockObject
+     */
+    protected function getUrlRedecoratorMock(): UrlRedecoratorInterface
+    {
+        if (null === $this->urlRedecoratorMock) {
+            $this->urlRedecoratorMock = $this->createMock(UrlRedecoratorInterface::class);
+        }
+
+        return $this->urlRedecoratorMock;
+    }
+}

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -18,6 +18,8 @@ services:
             $imageSizeMetadataHandler: '@ezpublish.fieldType.metadataHandler.imagesize'
             $deprecationWarner: '@ezpublish.utils.deprecation_warner'
             $aliasCleaner: '@eZ\Publish\Core\FieldType\Image\AliasCleanerInterface'
+            $urlRedecorator: '@ezpublish.core.io.image_fieldtype.legacy_url_redecorator'
+            $logger: '@logger'
         tags:
             - {name: ezplatform.field_type.external_storage_handler, alias: ezimage}
 

--- a/eZ/Publish/Core/settings/fieldtype_external_storages.yml
+++ b/eZ/Publish/Core/settings/fieldtype_external_storages.yml
@@ -15,8 +15,6 @@ services:
             $gateway: '@ezpublish.fieldType.ezimage.storage_gateway'
             $ioService: '@ezpublish.fieldType.ezimage.io_service'
             $pathGenerator: '@ezpublish.fieldType.ezimage.pathGenerator'
-            $imageSizeMetadataHandler: '@ezpublish.fieldType.metadataHandler.imagesize'
-            $deprecationWarner: '@ezpublish.utils.deprecation_warner'
             $aliasCleaner: '@eZ\Publish\Core\FieldType\Image\AliasCleanerInterface'
             $urlRedecorator: '@ezpublish.core.io.image_fieldtype.legacy_url_redecorator'
             $logger: '@logger'

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -7,13 +7,13 @@
 namespace eZ\Publish\SPI\Tests\FieldType;
 
 use eZ\Publish\Core\Persistence\Legacy;
-use eZ\Publish\Core\IO;
 use eZ\Publish\Core\FieldType;
 use eZ\Publish\Core\Base\Utils\DeprecationWarnerInterface;
 use eZ\Publish\Core\FieldType\Image\AliasCleanerInterface;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\NullLogger;
 use RecursiveIteratorIterator;
 use RecursiveDirectoryIterator;
 use FileSystemIterator;
@@ -93,9 +93,9 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
                 ),
                 $this->ioService,
                 new FieldType\Image\PathGenerator\LegacyPathGenerator(),
-                new IO\MetadataHandler\ImageSize(),
-                $this->getDeprecationWarnerMock(),
-                $this->getAliasCleanerMock()
+                $this->getAliasCleanerMock(),
+                $urlRedecorator,
+                new NullLogger()
             )
         );
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-31793
| **Requires** | ezsystems/ezpublish-kernel#3056
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.2`
| **BC breaks**                          | yes, on internal components
| **Doc needed**                       | maybe

Till now, Doctrine gateway (`DoctrineStorage`) for Image Field Type External Storage was responsible for processing XML of  `ezcontentobject_attribute`.`data_text` database field, which doesn't fall into a scope of Doctrine gateways.

The processing has been moved to `ImageStorage`. Moreover unused services injected into `ImageStorage` (`MetadataHandler`, `DeprecationWarner`) were dropped.

The processing of Image FT XML is now done by `ImageStorage::extractOriginalFilePathFromXML` method. The Gateway method `extractFilesFromXml` has been deprecated and will be removed in the next major.

The difference in behavior now is that the new method returns single string with the path to the original stored file (or null if not found) instead of an associative array containing original image path and variation paths. The reason for this change is that image variations are no longer stored in Image FT XML. They're generated on the fly when needed by `ez_image_alias` Twig function calling `\eZ\Publish\SPI\Variation\VariationHandler::getVariation` method.

To achieve the above goals, the `canRemoveImageReference` method was moved from the Doctrine gateway to `ImageStorage`. The `getImageXMLForOtherVersions` method has been implemented for the Doctrine gateway.


#### TODO
- [ ] Wait for ezsystems/ezpublish-kernel#3056
- [ ] Drop temporary base branch `merge-up-master/ezp-30857-image-storage-fixes`
- [ ] Drop TMP commit.

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
