### PR TITLE
Fixed NotImplementedException exception message thrown by CompositeCriterion::getSpecifications

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/CompositeCriterion.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/CompositeCriterion.php
@@ -23,6 +23,6 @@ abstract class CompositeCriterion extends Criterion
 
     public function getSpecifications(): array
     {
-        throw new NotImplementedException('getSpecifications() not implemented for AggregateCriterion');
+        throw new NotImplementedException('getSpecifications() not implemented for CompositeCriterion');
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

We decided to rename `AggregateCriterion` to `CompositeCriterion` during the code review.

#### Checklist:
- [x] PR description is updated.
- [ ] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
