### PR TITLE
EZP-31817: Enabled ezfloat values indexing

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -193,12 +193,6 @@ abstract class BaseTest extends TestCase
         return $this->setupFactory;
     }
 
-    protected function isLegacySearchEngine(): bool
-    {
-        // Check using get_class since the others extend SetupFactory\Legacy
-        return ltrim(get_class($this->getSetupFactory()), '\\') === Legacy::class;
-    }
-
     /**
      * Asserts that properties given in $expectedValues are correctly set in
      * $actualObject.

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -193,6 +193,12 @@ abstract class BaseTest extends TestCase
         return $this->setupFactory;
     }
 
+    protected function isLegacySearchEngine(): bool
+    {
+        // Check using get_class since the others extend SetupFactory\Legacy
+        return ltrim(get_class($this->getSetupFactory()), '\\') === Legacy::class;
+    }
+
     /**
      * Asserts that properties given in $expectedValues are correctly set in
      * $actualObject.

--- a/eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
@@ -358,4 +358,11 @@ class FloatIntegrationTest extends SearchBaseIntegrationTest
         // See \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase::index
         return !$this->isLegacySearchEngine();
     }
+
+    protected function getFullTextIndexedFieldData()
+    {
+        return [
+            ['25.519', '25.59'],
+        ];
+    }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
@@ -353,16 +353,6 @@ class FloatIntegrationTest extends SearchBaseIntegrationTest
 
     public function checkFullTextSupport(): bool
     {
-        // Legacy SE is indexing float numbers as two separate terms e.g.
-        // "25.519" will be indexed as "25" and "519"
-        // See \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase::index
-        return !$this->isLegacySearchEngine();
-    }
-
-    protected function getFullTextIndexedFieldData()
-    {
-        return [
-            ['25.519', '25.59'],
-        ];
+        return false;
     }
 }

--- a/eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
@@ -351,10 +351,11 @@ class FloatIntegrationTest extends SearchBaseIntegrationTest
         return 25.59;
     }
 
-    protected function getFullTextIndexedFieldData()
+    public function checkFullTextSupport(): bool
     {
-        return [
-            ['25.519', '25.59'],
-        ];
+        // Legacy SE is indexing float numbers as two separate terms e.g.
+        // "25.519" will be indexed as "25" and "519"
+        // See \eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway\DoctrineDatabase::index
+        return !$this->isLegacySearchEngine();
     }
 }

--- a/eZ/Publish/Core/FieldType/Float/Type.php
+++ b/eZ/Publish/Core/FieldType/Float/Type.php
@@ -219,10 +219,12 @@ class Type extends FieldType
 
     /**
      * {@inheritdoc}
+     *
+     * @param \eZ\Publish\Core\FieldType\Float\Value $value
      */
     protected function getSortInfo(BaseValue $value)
     {
-        return false;
+        return $value->value;
     }
 
     /**
@@ -255,5 +257,10 @@ class Type extends FieldType
         }
 
         return $value->value;
+    }
+
+    public function isSearchable(): bool
+    {
+        return true;
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/FloatConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/FloatConverter.php
@@ -42,7 +42,7 @@ class FloatConverter implements Converter
     public function toStorageValue(FieldValue $value, StorageFieldValue $storageFieldValue)
     {
         $storageFieldValue->dataFloat = $value->data;
-        $storageFieldValue->sortKeyInt = $value->sortKey;
+        $storageFieldValue->sortKeyString = $value->sortKey;
     }
 
     /**
@@ -54,7 +54,7 @@ class FloatConverter implements Converter
     public function toFieldValue(StorageFieldValue $value, FieldValue $fieldValue)
     {
         $fieldValue->data = $value->dataFloat;
-        $fieldValue->sortKey = $value->sortKeyInt;
+        $fieldValue->sortKey = $value->sortKeyString;
     }
 
     /**
@@ -112,7 +112,7 @@ class FloatConverter implements Converter
      */
     public function getIndexColumn()
     {
-        return 'sort_key_int';
+        return 'sort_key_string';
     }
 
     /**


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31817](https://jira.ez.no/browse/EZP-31817)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Tests pass**                          | yes
| **Doc needed**                       | no

Currently is not possible to search for `ezfloat` values  (e.g. using `\eZ\Publish\API\Repository\Values\Content\Query\Criterion\Field` criterion).

Even if there is `\eZ\Publish\SPI\FieldType\Indexable` implementation registered for `ezfloat` FT (see `\eZ\Publish\Core\FieldType\Float\SearchField`) still `\eZ\Publish\Core\FieldType\Float\Type::isSearchable` returns false.



#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
