### PR TITLE
EZP-29886: Added loadObjectStateGroupByIdentifier/loadObjectStateByIdentifier methods to ObjectStateService

### DIFF
--- a/eZ/Publish/API/Repository/ObjectStateService.php
+++ b/eZ/Publish/API/Repository/ObjectStateService.php
@@ -46,6 +46,18 @@ interface ObjectStateService
     public function loadObjectStateGroup(int $objectStateGroupId, array $prioritizedLanguages = []): ObjectStateGroup;
 
     /**
+     * Loads a object state group by identifier.
+     *
+     * @param string $objectStateGroupIdentifier
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the group was not found
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
+     */
+    public function loadObjectStateGroupByIdentifier(string $objectStateGroupIdentifier, array $prioritizedLanguages = []): ObjectStateGroup;
+
+    /**
      * Loads all object state groups.
      *
      * @param int $offset
@@ -115,6 +127,19 @@ interface ObjectStateService
      * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
      */
     public function loadObjectState(int $stateId, array $prioritizedLanguages = []): ObjectState;
+
+    /**
+     * Loads an object state by identifier and group it belongs to.
+     *
+     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
+     * @param string $objectStateIdentifier
+     * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the state was not found
+     *
+     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
+     */
+    public function loadObjectStateByIdentifier(ObjectStateGroup $objectStateGroup, string $objectStateIdentifier, array $prioritizedLanguages = []): ObjectState;
 
     /**
      * Updates an object state.

--- a/eZ/Publish/API/Repository/ObjectStateService.php
+++ b/eZ/Publish/API/Repository/ObjectStateService.php
@@ -48,12 +48,9 @@ interface ObjectStateService
     /**
      * Loads a object state group by identifier.
      *
-     * @param string $objectStateGroupIdentifier
      * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the group was not found
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup
      */
     public function loadObjectStateGroupByIdentifier(string $objectStateGroupIdentifier, array $prioritizedLanguages = []): ObjectStateGroup;
 
@@ -131,13 +128,9 @@ interface ObjectStateService
     /**
      * Loads an object state by identifier and group it belongs to.
      *
-     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
-     * @param string $objectStateIdentifier
      * @param string[] $prioritizedLanguages Used as prioritized language code on translated properties of returned object.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException if the state was not found
-     *
-     * @return \eZ\Publish\API\Repository\Values\ObjectState\ObjectState
      */
     public function loadObjectStateByIdentifier(ObjectStateGroup $objectStateGroup, string $objectStateIdentifier, array $prioritizedLanguages = []): ObjectState;
 

--- a/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
@@ -389,8 +389,6 @@ class ObjectStateServiceTest extends BaseTest
     {
         $repository = $this->getRepository();
 
-        // $objectStateGroupIdentifier contains the identifier of the standard object state
-        // group ez_lock.
         $objectStateService = $repository->getObjectStateService();
 
         $loadedObjectStateGroup = $objectStateService->loadObjectStateGroupByIdentifier(
@@ -420,12 +418,16 @@ class ObjectStateServiceTest extends BaseTest
      */
     public function testLoadObjectStateGroupByIdentifierThrowsNotFoundException(): void
     {
-        $this->expectException(NotFoundException::class);
-
         $repository = $this->getRepository();
 
         $objectStateService = $repository->getObjectStateService();
-        // Throws a not found exception
+
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(sprintf(
+            "Could not find 'ObjectStateGroup' with identifier '%s'",
+            self::NON_EXISTING_OBJECT_STATE_IDENTIFIER
+        ));
+
         $objectStateService->loadObjectStateGroupByIdentifier(
             self::NON_EXISTING_OBJECT_STATE_GROUP_IDENTIFIER
         );
@@ -1059,12 +1061,15 @@ class ObjectStateServiceTest extends BaseTest
             $loadedObjectState
         );
 
-        $this->assertPropertiesCorrect([
-            'id' => 2,
-            'identifier' => self::EXISTING_OBJECT_STATE_IDENTIFIER,
-            'priority' => 1,
-            'languageCodes' => ['eng-US'],
-        ], $loadedObjectState);
+        $this->assertPropertiesCorrect(
+            [
+                'id' => 2,
+                'identifier' => self::EXISTING_OBJECT_STATE_IDENTIFIER,
+                'priority' => 1,
+                'languageCodes' => ['eng-US'],
+            ],
+            $loadedObjectState
+        );
     }
 
     /**
@@ -1072,8 +1077,6 @@ class ObjectStateServiceTest extends BaseTest
      */
     public function testLoadObjectStateByIdentifierThrowsNotFoundException(): void
     {
-        $this->expectException(NotFoundException::class);
-
         $repository = $this->getRepository();
 
         $objectStateService = $repository->getObjectStateService();
@@ -1082,7 +1085,15 @@ class ObjectStateServiceTest extends BaseTest
             self::EXISTING_OBJECT_STATE_GROUP_IDENTIFIER
         );
 
-        // Throws a not found exception
+        $this->expectException(NotFoundException::class);
+        $this->expectExceptionMessage(sprintf(
+            "Could not find 'ObjectState' with identifier '%s'",
+            var_export([
+                'identifier' => self::NON_EXISTING_OBJECT_STATE_IDENTIFIER,
+                'groupId' => $loadedObjectStateGroup->id,
+            ], true)
+        ));
+
         $objectStateService->loadObjectStateByIdentifier(
             $loadedObjectStateGroup,
             self::NON_EXISTING_OBJECT_STATE_IDENTIFIER

--- a/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
@@ -23,6 +23,12 @@ use eZ\Publish\API\Repository\Exceptions\NotFoundException;
  */
 class ObjectStateServiceTest extends BaseTest
 {
+    private const EXISTING_OBJECT_STATE_GROUP_IDENTIFIER = 'ez_lock';
+    private const EXISTING_OBJECT_STATE_IDENTIFIER = 'locked';
+
+    private const NON_EXISTING_OBJECT_STATE_GROUP_IDENTIFIER = 'non-existing';
+    private const NON_EXISTING_OBJECT_STATE_IDENTIFIER = 'non-existing';
+
     /**
      * Test for the newObjectStateGroupCreateStruct() method.
      *
@@ -359,7 +365,7 @@ class ObjectStateServiceTest extends BaseTest
      */
     public function testLoadObjectStateGroupThrowsNotFoundException()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
+        $this->expectException(NotFoundException::class);
 
         $repository = $this->getRepository();
 
@@ -374,6 +380,55 @@ class ObjectStateServiceTest extends BaseTest
             $nonExistentObjectStateGroupId
         );
         /* END: Use Case */
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\ObjectStateService::loadGroupByIdentifier
+     */
+    public function testLoadObjectStateGroupByIdentifier(): void
+    {
+        $repository = $this->getRepository();
+
+        // $objectStateGroupIdentifier contains the identifier of the standard object state
+        // group ez_lock.
+        $objectStateService = $repository->getObjectStateService();
+
+        $loadedObjectStateGroup = $objectStateService->loadObjectStateGroupByIdentifier(
+            self::EXISTING_OBJECT_STATE_GROUP_IDENTIFIER
+        );
+
+        $this->assertInstanceOf(
+            ObjectStateGroup::class,
+            $loadedObjectStateGroup
+        );
+
+        $this->assertPropertiesCorrect(
+            [
+                'id' => 2,
+                'identifier' => 'ez_lock',
+                'mainLanguageCode' => 'eng-US',
+                'languageCodes' => ['eng-US'],
+                'names' => ['eng-US' => 'Lock'],
+                'descriptions' => ['eng-US' => ''],
+            ],
+            $loadedObjectStateGroup
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\API\Repository\ObjectStateService::loadGroupByIdentifier
+     */
+    public function testLoadObjectStateGroupByIdentifierThrowsNotFoundException(): void
+    {
+        $this->expectException(NotFoundException::class);
+
+        $repository = $this->getRepository();
+
+        $objectStateService = $repository->getObjectStateService();
+        // Throws a not found exception
+        $objectStateService->loadObjectStateGroupByIdentifier(
+            self::NON_EXISTING_OBJECT_STATE_GROUP_IDENTIFIER
+        );
     }
 
     /**
@@ -982,6 +1037,59 @@ class ObjectStateServiceTest extends BaseTest
     }
 
     /**
+     * @see \eZ\Publish\API\Repository\ObjectStateService::loadObjectStateByIdentifier
+     */
+    public function testLoadObjectStateByIdentifier(): void
+    {
+        $repository = $this->getRepository();
+
+        $objectStateService = $repository->getObjectStateService();
+
+        $objectStateGroup = $objectStateService->loadObjectStateGroupByIdentifier(
+            self::EXISTING_OBJECT_STATE_GROUP_IDENTIFIER
+        );
+
+        $loadedObjectState = $objectStateService->loadObjectStateByIdentifier(
+            $objectStateGroup,
+            self::EXISTING_OBJECT_STATE_IDENTIFIER
+        );
+
+        $this->assertInstanceOf(
+            ObjectState::class,
+            $loadedObjectState
+        );
+
+        $this->assertPropertiesCorrect([
+            'id' => 2,
+            'identifier' => self::EXISTING_OBJECT_STATE_IDENTIFIER,
+            'priority' => 1,
+            'languageCodes' => ['eng-US'],
+        ], $loadedObjectState);
+    }
+
+    /**
+     * @see \eZ\Publish\API\Repository\ObjectStateService::loadObjectStateByIdentifier
+     */
+    public function testLoadObjectStateByIdentifierThrowsNotFoundException(): void
+    {
+        $this->expectException(NotFoundException::class);
+
+        $repository = $this->getRepository();
+
+        $objectStateService = $repository->getObjectStateService();
+
+        $loadedObjectStateGroup = $objectStateService->loadObjectStateGroupByIdentifier(
+            self::EXISTING_OBJECT_STATE_GROUP_IDENTIFIER
+        );
+
+        // Throws a not found exception
+        $objectStateService->loadObjectStateByIdentifier(
+            $loadedObjectStateGroup,
+            self::NON_EXISTING_OBJECT_STATE_IDENTIFIER
+        );
+    }
+
+    /**
      * testLoadObjectStateStructValues.
      *
      * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectState $loadedObjectState
@@ -1024,7 +1132,7 @@ class ObjectStateServiceTest extends BaseTest
      */
     public function testLoadObjectStateThrowsNotFoundException()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
+        $this->expectException(NotFoundException::class);
 
         $repository = $this->getRepository();
 

--- a/eZ/Publish/Core/Repository/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/ObjectStateService.php
@@ -125,6 +125,15 @@ class ObjectStateService implements ObjectStateServiceInterface
         return $this->buildDomainObjectStateGroupObject($spiObjectStateGroup, $prioritizedLanguages);
     }
 
+    public function loadObjectStateGroupByIdentifier(
+        string $objectStateGroupIdentifier,
+        array $prioritizedLanguages = []
+    ): APIObjectStateGroup {
+        $spiObjectStateGroup = $this->objectStateHandler->loadGroupByIdentifier($objectStateGroupIdentifier);
+
+        return $this->buildDomainObjectStateGroupObject($spiObjectStateGroup, $prioritizedLanguages);
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -317,6 +326,19 @@ class ObjectStateService implements ObjectStateServiceInterface
     public function loadObjectState(int $stateId, array $prioritizedLanguages = []): APIObjectState
     {
         $spiObjectState = $this->objectStateHandler->load($stateId);
+
+        return $this->buildDomainObjectStateObject($spiObjectState, null, $prioritizedLanguages);
+    }
+
+    public function loadObjectStateByIdentifier(
+        APIObjectStateGroup $objectStateGroup,
+        string $objectStateIdentifier,
+        array $prioritizedLanguages = []
+    ): APIObjectState {
+        $spiObjectState = $this->objectStateHandler->loadByIdentifier(
+            $objectStateIdentifier,
+            $objectStateGroup->id
+        );
 
         return $this->buildDomainObjectStateObject($spiObjectState, null, $prioritizedLanguages);
     }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ObjectStateService.php
@@ -53,6 +53,15 @@ class ObjectStateService implements ObjectStateServiceInterface
         return $this->service->loadObjectStateGroup($objectStateGroupId, $prioritizedLanguages);
     }
 
+    public function loadObjectStateGroupByIdentifier(
+        string $objectStateGroupIdentifier,
+        array $prioritizedLanguages = null
+    ): ObjectStateGroup {
+        $prioritizedLanguages = $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages);
+
+        return $this->service->loadObjectStateGroupByIdentifier($objectStateGroupIdentifier, $prioritizedLanguages);
+    }
+
     public function loadObjectStateGroups(int $offset = 0, int $limit = -1, array $prioritizedLanguages = null): iterable
     {
         $prioritizedLanguages = $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages);
@@ -87,6 +96,20 @@ class ObjectStateService implements ObjectStateServiceInterface
         $prioritizedLanguages = $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages);
 
         return $this->service->loadObjectState($stateId, $prioritizedLanguages);
+    }
+
+    public function loadObjectStateByIdentifier(
+        ObjectStateGroup $objectStateGroup,
+        string $objectStateIdentifier,
+        array $prioritizedLanguages = null
+    ): ObjectState {
+        $prioritizedLanguages = $this->languageResolver->getPrioritizedLanguages($prioritizedLanguages);
+
+        return $this->service->loadObjectStateByIdentifier(
+            $objectStateGroup,
+            $objectStateIdentifier,
+            $prioritizedLanguages
+        );
     }
 
     public function updateObjectState(ObjectState $objectState, ObjectStateUpdateStruct $objectStateUpdateStruct): ObjectState

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ObjectStateServiceTest.php
@@ -70,9 +70,11 @@ class ObjectStateServiceTest extends AbstractServiceTest
         // string $method, array $arguments, mixed $return, int $languageArgumentIndex
         return [
             ['loadObjectStateGroup', [11, self::LANG_ARG], $objectStateGroup, 1],
+            ['loadObjectStateGroupByIdentifier', ['ez_lock', self::LANG_ARG], $objectStateGroup, 1],
             ['loadObjectStateGroups', [50, 50, self::LANG_ARG], [$objectStateGroup], 2],
             ['loadObjectStates', [$objectStateGroup, self::LANG_ARG], [$objectState], 1],
             ['loadObjectState', [3, self::LANG_ARG], $objectState, 1],
+            ['loadObjectStateByIdentifier', [$objectStateGroup, 'locked', self::LANG_ARG], $objectState, 2],
         ];
     }
 }

--- a/eZ/Publish/SPI/Repository/Decorator/ObjectStateServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/ObjectStateServiceDecorator.php
@@ -39,6 +39,13 @@ abstract class ObjectStateServiceDecorator implements ObjectStateService
         return $this->innerService->loadObjectStateGroup($objectStateGroupId, $prioritizedLanguages);
     }
 
+    public function loadObjectStateGroupByIdentifier(
+        string $objectStateGroupIdentifier,
+        array $prioritizedLanguages = []
+    ): ObjectStateGroup {
+        return $this->innerService->loadObjectStateGroupByIdentifier($objectStateGroupIdentifier, $prioritizedLanguages);
+    }
+
     public function loadObjectStateGroups(
         int $offset = 0,
         int $limit = -1,
@@ -78,6 +85,18 @@ abstract class ObjectStateServiceDecorator implements ObjectStateService
         array $prioritizedLanguages = []
     ): ObjectState {
         return $this->innerService->loadObjectState($stateId, $prioritizedLanguages);
+    }
+
+    public function loadObjectStateByIdentifier(
+        ObjectStateGroup $objectStateGroup,
+        string $objectStateIdentifier,
+        array $prioritizedLanguages = []
+    ): ObjectState {
+        return $this->innerService->loadObjectStateByIdentifier(
+            $objectStateGroup,
+            $objectStateIdentifier,
+            $prioritizedLanguages
+        );
     }
 
     public function updateObjectState(

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/ObjectStateServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/ObjectStateServiceDecoratorTest.php
@@ -60,6 +60,31 @@ class ObjectStateServiceDecoratorTest extends TestCase
         $decoratedService->loadObjectStateGroup(...$parameters);
     }
 
+    public function testLoadObjectStateGroupByIdentifierDecorator(): void
+    {
+        $serviceMock = $this->createServiceMock();
+        $decoratedService = $this->createDecorator($serviceMock);
+        $expectedObjectStateGroup = $this->createMock(ObjectStateGroup::class);
+
+        $parameters = [
+            'ez_lock',
+            ['eng-GB'],
+        ];
+
+        $serviceMock
+            ->expects($this->once())
+            ->method('loadObjectStateGroupByIdentifier')
+            ->with(...$parameters)
+            ->willReturn($expectedObjectStateGroup);
+
+        $actualObjectStateGroup = $decoratedService->loadObjectStateGroupByIdentifier(...$parameters);
+
+        $this->assertEquals(
+            $expectedObjectStateGroup,
+            $actualObjectStateGroup
+        );
+    }
+
     public function testLoadObjectStateGroupsDecorator()
     {
         $serviceMock = $this->createServiceMock();
@@ -146,6 +171,32 @@ class ObjectStateServiceDecoratorTest extends TestCase
         $serviceMock->expects($this->once())->method('loadObjectState')->with(...$parameters);
 
         $decoratedService->loadObjectState(...$parameters);
+    }
+
+    public function testLoadObjectStateDecoratorByIdentifier(): void
+    {
+        $serviceMock = $this->createServiceMock();
+        $decoratedService = $this->createDecorator($serviceMock);
+        $expectedObjectState = $this->createMock(ObjectState::class);
+
+        $parameters = [
+            $this->createMock(ObjectStateGroup::class),
+            'locked',
+            ['eng-GB'],
+        ];
+
+        $serviceMock
+            ->expects($this->once())
+            ->method('loadObjectStateByIdentifier')
+            ->with(...$parameters)
+            ->willReturn($expectedObjectState);
+
+        $actualObjectState = $decoratedService->loadObjectStateByIdentifier(...$parameters);
+
+        $this->assertEquals(
+            $expectedObjectState,
+            $actualObjectState
+        );
     }
 
     public function testUpdateObjectStateDecorator()


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-29886](https://jira.ez.no/browse/EZP-29886)
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | yes

Introduced 

* `loadObjectStateGroupByIdentifier(string $objectStateGroupIdentifier, array $prioritizedLanguages = []): ObjectStateGroup` 
* `loadObjectStateByIdentifier(ObjectStateGroup $objectStateGroup, string $objectStateIdentifier, array $prioritizedLanguages = []): ObjectState` 

methods to `\eZ\Publish\API\Repository\ObjectStateService`. 

PR is based on original @wizhippo work in https://github.com/ezsystems/ezpublish-kernel/pull/2500. In compare to original PR code has been adapted to changes introduced in 3.0.

Needed to unblock implementation of Object State aggregation in https://github.com/ezsystems/ezplatform-elastic-search-engine/pull/13 ezsystems/ezplatform-solr-search-engine#192


#### Checklist:
- [X] PR description is updated.
- [X] Tests are implemented.
- [X] Added code follows Coding Standards (use `$ composer fix-cs`).
- [X] PR is ready for a review.
