### PR TITLE
EZP-31851: Added Twig helpers that abstracts content rendering

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -155,6 +155,75 @@ services:
         tags:
             - { name: twig.extension }
 
+    eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\RenderExtension:
+        arguments:
+            $renderStrategy: '@eZ\Publish\SPI\MVC\Templating\RenderStrategy'
+            $eventDispatcher: '@event_dispatcher'
+        tags:
+            - { name: twig.extension }
+
+    eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\RenderContentExtension:
+        arguments:
+            $renderContentStrategy: '@eZ\Publish\Core\MVC\Symfony\Templating\RenderContentStrategy'
+            $eventDispatcher: '@event_dispatcher'
+        tags:
+            - { name: twig.extension }
+
+    eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\RenderLocationExtension:
+        arguments:
+            $renderLocationStrategy: '@eZ\Publish\Core\MVC\Symfony\Templating\RenderLocationStrategy'
+            $eventDispatcher: '@event_dispatcher'
+        tags:
+            - { name: twig.extension }
+
+    eZ\Publish\Core\MVC\Symfony\Templating\RenderStrategy:
+        arguments:
+            $strategies: !tagged_iterator ibexa.platform.render.strategy
+
+    eZ\Publish\SPI\MVC\Templating\RenderStrategy: '@eZ\Publish\Core\MVC\Symfony\Templating\RenderStrategy'
+
+    eZ\Publish\Core\MVC\Symfony\Templating\RenderContentStrategy:
+        arguments:
+            $defaultMethod: 'inline'
+            $renderMethods: !tagged_iterator ibexa.platform.render.method
+            $siteAccess: '@ezpublish.siteaccess'
+            $requestStack: '@request_stack'
+        tags:
+            - { name: ibexa.platform.render.strategy }
+
+    eZ\Publish\Core\MVC\Symfony\Templating\RenderLocationStrategy:
+        arguments:
+            $defaultMethod: 'inline'
+            $renderMethods: !tagged_iterator ibexa.platform.render.method
+            $siteAccess: '@ezpublish.siteaccess'
+            $requestStack: '@request_stack'
+        tags:
+            - { name: ibexa.platform.render.strategy }
+
+    eZ\Publish\Core\MVC\Symfony\Templating\RenderMethod\RenderInline:
+        arguments:
+            $kernel: '@kernel'
+            $controllerListener: '@ezpublish.view_controller_listener'
+            $controllerResolver: '@controller_resolver'
+            $argumentMetadataFactory: '@argument_metadata_factory'
+            $argumentValueResolver: '@argument_resolver.request_attribute'
+            $viewTemplateRenderer: '@ezpublish.view.template_renderer'
+        tags:
+            - { name: ibexa.platform.render.method }
+
+    eZ\Publish\Core\MVC\Symfony\Templating\RenderMethod\RenderSubRequest:
+        arguments:
+            $kernel: '@kernel'
+        tags:
+            - { name: ibexa.platform.render.method }
+
+    eZ\Publish\Core\MVC\Symfony\Templating\RenderMethod\RenderEdgeSideInclude:
+        arguments:
+            $fragmentRenderer: '@fragment.renderer.esi'
+            $router: '@router'
+        tags:
+            - { name: ibexa.platform.render.method }
+
     ezpublish.twig.extension.image:
         class: eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\ImageExtension
         arguments:

--- a/eZ/Publish/Core/MVC/Symfony/Event/ResolveRenderOptionsEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/ResolveRenderOptionsEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Event;
+
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderOptions;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class ResolveRenderOptionsEvent extends Event
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\Templating\RenderOptions */
+    private $renderOptions;
+
+    public function __construct(
+        RenderOptions $renderOptions
+    ) {
+        $this->renderOptions = $renderOptions;
+    }
+
+    public function getRenderOptions(): RenderOptions
+    {
+        return $this->renderOptions;
+    }
+
+    public function setRenderOptions(RenderOptions $renderOptions): void
+    {
+        $this->renderOptions = $renderOptions;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Exception/InvalidResponseException.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Exception/InvalidResponseException.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Exception;
+
+use eZ\Publish\Core\Base\Exceptions\ForbiddenException;
+use eZ\Publish\Core\Base\Translatable;
+use eZ\Publish\Core\Base\TranslatableBase;
+
+class InvalidResponseException extends ForbiddenException implements Translatable
+{
+    use TranslatableBase;
+
+    public function __construct(string $whatIsWrong)
+    {
+        parent::__construct(
+            'Response is invalid: %whatIsWrong%',
+            [
+                '%whatIsWrong%' => $whatIsWrong,
+            ]
+        );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderContentStrategy.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderContentStrategy.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\SPI\MVC\Templating\BaseRenderStrategy;
+use eZ\Publish\SPI\MVC\Templating\RenderStrategy;
+use Symfony\Component\HttpFoundation\Request;
+
+final class RenderContentStrategy extends BaseRenderStrategy implements RenderStrategy
+{
+    private const DEFAULT_VIEW_TYPE = 'embed';
+
+    public function supports(ValueObject $valueObject): bool
+    {
+        return $valueObject instanceof Content;
+    }
+
+    public function render(ValueObject $valueObject, RenderOptions $options): string
+    {
+        if (!$this->supports($valueObject)) {
+            throw new InvalidArgumentException(
+                'valueObject',
+                'Must be a type of ' . Content::class
+            );
+        }
+
+        /** @var \eZ\Publish\API\Repository\Values\Content\Content $content */
+        $content = $valueObject;
+
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        $surrogateCapability = $currentRequest->get('Surrogate-Capability');
+
+        $request = new Request();
+        $request->headers->set('siteaccess', $this->siteAccess->name);
+        $request->headers->set('Surrogate-Capability', $surrogateCapability);
+
+        $request->attributes->add([
+            '_route' => '_ez_content_view',
+            '_controller' => 'ez_content::viewAction',
+            'siteaccess' => $this->siteAccess,
+            'contentId' => $content->id,
+            'viewType' => $options->get('viewType', self::DEFAULT_VIEW_TYPE),
+        ]);
+
+        $renderMethod = $this->getRenderMethod($options, $content);
+
+        return $renderMethod->render($request);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderLocationStrategy.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderLocationStrategy.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\SPI\MVC\Templating\BaseRenderStrategy;
+use eZ\Publish\SPI\MVC\Templating\RenderStrategy;
+use Symfony\Component\HttpFoundation\Request;
+
+final class RenderLocationStrategy extends BaseRenderStrategy implements RenderStrategy
+{
+    private const DEFAULT_VIEW_TYPE = 'embed';
+
+    public function supports(ValueObject $valueObject): bool
+    {
+        return $valueObject instanceof Location;
+    }
+
+    public function render(ValueObject $valueObject, RenderOptions $options): string
+    {
+        if (!$this->supports($valueObject)) {
+            throw new InvalidArgumentException(
+                'valueObject',
+                'Must be a type of ' . Location::class
+            );
+        }
+
+        /** @var \eZ\Publish\API\Repository\Values\Content\Location $location */
+        $location = $valueObject;
+        $content = $location->getContent();
+
+        $currentRequest = $this->requestStack->getCurrentRequest();
+        $surrogateCapability = $currentRequest->get('Surrogate-Capability');
+
+        $request = new Request();
+        $request->headers->set('siteaccess', $this->siteAccess->name);
+        $request->headers->set('Surrogate-Capability', $surrogateCapability);
+
+        $request->attributes->add([
+            '_route' => '_ez_content_view',
+            '_controller' => 'ez_content::viewAction',
+            'siteaccess' => $this->siteAccess,
+            'locationId' => $location->id,
+            'contentId' => $content->id,
+            'viewType' => $options->get('viewType', self::DEFAULT_VIEW_TYPE),
+        ]);
+
+        $renderMethod = $this->getRenderMethod($options, $content);
+
+        return $renderMethod->render($request);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderMethod/RenderEdgeSideInclude.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderMethod/RenderEdgeSideInclude.php
@@ -1,0 +1,71 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\RenderMethod;
+
+use eZ\Publish\SPI\MVC\Templating\RenderMethod;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ControllerReference;
+use Symfony\Component\HttpKernel\Fragment\FragmentRendererInterface;
+use Symfony\Component\Routing\RouteCompiler;
+use Symfony\Component\Routing\RouterInterface;
+
+/**
+ * @internal
+ */
+final class RenderEdgeSideInclude implements RenderMethod
+{
+    public const IDENTIFIER = 'esi';
+
+    /** @var \Symfony\Component\HttpKernel\Fragment\AbstractSurrogateFragmentRenderer */
+    private $fragmentRenderer;
+
+    /** @var \Symfony\Component\Routing\RouterInterface */
+    private $router;
+
+    public function __construct(
+        FragmentRendererInterface $fragmentRenderer,
+        RouterInterface $router
+    ) {
+        $this->fragmentRenderer = $fragmentRenderer;
+        $this->router = $router;
+    }
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    public function render(Request $request): string
+    {
+        $controllerReference = new ControllerReference(
+            $request->get('_controller'),
+            $this->getRouteAttributes($request)
+        );
+
+        $esiFragmentResponse = $this->fragmentRenderer->render($controllerReference, $request);
+
+        return $esiFragmentResponse->getContent();
+    }
+
+    private function getRouteAttributes(Request $request): array
+    {
+        $route = $this->router->getRouteCollection()->get($request->get('_route'));
+        $variables = RouteCompiler::compile($route)->getVariables();
+
+        $routeAttributes = [
+            'siteaccess' => $request->headers->get('siteaccess'),
+        ];
+
+        foreach ($variables as $variable) {
+            $routeAttributes[$variable] = $request->attributes->get($variable);
+        }
+
+        return $routeAttributes;
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderMethod/RenderInline.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderMethod/RenderInline.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\RenderMethod;
+
+use eZ\Bundle\EzPublishCoreBundle\EventListener\ViewControllerListener;
+use eZ\Publish\Core\MVC\Symfony\Templating\Exception\InvalidResponseException;
+use eZ\Publish\Core\MVC\Symfony\View\Renderer\TemplateRenderer;
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use eZ\Publish\SPI\MVC\Templating\RenderMethod;
+use eZ\Publish\SPI\MVC\Templating\RenderMethod\ControllerRenderMethod;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactoryInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @internal
+ */
+final class RenderInline extends ControllerRenderMethod implements RenderMethod
+{
+    public const IDENTIFIER = 'inline';
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\Renderer\TemplateRenderer */
+    private $viewTemplateRenderer;
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    public function __construct(
+        KernelInterface $kernel,
+        ViewControllerListener $controllerListener,
+        ControllerResolverInterface $controllerResolver,
+        ArgumentMetadataFactoryInterface $argumentMetadataFactory,
+        ArgumentValueResolverInterface $argumentValueResolver,
+        TemplateRenderer $viewTemplateRenderer
+    ) {
+        parent::__construct(
+            $kernel,
+            $controllerListener,
+            $controllerResolver,
+            $argumentMetadataFactory,
+            $argumentValueResolver
+        );
+
+        $this->viewTemplateRenderer = $viewTemplateRenderer;
+    }
+
+    public function render(Request $request): string
+    {
+        $event = $this->getControllerEvent($request);
+        $controller = $this->getController($event);
+        $arguments = $this->getArguments($controller, $event);
+
+        $response = call_user_func_array($controller, $arguments);
+
+        if ($response instanceof View) {
+            return $this->viewTemplateRenderer->render($response);
+        } elseif ($response instanceof Response) {
+            return $response->getContent();
+        } elseif (is_string($response)) {
+            return $response;
+        }
+
+        throw new InvalidResponseException(
+            sprintf('Unsupported type (%s)', get_class($response))
+        );
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderMethod/RenderSubRequest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderMethod/RenderSubRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\RenderMethod;
+
+use eZ\Publish\SPI\MVC\Templating\RenderMethod;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * @internal
+ */
+final class RenderSubRequest implements RenderMethod
+{
+    public const IDENTIFIER = 'subrequest';
+
+    /** @var \Symfony\Component\HttpKernel\KernelInterface */
+    private $kernel;
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    public function __construct(
+        KernelInterface $kernel
+    ) {
+        $this->kernel = $kernel;
+    }
+
+    public function render(Request $request): string
+    {
+        $response = $this->kernel->handle($request);
+
+        return $response->getContent();
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderOptions.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderOptions.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating;
+
+use eZ\Publish\SPI\Options\MutableOptionsBag;
+
+final class RenderOptions implements MutableOptionsBag
+{
+    /** @var array */
+    private $options;
+
+    public function __construct(array $options = [])
+    {
+        $this->options = $options;
+    }
+
+    public function all(): array
+    {
+        return $this->options;
+    }
+
+    /**
+     * @param mixed|null $default
+     *
+     * @return mixed|null
+     */
+    public function get(string $key, $default = null)
+    {
+        if ($this->has($key)) {
+            return $this->options[$key];
+        }
+
+        return $default;
+    }
+
+    /**
+     * @param mixed|null $value
+     */
+    public function set(string $key, $value): void
+    {
+        $this->options[$key] = $value;
+    }
+
+    public function has(string $key): bool
+    {
+        return !empty($this->options[$key]);
+    }
+
+    public function remove(string $key): void
+    {
+        unset($this->options[$key]);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderStrategy.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderStrategy.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\SPI\MVC\Templating\RenderStrategy as SPIRenderStrategy;
+
+final class RenderStrategy implements SPIRenderStrategy
+{
+    /** @var \eZ\Publish\SPI\MVC\Templating\RenderStrategy[] */
+    private $strategies;
+
+    public function __construct(iterable $strategies)
+    {
+        $this->strategies = $strategies;
+    }
+
+    public function supports(ValueObject $valueObject): bool
+    {
+        foreach ($this->strategies as $strategy) {
+            if ($strategy->supports($valueObject)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function render(ValueObject $valueObject, RenderOptions $options): string
+    {
+        foreach ($this->strategies as $strategy) {
+            if ($strategy->supports($valueObject)) {
+                return $strategy->render($valueObject, $options);
+            }
+        }
+
+        throw new InvalidArgumentException('valueObject', sprintf(
+            "Method '%s' is not supported for %s.", $options->get('method'), get_class($valueObject)
+        ));
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;
+
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\Core\MVC\Symfony\Event\ResolveRenderOptionsEvent;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderContentStrategy;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderOptions;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @internal
+ */
+final class RenderContentExtension extends AbstractExtension
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\Templating\RenderContentStrategy */
+    private $renderContentStrategy;
+
+    /** @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface */
+    private $eventDispatcher;
+
+    public function __construct(
+        RenderContentStrategy $renderContentStrategy,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->renderContentStrategy = $renderContentStrategy;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'ez_render_content',
+                [$this, 'renderContent'],
+                ['is_safe' => ['html']]
+            ),
+        ];
+    }
+
+    public function renderContent(Content $content, array $options = []): string
+    {
+        $renderOptions = new RenderOptions($options);
+        $event = $this->eventDispatcher->dispatch(
+            new ResolveRenderOptionsEvent($renderOptions)
+        );
+
+        return $this->renderContentStrategy->render($content, $event->getRenderOptions());
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RenderExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RenderExtension.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\MVC\Symfony\Event\ResolveRenderOptionsEvent;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderOptions;
+use eZ\Publish\SPI\MVC\Templating\RenderStrategy;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @internal
+ */
+final class RenderExtension extends AbstractExtension
+{
+    /** @var \eZ\Publish\SPI\MVC\Templating\RenderStrategy */
+    private $renderStrategy;
+
+    /** @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface */
+    private $eventDispatcher;
+
+    public function __construct(
+        RenderStrategy $renderStrategy,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->renderStrategy = $renderStrategy;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'ez_render',
+                [$this, 'render'],
+                ['is_safe' => ['html']]
+            ),
+        ];
+    }
+
+    public function render(ValueObject $valueObject, array $options = []): string
+    {
+        if (!$this->renderStrategy->supports($valueObject)) {
+            throw new InvalidArgumentException(
+                'valueObject',
+                sprintf('%s is not supported.', get_class($valueObject))
+            );
+        }
+
+        $renderOptions = new RenderOptions($options);
+        $event = $this->eventDispatcher->dispatch(
+            new ResolveRenderOptionsEvent($renderOptions)
+        );
+
+        return $this->renderStrategy->render($valueObject, $event->getRenderOptions());
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RenderLocationExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RenderLocationExtension.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;
+
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\Core\MVC\Symfony\Event\ResolveRenderOptionsEvent;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderLocationStrategy;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderOptions;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+/**
+ * @internal
+ */
+final class RenderLocationExtension extends AbstractExtension
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\Templating\RenderLocationStrategy */
+    private $renderLocationStrategy;
+
+    /** @var \Symfony\Contracts\EventDispatcher\EventDispatcherInterface */
+    private $eventDispatcher;
+
+    public function __construct(
+        RenderLocationStrategy $renderLocationStrategy,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->renderLocationStrategy = $renderLocationStrategy;
+        $this->eventDispatcher = $eventDispatcher;
+    }
+
+    public function getFunctions(): array
+    {
+        return [
+            new TwigFunction(
+                'ez_render_location',
+                [$this, 'renderLocation'],
+                ['is_safe' => ['html']]
+            ),
+        ];
+    }
+
+    public function renderLocation(Location $location, array $options = []): string
+    {
+        $renderOptions = new RenderOptions($options);
+        $event = $this->eventDispatcher->dispatch(
+            new ResolveRenderOptionsEvent($renderOptions)
+        );
+
+        return $this->renderLocationStrategy->render($location, $event->getRenderOptions());
+    }
+}

--- a/eZ/Publish/SPI/MVC/Templating/BaseRenderStrategy.php
+++ b/eZ/Publish/SPI/MVC/Templating/BaseRenderStrategy.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\MVC\Templating;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderOptions;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+abstract class BaseRenderStrategy implements RenderStrategy
+{
+    /** @var string */
+    protected $defaultMethod;
+
+    /** @var \eZ\Publish\SPI\MVC\Templating\RenderMethod[] */
+    protected $renderMethods = [];
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess */
+    protected $siteAccess;
+
+    /** @var \Symfony\Component\HttpFoundation\RequestStack */
+    protected $requestStack;
+
+    public function __construct(
+        iterable $renderMethods,
+        string $defaultMethod,
+        SiteAccess $siteAccess,
+        RequestStack $requestStack
+    ) {
+        $this->defaultMethod = $defaultMethod;
+        $this->siteAccess = $siteAccess;
+
+        foreach ($renderMethods as $renderMethod) {
+            $this->renderMethods[$renderMethod->getIdentifier()] = $renderMethod;
+        }
+        $this->requestStack = $requestStack;
+    }
+
+    protected function getRenderMethod(RenderOptions $options, ValueObject $valueObject): RenderMethod
+    {
+        $method = $options->get('method', $this->defaultMethod);
+
+        if (empty($this->renderMethods[$method])) {
+            throw new InvalidArgumentException('method', sprintf(
+                "Method '%s' is not supported for %s.", $method, get_class($valueObject)
+            ));
+        }
+
+        return $this->renderMethods[$method];
+    }
+}

--- a/eZ/Publish/SPI/MVC/Templating/RenderMethod.php
+++ b/eZ/Publish/SPI/MVC/Templating/RenderMethod.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\MVC\Templating;
+
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Abstracts extensibility point of adding new rendering
+ * methods for various Ibexa value objects.
+ */
+interface RenderMethod
+{
+    /**
+     * Arbitrary string to be used as an option value for
+     * rendering abstraction Twig helpers, like:
+     *     {{ ez_render_content(content, {
+     *         method: "render_method_identifier"
+     *     }) }}.
+     */
+    public function getIdentifier(): string;
+
+    public function render(Request $request): string;
+}

--- a/eZ/Publish/SPI/MVC/Templating/RenderMethod/ControllerRenderMethod.php
+++ b/eZ/Publish/SPI/MVC/Templating/RenderMethod/ControllerRenderMethod.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\MVC\Templating\RenderMethod;
+
+use eZ\Bundle\EzPublishCoreBundle\EventListener\ViewControllerListener;
+use eZ\Publish\SPI\MVC\Templating\RenderMethod;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactoryInterface;
+use Symfony\Component\HttpKernel\Event\ControllerEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+abstract class ControllerRenderMethod implements RenderMethod
+{
+    /** @var \Symfony\Component\HttpKernel\KernelInterface */
+    protected $kernel;
+
+    /** @var \eZ\Bundle\EzPublishCoreBundle\EventListener\ViewControllerListener */
+    protected $controllerListener;
+
+    /** @var \Symfony\Component\HttpKernel\Controller\ControllerResolverInterface */
+    protected $controllerResolver;
+
+    /** @var \Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactoryInterface */
+    protected $argumentMetadataFactory;
+
+    /** @var \Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface */
+    protected $argumentValueResolver;
+
+    public function __construct(
+        KernelInterface $kernel,
+        ViewControllerListener $controllerListener,
+        ControllerResolverInterface $controllerResolver,
+        ArgumentMetadataFactoryInterface $argumentMetadataFactory,
+        ArgumentValueResolverInterface $argumentValueResolver
+    ) {
+        $this->kernel = $kernel;
+        $this->controllerListener = $controllerListener;
+        $this->controllerResolver = $controllerResolver;
+        $this->argumentMetadataFactory = $argumentMetadataFactory;
+        $this->argumentValueResolver = $argumentValueResolver;
+    }
+
+    protected function getControllerEvent(Request $request): ControllerEvent
+    {
+        $controller = $this->controllerResolver->getController($request);
+
+        $this->controllerListener->getController(
+            $event = new ControllerEvent(
+                $this->kernel,
+                $controller,
+                $request,
+                HttpKernelInterface::SUB_REQUEST
+            )
+        );
+
+        return $event;
+    }
+
+    protected function getController(ControllerEvent $event): callable
+    {
+        return $this->controllerResolver->getController($event->getRequest());
+    }
+
+    protected function getArguments(callable $controller, ControllerEvent $event): array
+    {
+        $argumentsMetadata = $this->argumentMetadataFactory->createArgumentMetadata($controller);
+
+        $arguments = [];
+        foreach ($argumentsMetadata as $argumentMetadata) {
+            // Single-value generator
+            $valueGenerator = $this->argumentValueResolver->resolve($event->getRequest(), $argumentMetadata);
+            foreach ($valueGenerator as $value) {
+                $arguments[$argumentMetadata->getName()] = $value;
+                break;
+            }
+        }
+
+        return $arguments;
+    }
+}

--- a/eZ/Publish/SPI/MVC/Templating/RenderStrategy.php
+++ b/eZ/Publish/SPI/MVC/Templating/RenderStrategy.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\MVC\Templating;
+
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderOptions;
+
+/**
+ * Strategy to decide, based on ValueObject descendant type, which
+ * renderer to pick (like RenderContentStrategy or else). To be used
+ * mainly by rendering abstraction Twig helpers, but may be used to
+ * inline rendering of Ibexa VOs anywhere.
+ */
+interface RenderStrategy
+{
+    public function supports(ValueObject $valueObject): bool;
+
+    public function render(ValueObject $valueObject, RenderOptions $options): string;
+}

--- a/eZ/Publish/SPI/Options/MutableOptionsBag.php
+++ b/eZ/Publish/SPI/Options/MutableOptionsBag.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Options;
+
+interface MutableOptionsBag extends OptionsBag
+{
+    /**
+     * @param mixed|null $value
+     */
+    public function set(string $key, $value): void;
+
+    public function remove(string $key): void;
+}

--- a/eZ/Publish/SPI/Options/OptionsBag.php
+++ b/eZ/Publish/SPI/Options/OptionsBag.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\Options;
+
+interface OptionsBag
+{
+    public function all(): array;
+
+    /**
+     * @param mixed|null $default
+     *
+     * @return mixed|null
+     */
+    public function get(string $key, $default = null);
+
+    public function has(string $key): bool;
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-31851
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | yes

#### Still WIP (Todo section below), but open for brief review as main feature is done.

Based on a Proof of Concept/Experiment: https://github.com/ezsystems/ezpublish-kernel/pull/1518

This PR provides two Twig helper functions and extensibility point for more:
 - `ez_render_content` - abstracts Content rendering via different rendering methods (default `inline`, `subrequest`, `esi`)
 - `ez_render_location` - abstracts Location rendering via different rendering methods (default `inline`, `subrequest`, `esi`)
 - `ez_render` - provides strategy (that comes with abstraction for extensibility) for sub-renderers (like one used directly by `ez_render_content` or `ez_render_location` helper)

### Usage
##### Strategy used, default method:
```twig
{{ ez_render(content) }} 
```
##### Direct renderer, default method:
```twig
{{ ez_render_content(content) }} 
```
##### Direct renderer, subrequest method:
```twig
{{ ez_render_location(location, { method: "subrequest" }) }} 
```

## Todo:
 - Tests, tests tests...
 - ~(Optional) Strategy for `Location` object with `ez_render_location` as helper.~

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
