### PR TITLE
EZP-31740: Introduced SiteAccess-aware NFS adapter

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/helpers.yml
@@ -59,6 +59,9 @@ services:
             $configResolver: '@ezpublish.config.resolver'
             $siteAccessService: '@ezpublish.siteaccess_service'
 
+    eZ\Publish\SPI\SiteAccess\ConfigProcessor:
+        alias: eZ\Bundle\EzPublishCoreBundle\SiteAccess\Config\ComplexConfigProcessor
+
     eZ\Bundle\EzPublishCoreBundle\SiteAccess\Config\IOConfigResolver:
         arguments:
             $complexConfigProcessor: '@eZ\Bundle\EzPublishCoreBundle\SiteAccess\Config\ComplexConfigProcessor'

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/Config/ComplexConfigProcessor.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/Config/ComplexConfigProcessor.php
@@ -12,9 +12,10 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ComplexSetti
 use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessService;
+use eZ\Publish\SPI\SiteAccess\ConfigProcessor;
 use function str_replace;
 
-final class ComplexConfigProcessor
+final class ComplexConfigProcessor implements ConfigProcessor
 {
     private const DEFAULT_NAMESPACE = 'ezsettings';
 

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/Config/ComplexConfigProcessor.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/Config/ComplexConfigProcessor.php
@@ -12,6 +12,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ComplexSetti
 use eZ\Publish\Core\MVC\Exception\ParameterNotFoundException;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessService;
+use function str_replace;
 
 final class ComplexConfigProcessor
 {
@@ -23,12 +24,18 @@ final class ComplexConfigProcessor
     /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessService */
     private $siteAccessService;
 
+    /** @var \eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ComplexSettings\ComplexSettingParserInterface */
+    private $complexSettingParser;
+
     public function __construct(
         ConfigResolverInterface $configResolver,
         SiteAccessService $siteAccessService
     ) {
         $this->configResolver = $configResolver;
         $this->siteAccessService = $siteAccessService;
+
+        // instantiate non-injectable DI configuration parser
+        $this->complexSettingParser = new ComplexSettingParser();
     }
 
     public function processComplexSetting(string $setting): string
@@ -39,31 +46,35 @@ final class ComplexConfigProcessor
             throw new ParameterNotFoundException($setting, null, [$siteAccessName]);
         }
 
-        $complexSettingParser = new ComplexSettingParser();
         $settingValue = $this->configResolver->getParameter($setting, null, $siteAccessName);
 
-        if (!$complexSettingParser->containsDynamicSettings($settingValue)) {
+        if (!$this->complexSettingParser->containsDynamicSettings($settingValue)) {
             return $settingValue;
         }
 
         // we kind of need to process this as well, don't we ?
-        if ($complexSettingParser->isDynamicSetting($settingValue)) {
-            $parts = $complexSettingParser->parseDynamicSetting($settingValue);
+        if ($this->complexSettingParser->isDynamicSetting($settingValue)) {
+            $parts = $this->complexSettingParser->parseDynamicSetting($settingValue);
 
             return $this->configResolver->getParameter($parts['param'], null, $siteAccessName);
         }
 
-        $value = $settingValue;
-        foreach ($complexSettingParser->parseComplexSetting($settingValue) as $dynamicSetting) {
-            $parts = $complexSettingParser->parseDynamicSetting($dynamicSetting);
+        return $this->processSettingValue($settingValue);
+    }
+
+    public function processSettingValue(string $value): string
+    {
+        foreach ($this->complexSettingParser->parseComplexSetting($value) as $dynamicSetting) {
+            $parts = $this->complexSettingParser->parseDynamicSetting($dynamicSetting);
             if (!isset($parts['namespace'])) {
                 $parts['namespace'] = self::DEFAULT_NAMESPACE;
             }
-            if (!isset($parts['scope'])) {
-                $parts['scope'] = $siteAccessName;
-            }
 
-            $dynamicSettingValue = $this->configResolver->getParameter($parts['param'], $parts['namespace'], $parts['scope']);
+            $dynamicSettingValue = $this->configResolver->getParameter(
+                $parts['param'],
+                $parts['namespace'],
+                $parts['scope'] ?? $this->siteAccessService->getCurrent()->name
+            );
 
             $value = str_replace($dynamicSetting, $dynamicSettingValue, $value);
         }

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/Flysystem.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/Flysystem.php
@@ -62,7 +62,8 @@ abstract class Flysystem implements ConfigurationFactory, ContainerAwareInterfac
     private function createFilesystem(ContainerBuilder $container, $name, $adapter)
     {
         $adapterId = sprintf('oneup_flysystem.%s_adapter', $adapter);
-        if (!$container->hasDefinition($adapterId)) {
+        // has either definition or alias
+        if (!$container->has($adapterId)) {
             throw new InvalidConfigurationException("Unknown flysystem adapter $adapter");
         }
 

--- a/eZ/Bundle/EzPublishIOBundle/Flysystem/Adapter/SiteAccessAwareLocalAdapter.php
+++ b/eZ/Bundle/EzPublishIOBundle/Flysystem/Adapter/SiteAccessAwareLocalAdapter.php
@@ -43,6 +43,7 @@ final class SiteAccessAwareLocalAdapter extends Local
     {
         $contextPath = $this->configProcessor->processSettingValue($this->path);
 
-        return sprintf('%s%s%s', $this->pathPrefix, \DIRECTORY_SEPARATOR, $contextPath);
+        // path prefix is guaranteed to have path separator suffix, see parent::setPathPrefix
+        return sprintf('%s%s', $this->pathPrefix, $contextPath);
     }
 }

--- a/eZ/Bundle/EzPublishIOBundle/Flysystem/Adapter/SiteAccessAwareLocalAdapter.php
+++ b/eZ/Bundle/EzPublishIOBundle/Flysystem/Adapter/SiteAccessAwareLocalAdapter.php
@@ -8,7 +8,7 @@ declare(strict_types=1);
 
 namespace eZ\Bundle\EzPublishIOBundle\Flysystem\Adapter;
 
-use eZ\Bundle\EzPublishCoreBundle\SiteAccess\Config\ComplexConfigProcessor;
+use eZ\Publish\SPI\SiteAccess\ConfigProcessor;
 use League\Flysystem\Adapter\Local;
 use function sprintf;
 
@@ -18,16 +18,16 @@ use function sprintf;
 final class SiteAccessAwareLocalAdapter extends Local
 {
     /** @var \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Config\ComplexConfigProcessor */
-    private $complexConfigProcessor;
+    private $configProcessor;
 
     /** @var string */
     private $path;
 
     public function __construct(
-        ComplexConfigProcessor $complexConfigProcessor,
+        ConfigProcessor $configProcessor,
         array $config
     ) {
-        $this->complexConfigProcessor = $complexConfigProcessor;
+        $this->configProcessor = $configProcessor;
 
         parent::__construct(
             $config['root'],
@@ -41,7 +41,7 @@ final class SiteAccessAwareLocalAdapter extends Local
 
     public function getPathPrefix(): string
     {
-        $contextPath = $this->complexConfigProcessor->processSettingValue($this->path);
+        $contextPath = $this->configProcessor->processSettingValue($this->path);
 
         return sprintf('%s%s%s', $this->pathPrefix, \DIRECTORY_SEPARATOR, $contextPath);
     }

--- a/eZ/Bundle/EzPublishIOBundle/Flysystem/Adapter/SiteAccessAwareLocalAdapter.php
+++ b/eZ/Bundle/EzPublishIOBundle/Flysystem/Adapter/SiteAccessAwareLocalAdapter.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Bundle\EzPublishIOBundle\Flysystem\Adapter;
+
+use eZ\Bundle\EzPublishCoreBundle\SiteAccess\Config\ComplexConfigProcessor;
+use League\Flysystem\Adapter\Local;
+
+/**
+ * @internal for internal use by Repository IO integration. Do not use directly.
+ */
+final class SiteAccessAwareLocalAdapter extends Local
+{
+    /** @var \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Config\ComplexConfigProcessor */
+    private $complexConfigProcessor;
+
+    public function __construct(
+        ComplexConfigProcessor $complexConfigProcessor,
+        array $config
+    ) {
+        parent::__construct(
+            $config['directory'],
+            $config['writeFlags'],
+            $config['linkHandling'],
+            $config['permissions']
+        );
+
+        $this->complexConfigProcessor = $complexConfigProcessor;
+    }
+
+    public function getPathPrefix(): string
+    {
+        return $this->complexConfigProcessor->processSettingValue($this->pathPrefix);
+    }
+}

--- a/eZ/Bundle/EzPublishIOBundle/Flysystem/Adapter/SiteAccessAwareLocalAdapter.php
+++ b/eZ/Bundle/EzPublishIOBundle/Flysystem/Adapter/SiteAccessAwareLocalAdapter.php
@@ -10,6 +10,7 @@ namespace eZ\Bundle\EzPublishIOBundle\Flysystem\Adapter;
 
 use eZ\Bundle\EzPublishCoreBundle\SiteAccess\Config\ComplexConfigProcessor;
 use League\Flysystem\Adapter\Local;
+use function sprintf;
 
 /**
  * @internal for internal use by Repository IO integration. Do not use directly.
@@ -19,22 +20,29 @@ final class SiteAccessAwareLocalAdapter extends Local
     /** @var \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Config\ComplexConfigProcessor */
     private $complexConfigProcessor;
 
+    /** @var string */
+    private $path;
+
     public function __construct(
         ComplexConfigProcessor $complexConfigProcessor,
         array $config
     ) {
+        $this->complexConfigProcessor = $complexConfigProcessor;
+
         parent::__construct(
-            $config['directory'],
+            $config['root'],
             $config['writeFlags'],
             $config['linkHandling'],
             $config['permissions']
         );
 
-        $this->complexConfigProcessor = $complexConfigProcessor;
+        $this->path = $config['path'];
     }
 
     public function getPathPrefix(): string
     {
-        return $this->complexConfigProcessor->processSettingValue($this->pathPrefix);
+        $contextPath = $this->complexConfigProcessor->processSettingValue($this->path);
+
+        return sprintf('%s%s%s', $this->pathPrefix, \DIRECTORY_SEPARATOR, $contextPath);
     }
 }

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -1,3 +1,10 @@
+parameters:
+    ibexa.platform.io.nfs.adapter.config:
+        directory: '$var_dir$/$storage_dir$'
+        writeFlags: ~
+        linkHandling: ~
+        permissions: [ ]
+
 services:
     ezpublish.core.io.command.migrate_files:
         class: eZ\Bundle\EzPublishIOBundle\Command\MigrateFilesCommand
@@ -102,6 +109,14 @@ services:
         arguments:
             - '@eZ\Publish\Core\IO\IOConfigProvider'
             - '@ezpublish.config.resolver'
+
+    eZ\Bundle\EzPublishIOBundle\Flysystem\Adapter\SiteAccessAwareLocalAdapter:
+        arguments:
+            $complexConfigProcessor: '@eZ\Bundle\EzPublishCoreBundle\SiteAccess\Config\ComplexConfigProcessor'
+            $config: '%ibexa.platform.io.nfs.adapter.config%'
+
+    ibexa.platform.io.nfs.adapter.site_access_aware:
+        alias: eZ\Bundle\EzPublishIOBundle\Flysystem\Adapter\SiteAccessAwareLocalAdapter
 
     ezpublish.core.io.prefix_url_decorator:
         class: eZ\Publish\Core\IO\UrlDecorator\AbsolutePrefix

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -113,7 +113,7 @@ services:
 
     eZ\Bundle\EzPublishIOBundle\Flysystem\Adapter\SiteAccessAwareLocalAdapter:
         arguments:
-            $complexConfigProcessor: '@eZ\Bundle\EzPublishCoreBundle\SiteAccess\Config\ComplexConfigProcessor'
+            $configProcessor: '@eZ\Publish\SPI\SiteAccess\ConfigProcessor'
             $config: '%ibexa.platform.io.nfs.adapter.config%'
 
     ibexa.platform.io.nfs.adapter.site_access_aware:

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -1,6 +1,7 @@
 parameters:
     ibexa.platform.io.nfs.adapter.config:
-        directory: '$var_dir$/$storage_dir$'
+        root: './'
+        path: '$var_dir$/$storage_dir$/'
         writeFlags: ~
         linkHandling: ~
         permissions: [ ]

--- a/eZ/Bundle/EzPublishIOBundle/Tests/Flysystem/Adapter/SiteAccessAwareLocalAdapterTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/Flysystem/Adapter/SiteAccessAwareLocalAdapterTest.php
@@ -1,0 +1,65 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Bundle\EzPublishIOBundle\Tests\Flysystem\Adapter;
+
+use eZ\Bundle\EzPublishIOBundle\Flysystem\Adapter\SiteAccessAwareLocalAdapter;
+use eZ\Publish\SPI\SiteAccess\ConfigProcessor;
+use PHPUnit\Framework\TestCase;
+
+class SiteAccessAwareLocalAdapterTest extends TestCase
+{
+    private const DYNAMIC_PATH = '__DYNAMIC_PATH__';
+    private const STATIC_PATH = '__STATIC_PATH__';
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\SiteAccess\Config\ComplexConfigProcessor|\PHPUnit\Framework\MockObject\MockObject */
+    private $complexConfigProcessor;
+
+    protected function setUp(): void
+    {
+        $this->complexConfigProcessor = $this->createMock(ConfigProcessor::class);
+    }
+
+    private static function getConfig(): array
+    {
+        return [
+            'root' => self::getTemporaryRootDir(),
+            'writeFlags' => LOCK_EX,
+            'linkHandling' => SiteAccessAwareLocalAdapter::DISALLOW_LINKS,
+            'permissions' => [],
+            'path' => self::DYNAMIC_PATH,
+        ];
+    }
+
+    public function testGetPathPrefix(): void
+    {
+        $this->complexConfigProcessor
+            ->method('processSettingValue')
+            ->with(self::equalTo(self::DYNAMIC_PATH))
+            ->willReturn(self::STATIC_PATH);
+
+        $adapter = new SiteAccessAwareLocalAdapter(
+            $this->complexConfigProcessor,
+            self::getConfig()
+        );
+
+        $expectedPath = self::getTemporaryRootDir() . '/' . self::STATIC_PATH;
+        self::assertEquals($expectedPath, $adapter->getPathPrefix());
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        $dir = self::getTemporaryRootDir();
+        if (is_dir($dir)) {
+            rmdir($dir);
+        }
+    }
+
+    private static function getTemporaryRootDir(): string
+    {
+        return sys_get_temp_dir() . '/ezplatform-kernel-tests';
+    }
+}

--- a/eZ/Publish/SPI/SiteAccess/ConfigProcessor.php
+++ b/eZ/Publish/SPI/SiteAccess/ConfigProcessor.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\SiteAccess;
+
+/**
+ * @internal
+ */
+interface ConfigProcessor
+{
+    public function processComplexSetting(string $setting): string;
+
+    public function processSettingValue(string $value): string;
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-31740](https://jira.ez.no/browse/EZP-31740)
| **Required by**                        | ezsystems/ezplatform#596
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.1`+
| **BC breaks**                          | no
| **Doc needed**                       | yes, will be covered in meta PR

## TL;DR;

This PR introduces our custom SiteAccess-aware local NFS adapter based on Flysystem's one. For configuration see the meta PR (ezsystems/ezplatform#596).

## Summary

We need to be able to process dynamic paths for NFS instance in the form of `%dfs_nfs_path%/$var_dir$/$storage_dir$`, mapped to proper Repository & SiteAccess settings based on a current request context. Prior Symfony 4 it was done by replacing injected service parameters on the fly when context had changed. Since Symfony 4+ it's no longer possible because the Container is frozen. Moreover in this case settings apply to 3rd party Semantic configuration, so usual simple fix with ConfigResolver injection is not possible.

To solve the issue we've introduced [custom adapter](https://github.com/1up-lab/OneupFlysystemBundle/blob/3.5.0/Resources/doc/adapter_custom.md) which resolves dynamically the mentioned path parameter.

Existing `ComplexConfigProcessor`, which previously was used to replace container parameters on the fly, has been refactored to process strings with multiple settings. Note that SiteAccess name resolution has been dropped there from the last step, because it's redundant (`getParameter` should use current scope if none given). In fact it can probably be dropped from the entire service, but further codebase adjustments are required for that.

## Review

See review notes in diff comments.

## QA

See ezsystems/ezplatform#596

## TODO
- [x] Add unit tests coverage.
- [x] Wait for Travis

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
