### PR TITLE
EZP-31806: Casted destinationContentId to int

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/FieldType/ImageAsset/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/ImageAsset/ParameterProvider.php
@@ -50,7 +50,7 @@ class ParameterProvider implements ParameterProviderInterface
 
         try {
             $contentInfo = $this->loadContentInfo(
-                $field->value->destinationContentId
+                (int)$field->value->destinationContentId
             );
 
             return [


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31806](https://jira.ez.no/browse/EZP-31806)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

As stated in `\eZ\Publish\Core\FieldType\ImageAsset\Value`
```php
    /**
     * Related content id's.
     *
     * @var mixed|null
     */
    public $destinationContentId;
```

destination content ID could be also a string, as it is not utilized now and there is always int passed in terms of creating external connectors this needs to be unified in one way or another, till that it seems only fair to handle in both and cast that ID to int before passing to service.

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
