### PR TITLE
EZP-31462: Added command checking if there are any unsupported password hash types

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/ValidatePasswordHashesCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/ValidatePasswordHashesCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace EzSystems\PlatformInstallerBundle\Command;
+
+use eZ\Publish\Core\FieldType\User\UserStorage;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+final class ValidatePasswordHashesCommand extends Command
+{
+    /** @var \eZ\Publish\Core\FieldType\User\UserStorage */
+    private $userStorage;
+
+    public function __construct(
+        UserStorage $userStorage
+    ) {
+        $this->userStorage = $userStorage;
+        parent::__construct();
+    }
+
+    protected function configure()
+    {
+        $this->setName('ezplatform:user:validate-password-hashes');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $unsupportedHashesCounter = $this->userStorage->countUsersWithUnsupportedHashType();
+
+        if ($unsupportedHashesCounter > 0) {
+            $output->writeln(sprintf('<error>Found %s users with unsupported password hash types</error>', $unsupportedHashesCounter));
+            $output->writeln('<info>For more details check documentation:</info> <href=https://doc.ezplatform.com/en/latest/releases/ez_platform_v3.0_deprecations/#password-hashes>https://doc.ezplatform.com/en/latest/releases/ez_platform_v3.0_deprecations/#password-hashes</>');
+        } else {
+            $output->writeln('OK - <info>All users have supported password hash types</info>');
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -25,3 +25,10 @@ services:
             $repositoryConfigurationProvider: '@ezpublish.api.repository_configuration_provider'
         tags:
             - { name: console.command, command: ezplatform:install }
+
+    EzSystems\PlatformInstallerBundle\Command\ValidatePasswordHashesCommand:
+        arguments:
+            $userStorage: '@ezpublish.fieldType.ezuser.externalStorage'
+
+        tags:
+            - { name: console.command, command: ezplatform:user:validate-password-hashes }

--- a/eZ/Publish/API/Repository/Exceptions/PasswordInUnsupportedFormatException.php
+++ b/eZ/Publish/API/Repository/Exceptions/PasswordInUnsupportedFormatException.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Exceptions;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+use Throwable;
+
+class PasswordInUnsupportedFormatException extends AuthenticationException
+{
+    public function __construct(Throwable $previous = null)
+    {
+        parent::__construct("User's password is in a format which is not supported any more.", 0, $previous);
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
@@ -260,7 +260,7 @@ class UserIntegrationTest extends BaseIntegrationTest
                 'login' => 'changeLogin',
                 'email' => 'changeEmail@ez.no',
                 'passwordHash' => '*2',
-                'passwordHashType' => 1,
+                'passwordHashType' => User::DEFAULT_PASSWORD_HASH,
                 'enabled' => false,
             ]
         );
@@ -284,7 +284,7 @@ class UserIntegrationTest extends BaseIntegrationTest
             'hasStoredLogin' => true,
             'login' => 'changeLogin',
             'email' => 'changeEmail@ez.no',
-            'passwordHashType' => 1,
+            'passwordHashType' => User::DEFAULT_PASSWORD_HASH,
             'enabled' => false,
         ];
 

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -10,7 +10,6 @@ use DateInterval;
 use DateTime;
 use DateTimeImmutable;
 use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
-use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\API\Repository\Values\Content\Language;
@@ -2707,7 +2706,7 @@ class UserServiceTest extends BaseTest
      *
      * @see \eZ\Publish\API\Repository\UserService::createUser()
      */
-    public function testCreateUserInvalidPasswordHashTypeThrowsException()
+    public function testCreateUserWithDefaultPasswordHashTypeWhenHashTypeIsUnsupported(): void
     {
         $repository = $this->getRepository();
         $eventUserService = $repository->getUserService();
@@ -2743,12 +2742,11 @@ class UserServiceTest extends BaseTest
         // Set not supported hash type.
         $userValue->passwordHashType = 42424242;
 
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage("Argument 'hashType' is invalid: Password hash type '42424242' is not recognized");
-
         // Create a new user instance.
         // 13 is ID of the "Editors" user group in an eZ Publish demo installation.
-        $eventUserService->createUser($createStruct, [$eventUserService->loadUserGroup(13)]);
+        $createdUser = $eventUserService->createUser($createStruct, [$eventUserService->loadUserGroup(13)]);
+
+        self::assertEquals(User::DEFAULT_PASSWORD_HASH, $createdUser->hashAlgorithm);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Values/User/User.php
+++ b/eZ/Publish/API/Repository/Values/User/User.php
@@ -24,6 +24,11 @@ use eZ\Publish\API\Repository\Values\Content\Content;
  */
 abstract class User extends Content implements UserReference
 {
+    public const SUPPORTED_PASSWORD_HASHES = [
+        self::PASSWORD_HASH_BCRYPT,
+        self::PASSWORD_HASH_PHP_DEFAULT,
+    ];
+
     /** @var int Passwords in bcrypt */
     const PASSWORD_HASH_BCRYPT = 6;
 

--- a/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/UserDoctrineStorageGatewayTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/UserDoctrineStorageGatewayTest.php
@@ -1,0 +1,21 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Integration\User\UserStorage;
+
+use eZ\Publish\Core\FieldType\Tests\Integration\User\UserStorage\UserStorageGatewayTest;
+use eZ\Publish\Core\FieldType\User\UserStorage\Gateway as UserStorageGateway;
+use eZ\Publish\Core\FieldType\User\UserStorage\Gateway\DoctrineStorage;
+
+final class UserDoctrineStorageGatewayTest extends UserStorageGatewayTest
+{
+    protected function getGateway(): UserStorageGateway
+    {
+        return new DoctrineStorage($this->getDatabaseConnection());
+    }
+}

--- a/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/_fixtures/unsupported_hash.yaml
+++ b/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/_fixtures/unsupported_hash.yaml
@@ -1,0 +1,4 @@
+ezuser:
+    - { contentobject_id: 10, email: nospam@ez.no, login: anonymous, password_hash: $2y$10$35gOSQs6JK4u4whyERaeUuVeQBi2TUBIZIfP7HEj7sfz.MxvTuOeC, password_hash_type: 7 }
+    - { contentobject_id: 16, email: test@link.invalid, login: test, password_hash: $2y$10$35gOSQs6JK4u4whyERaeUuVeQBi2TUBIZIfP7HEj7sfz.MxvTuOeC, password_hash_type: 5 }
+    - { contentobject_id: 14, email: spam@ez.no, login: admin, password_hash: $2y$10$FDn9NPwzhq85cLLxfD5Wu.L3SL3Z/LNCvhkltJUV0wcJj7ciJg2oy, password_hash_type: 7 }

--- a/eZ/Publish/Core/FieldType/User/Type.php
+++ b/eZ/Publish/Core/FieldType/User/Type.php
@@ -10,6 +10,7 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\Core\Repository\Values\User\User;
 use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
 use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use eZ\Publish\Core\Repository\User\PasswordValidatorInterface;
@@ -251,7 +252,7 @@ class Type extends FieldType
      */
     public function toPersistenceValue(SPIValue $value)
     {
-        $value->passwordHashType = $value->passwordHashType ?? $this->passwordHashService->getDefaultHashType();
+        $value->passwordHashType = $this->getPasswordHashTypeForPersistenceValue($value);
         if ($value->plainPassword) {
             $value->passwordHash = $this->passwordHashService->createPasswordHash(
                 $value->plainPassword,
@@ -267,6 +268,19 @@ class Type extends FieldType
                 'sortKey' => null,
             ]
         );
+    }
+
+    private function getPasswordHashTypeForPersistenceValue(SPIValue $value): int
+    {
+        if (null === $value->passwordHashType) {
+            return $this->passwordHashService->getDefaultHashType();
+        }
+
+        if (!in_array($value->passwordHashType, User::SUPPORTED_PASSWORD_HASHES, true)) {
+            return $this->passwordHashService->getDefaultHashType();
+        }
+
+        return $value->passwordHashType;
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/User/UserStorage.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage.php
@@ -112,4 +112,9 @@ class UserStorage extends GatewayBasedStorage
     public function getIndexData(VersionInfo $versionInfo, Field $field, array $context)
     {
     }
+
+    public function countUsersWithUnsupportedHashType(): int
+    {
+        return $this->gateway->countUsersWithUnsupportedHashType();
+    }
 }

--- a/eZ/Publish/Core/FieldType/User/UserStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage/Gateway.php
@@ -49,4 +49,6 @@ abstract class Gateway extends StorageGateway
      * @throws \Doctrine\DBAL\DBALException
      */
     abstract public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds): bool;
+
+    abstract public function countUsersWithUnsupportedHashType(): int;
 }

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
@@ -6,10 +6,13 @@
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Authentication;
 
+use eZ\Publish\API\Repository\Exceptions\PasswordInUnsupportedFormatException;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\Core\MVC\Symfony\Security\UserInterface as EzUserInterface;
+use eZ\Publish\Core\Repository\User\Exception\UnsupportedPasswordHashType;
 use Symfony\Component\Security\Core\Authentication\Provider\DaoAuthenticationProvider;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
 use Symfony\Component\Security\Core\Exception\BadCredentialsException;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -59,5 +62,17 @@ class RepositoryAuthenticationProvider extends DaoAuthenticationProvider
 
         // Finally inject current user in the Repository
         $this->permissionResolver->setCurrentUserReference($apiUser);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\PasswordInUnsupportedFormatException
+     */
+    public function authenticate(TokenInterface $token)
+    {
+        try {
+            return parent::authenticate($token);
+        } catch (UnsupportedPasswordHashType $exception) {
+            throw new PasswordInUnsupportedFormatException($exception);
+        }
     }
 }

--- a/eZ/Publish/Core/Repository/User/Exception/UnsupportedPasswordHashType.php
+++ b/eZ/Publish/Core/Repository/User/Exception/UnsupportedPasswordHashType.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Repository\User\Exception;
+
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+
+class UnsupportedPasswordHashType extends InvalidArgumentException
+{
+    public function __construct(int $hashType)
+    {
+        parent::__construct('hashType', "Password hash type '$hashType' is not recognized");
+    }
+}

--- a/eZ/Publish/Core/Repository/User/PasswordHashService.php
+++ b/eZ/Publish/Core/Repository/User/PasswordHashService.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\Repository\User;
 
 use eZ\Publish\API\Repository\Values\User\User;
-use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\Repository\User\Exception\UnsupportedPasswordHashType;
 
 /**
  * @internal
@@ -29,6 +29,9 @@ final class PasswordHashService implements PasswordHashServiceInterface
         return $this->hashType;
     }
 
+    /**
+     * @throws \eZ\Publish\Core\Repository\User\Exception\UnsupportedPasswordHashType
+     */
     public function createPasswordHash(string $password, ?int $hashType = null): string
     {
         $hashType = $hashType ?? $this->hashType;
@@ -41,7 +44,7 @@ final class PasswordHashService implements PasswordHashServiceInterface
                 return password_hash($password, PASSWORD_DEFAULT);
 
             default:
-                throw new InvalidArgumentException('hashType', "Password hash type '$hashType' is not recognized");
+                throw new UnsupportedPasswordHashType($hashType);
         }
     }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31462](https://jira.ez.no/browse/EZP-31462)
| **Required by**                       | ezsystems/ezplatform-user#75 ezsystems/ezplatform#593
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.1`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | yes

In order to have better UX, there was added redirection to 'Change password' page in a case when a user with unsupported hash type tries to log in. To achieve that more significant exceptions were added to detect unsupported hash type scenario - an exception will be handle by ezplatform-user (https://github.com/ezsystems/ezplatform-user/pull/75).
It does not affect REST API authentication, invariably 401:Unauthorized is returned.
It does not affect GraphQL, to get session ID for GraphQL you should authenticate by REST API first.

Additionally, the command was created which can be run during upgrade process. Command informs if there are any users with unsupported hash types in DB

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.