### PR TITLE
EZP-31912: Fixed decorating binary files URLs with proper absolute prefix

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/EzPublishIOExtensionTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/EzPublishIOExtensionTest.php
@@ -6,12 +6,20 @@
  */
 namespace eZ\Bundle\EzPublishIOBundle\Tests\DependencyInjection;
 
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler\ChainConfigResolverPass;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ComplexSettings\ComplexSettingParser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;
+use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
 use eZ\Bundle\EzPublishIOBundle\DependencyInjection\EzPublishIOExtension;
 use eZ\Bundle\EzPublishIOBundle\DependencyInjection\ConfigurationFactory;
+use eZ\Publish\API\Repository\Tests\Container\Compiler\SetAllServicesPublicPass;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+use Symfony\Component\Yaml\Yaml;
 
 class EzPublishIOExtensionTest extends AbstractExtensionTestCase
 {
+    const FIXTURES_DIR = __DIR__ . '/../_fixtures';
+
     protected function getContainerExtensions(): array
     {
         $extension = new EzPublishIOExtension();
@@ -59,5 +67,42 @@ class EzPublishIOExtensionTest extends AbstractExtensionTestCase
             'ez_io.binarydata_handlers',
             ['my_binarydata_handler' => ['name' => 'my_binarydata_handler', 'type' => 'flysystem', 'adapter' => 'my_adapter']]
         );
+    }
+
+    public function testUrlPrefixConfigurationIsUsedToDecorateUrl(): void
+    {
+        $this->container->registerExtension(
+            new EzPublishCoreExtension(
+                [
+                    new Parser\IO(new ComplexSettingParser()),
+                ]
+            )
+        );
+        $this->container->prependExtensionConfig(
+            'ezpublish',
+            Yaml::parseFile(self::FIXTURES_DIR . '/url_prefix_test_config.yaml')['ezplatform']
+        );
+        $this->buildMinimalContainerForUrlPrefixTest();
+
+        $decorator = $this->container->get('ezpublish.core.io.prefix_url_decorator');
+
+        self::assertEquals(
+            'http://static.example.com/my/image.png',
+            $decorator->decorate('my/image.png')
+        );
+    }
+
+    private function buildMinimalContainerForUrlPrefixTest(): void
+    {
+        // unrelated, but needed Container configuration
+        $this->container->setParameter('kernel.environment', 'dev');
+        $this->container->setParameter('kernel.debug', true);
+        $this->container->setParameter('kernel.project_dir', self::FIXTURES_DIR);
+        $this->container->setParameter('kernel.cache_dir', self::FIXTURES_DIR . '/cache');
+
+        $this->container->addCompilerPass(new ChainConfigResolverPass());
+        $this->container->addCompilerPass(new SetAllServicesPublicPass());
+
+        $this->container->compile();
     }
 }

--- a/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/EzPublishIOExtensionTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/EzPublishIOExtensionTest.php
@@ -18,7 +18,7 @@ use Symfony\Component\Yaml\Yaml;
 
 class EzPublishIOExtensionTest extends AbstractExtensionTestCase
 {
-    const FIXTURES_DIR = __DIR__ . '/../_fixtures';
+    private const FIXTURES_DIR = __DIR__ . '/../_fixtures';
 
     protected function getContainerExtensions(): array
     {

--- a/eZ/Bundle/EzPublishIOBundle/Tests/_fixtures/url_prefix_test_config.yaml
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/_fixtures/url_prefix_test_config.yaml
@@ -1,0 +1,10 @@
+ezplatform:
+    siteaccess:
+        list: [site]
+        default_siteaccess: site
+        match:
+            URIElement: 1
+    system:
+        default:
+            io:
+                url_prefix: 'http://static.example.com/'

--- a/eZ/Publish/Core/IO/Tests/UrlDecorator/AbsolutePrefixTest.php
+++ b/eZ/Publish/Core/IO/Tests/UrlDecorator/AbsolutePrefixTest.php
@@ -21,7 +21,7 @@ class AbsolutePrefixTest extends PrefixTest
     {
         $ioConfigResolverMock = $this->createMock(IOConfigProvider::class);
         $ioConfigResolverMock
-            ->method('getLegacyUrlPrefix')
+            ->method('getUrlPrefix')
             ->willReturn($prefix);
 
         return new AbsolutePrefix($ioConfigResolverMock);

--- a/eZ/Publish/Core/IO/UrlDecorator/AbsolutePrefix.php
+++ b/eZ/Publish/Core/IO/UrlDecorator/AbsolutePrefix.php
@@ -8,16 +8,14 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\IO\UrlDecorator;
 
-use eZ\Publish\Core\IO\UrlDecorator;
-
 /**
  * Prefixes the URI with a string, and makes it absolute.
  */
-class AbsolutePrefix extends Prefix implements UrlDecorator
+class AbsolutePrefix extends Prefix
 {
     public function getPrefix(): string
     {
-        $prefix = $this->ioConfigResolver->getLegacyUrlPrefix();
+        $prefix = $this->ioConfigResolver->getUrlPrefix();
 
         if ($prefix !== '') {
             $urlParts = parse_url($prefix);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-31912
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.1`+
| **BC breaks**                          | no
| **Doc needed**                       | ezsystems/developer-documentation#1142

This PR fixes [decorating binary files (images, other media) URLs with custom `url_prefix`](https://doc.ezplatform.com/en/3.1/guide/file_management/#using-a-static-server-for-images).

While the JIRA ticket describes complicated AWS case, in fact URL prefix can be used with local (default) binary handler and it was the part which was broken.

In 2.5 [we used to fetch `io.url_prefix` from dynamic (SiteAccess-aware) configuration for AbsolutePrefix](https://github.com/ezsystems/ezpublish-kernel/blob/v7.5.11/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml#L131) which decorates media URLs.

Since dynamic settings feature was no longer possible due to Symfony 4+ Container changes, we've rewritten the decorating to make the implementation [fetch the proper setting](https://github.com/ezsystems/ezplatform-kernel/blob/v1.0.0/eZ/Publish/Core/IO/UrlDecorator/AbsolutePrefix.php#L20).

It seems however that what should be used at the line above is actually `getUrlPrefix` instead of `getLegacyUrlPrefix`. See [the parameter names fetched by both methods](https://github.com/ezsystems/ezplatform-kernel/blob/v1.0.0/eZ/Bundle/EzPublishCoreBundle/SiteAccess/Config/IOConfigResolver.php#L34-L39).

### TODO:

- [x] See if DI Container test coverage can be added for this case to avoid another regression in the future

#### Checklist:
- [x] PR description is updated.
- [x] Tests are implemented.
- [x] Added code follows Coding Standards (use `$ composer fix-cs`).
- [x] PR is ready for a review.
