### PR TITLE
EZP-31811: Fixed deleted relation fieldtypes

### DIFF
--- a/eZ/Publish/Core/Repository/Helper/RelationProcessor.php
+++ b/eZ/Publish/Core/Repository/Helper/RelationProcessor.php
@@ -116,7 +116,7 @@ class RelationProcessor
         // Map existing relations for easier handling
         $mappedRelations = [];
         foreach ($existingRelations as $relation) {
-            if ($relation->type & Relation::FIELD) {
+            if ($relation->type & Relation::FIELD && null !== $relation->sourceFieldDefinitionIdentifier) {
                 $fieldDefinition = $contentType->getFieldDefinition($relation->sourceFieldDefinitionIdentifier);
                 if ($fieldDefinition !== null) {
                     $mappedRelations[Relation::FIELD][$fieldDefinition->id][$relation->destinationContentInfo->id] = $relation;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31811](https://jira.ez.no/browse/EZP-31811)
| **Type**                                   | bug
| **Target eZ Platform version** | v3.1
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

Deleted 'Content relation' fieldtype results in an error when editing Content possessing this relation previously. When the relation does not exist anymore `mappedRelations` will be build and throw an exception before.

#### Checklist:
- [x] PR description is updated.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.