### PR TITLE
EZP-31851: Added Unit tests for Render strategies

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderContentStrategy.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderContentStrategy.php
@@ -37,7 +37,7 @@ final class RenderContentStrategy extends BaseRenderStrategy implements RenderSt
         $content = $valueObject;
 
         $currentRequest = $this->requestStack->getCurrentRequest();
-        $surrogateCapability = $currentRequest->get('Surrogate-Capability');
+        $surrogateCapability = $currentRequest->headers->get('Surrogate-Capability');
 
         $request = new Request();
         $request->headers->set('siteaccess', $this->siteAccess->name);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderLocationStrategy.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderLocationStrategy.php
@@ -38,7 +38,7 @@ final class RenderLocationStrategy extends BaseRenderStrategy implements RenderS
         $content = $location->getContent();
 
         $currentRequest = $this->requestStack->getCurrentRequest();
-        $surrogateCapability = $currentRequest->get('Surrogate-Capability');
+        $surrogateCapability = $currentRequest->headers->get('Surrogate-Capability');
 
         $request = new Request();
         $request->headers->set('siteaccess', $this->siteAccess->name);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/BaseRenderStrategyTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/BaseRenderStrategyTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests;
+
+use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\Location;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\Search\Tests\TestCase;
+use eZ\Publish\SPI\MVC\Templating\RenderMethod;
+use eZ\Publish\SPI\MVC\Templating\RenderStrategy;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+abstract class BaseRenderStrategyTest extends TestCase
+{
+    public function createRenderStrategy(
+        string $typeClass,
+        array $renderMethods,
+        string $defaultMethod = 'inline',
+        string $siteAccessName = 'default',
+        Request $request = null
+    ): RenderStrategy {
+        $siteAccess = new SiteAccess($siteAccessName);
+
+        $requestStack = new RequestStack();
+        $requestStack->push($request ?? new Request());
+
+        return new $typeClass(
+            $renderMethods,
+            $defaultMethod,
+            $siteAccess,
+            $requestStack
+        );
+    }
+
+    public function createRenderMethod(
+        string $identifier = 'inline',
+        string $rendered = null
+    ): RenderMethod {
+        return new class($identifier, $rendered) implements RenderMethod {
+            /** @var string */
+            private $identifier;
+
+            /** @var string */
+            private $rendered;
+
+            public function __construct(
+                string $identifier,
+                ?string $rendered
+            ) {
+                $this->identifier = $identifier;
+                $this->rendered = $rendered;
+            }
+
+            public function getIdentifier(): string
+            {
+                return $this->identifier;
+            }
+
+            public function render(Request $request): string
+            {
+                return $this->rendered ?? $this->identifier . '_rendered';
+            }
+        };
+    }
+
+    public function createLocation(APIContent $content, int $id): APILocation
+    {
+        return new Location([
+            'id' => $id,
+            'contentInfo' => $content->versionInfo->contentInfo,
+            'content' => $content,
+        ]);
+    }
+
+    public function createContent(int $id): APIContent
+    {
+        return new Content([
+            'versionInfo' => new VersionInfo([
+                'contentInfo' => new ContentInfo([
+                    'id' => $id,
+                ]),
+            ]),
+        ]);
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderContentStrategyTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderContentStrategyTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests;
+
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderContentStrategy;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderOptions;
+use eZ\Publish\SPI\MVC\Templating\RenderMethod;
+use Symfony\Component\HttpFoundation\Request;
+
+class RenderContentStrategyTest extends BaseRenderStrategyTest
+{
+    public function testUnsupportedValueObject(): void
+    {
+        $renderContentStrategy = $this->createRenderStrategy(
+            RenderContentStrategy::class,
+            [
+                $this->createRenderMethod(),
+            ]
+        );
+
+        $valueObject = new class() extends ValueObject {
+        };
+        $this->assertFalse($renderContentStrategy->supports($valueObject));
+
+        $this->expectException(InvalidArgumentException::class);
+        $renderContentStrategy->render($valueObject, new RenderOptions());
+    }
+
+    public function testDefaultRenderMethod(): void
+    {
+        $renderContentStrategy = $this->createRenderStrategy(
+            RenderContentStrategy::class,
+            [
+                $this->createRenderMethod('inline'),
+            ],
+            'inline'
+        );
+
+        $contentMock = $this->createMock(Content::class);
+        $this->assertTrue($renderContentStrategy->supports($contentMock));
+
+        $this->assertSame(
+            'inline_rendered',
+            $renderContentStrategy->render($contentMock, new RenderOptions())
+        );
+    }
+
+    public function testUnknownRenderMethod(): void
+    {
+        $renderContentStrategy = $this->createRenderStrategy(
+            RenderContentStrategy::class,
+            [],
+        );
+
+        $contentMock = $this->createMock(Content::class);
+        $this->assertTrue($renderContentStrategy->supports($contentMock));
+
+        $this->expectException(InvalidArgumentException::class);
+        $renderContentStrategy->render($contentMock, new RenderOptions());
+    }
+
+    public function testMultipleRenderMethods(): void
+    {
+        $renderContentStrategy = $this->createRenderStrategy(
+            RenderContentStrategy::class,
+            [
+                $this->createRenderMethod('method_a'),
+                $this->createRenderMethod('method_b'),
+                $this->createRenderMethod('method_c'),
+            ],
+        );
+
+        $contentMock = $this->createMock(Content::class);
+        $this->assertTrue($renderContentStrategy->supports($contentMock));
+
+        $this->assertSame(
+            'method_b_rendered',
+            $renderContentStrategy->render($contentMock, new RenderOptions([
+                'method' => 'method_b',
+            ]))
+        );
+    }
+
+    public function testExpectedMethodRenderRequestFormat(): void
+    {
+        $request = new Request();
+        $request->headers->set('Surrogate-Capability', 'TEST/1.0');
+
+        $renderMethodMock = $this->createMock(RenderMethod::class);
+        $renderMethodMock
+            ->method('getIdentifier')
+            ->willReturn('method_b');
+
+        $siteAccess = new SiteAccess('some_siteaccess');
+
+        $content = $this->createContent(123);
+
+        $renderMethodMock
+            ->expects($this->once())
+            ->method('render')
+            ->with($this->callback(function (Request $request) use ($siteAccess, $content): bool {
+                $headers = $request->headers;
+                $this->assertSame('some_siteaccess', $headers->get('siteaccess'));
+                $this->assertSame('TEST/1.0', $headers->get('Surrogate-Capability'));
+
+                $attributes = $request->attributes;
+                $this->assertSame('_ez_content_view', $attributes->get('_route'));
+                $this->assertSame('ez_content::viewAction', $attributes->get('_controller'));
+                $this->assertEquals($siteAccess, $attributes->get('siteaccess'));
+                $this->assertSame($content->id, $attributes->get('contentId'));
+                $this->assertSame('awesome', $attributes->get('viewType'));
+
+                return true;
+            }))
+            ->willReturn('some_rendered_content');
+
+        $renderContentStrategy = $this->createRenderStrategy(
+            RenderContentStrategy::class,
+            [
+                $this->createRenderMethod('method_a'),
+                $renderMethodMock,
+                $this->createRenderMethod('method_c'),
+            ],
+            'method_a',
+            $siteAccess->name,
+            $request
+        );
+
+        $this->assertSame('some_rendered_content', $renderContentStrategy->render(
+            $content,
+            new RenderOptions([
+                'method' => 'method_b',
+                'viewType' => 'awesome',
+            ])
+        ));
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderLocationStrategyTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderLocationStrategyTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests;
+
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderLocationStrategy;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderOptions;
+use eZ\Publish\SPI\MVC\Templating\RenderMethod;
+use Symfony\Component\HttpFoundation\Request;
+
+class RenderLocationStrategyTest extends BaseRenderStrategyTest
+{
+    public function testUnsupportedValueObject(): void
+    {
+        $renderLocationStrategy = $this->createRenderStrategy(
+            RenderLocationStrategy::class,
+            [
+                $this->createRenderMethod(),
+            ]
+        );
+
+        $valueObject = new class() extends ValueObject {
+        };
+        $this->assertFalse($renderLocationStrategy->supports($valueObject));
+
+        $this->expectException(InvalidArgumentException::class);
+        $renderLocationStrategy->render($valueObject, new RenderOptions());
+    }
+
+    public function testDefaultRenderMethod(): void
+    {
+        $renderLocationStrategy = $this->createRenderStrategy(
+            RenderLocationStrategy::class,
+            [
+                $this->createRenderMethod('inline'),
+            ],
+            'inline'
+        );
+
+        $locationMock = $this->createMock(Location::class);
+        $this->assertTrue($renderLocationStrategy->supports($locationMock));
+
+        $this->assertSame(
+            'inline_rendered',
+            $renderLocationStrategy->render($locationMock, new RenderOptions())
+        );
+    }
+
+    public function testUnknownRenderMethod(): void
+    {
+        $renderLocationStrategy = $this->createRenderStrategy(
+            RenderLocationStrategy::class,
+            [],
+        );
+
+        $locationMock = $this->createMock(Location::class);
+        $this->assertTrue($renderLocationStrategy->supports($locationMock));
+
+        $this->expectException(InvalidArgumentException::class);
+        $renderLocationStrategy->render($locationMock, new RenderOptions());
+    }
+
+    public function testMultipleRenderMethods(): void
+    {
+        $renderLocationStrategy = $this->createRenderStrategy(
+            RenderLocationStrategy::class,
+            [
+                $this->createRenderMethod('method_a'),
+                $this->createRenderMethod('method_b'),
+                $this->createRenderMethod('method_c'),
+            ],
+        );
+
+        $locationMock = $this->createMock(Location::class);
+        $this->assertTrue($renderLocationStrategy->supports($locationMock));
+
+        $this->assertSame(
+            'method_b_rendered',
+            $renderLocationStrategy->render($locationMock, new RenderOptions([
+                'method' => 'method_b',
+            ]))
+        );
+    }
+
+    public function testExpectedMethodRenderRequestFormat(): void
+    {
+        $request = new Request();
+        $request->headers->set('Surrogate-Capability', 'TEST/1.0');
+
+        $renderMethodMock = $this->createMock(RenderMethod::class);
+        $renderMethodMock
+            ->method('getIdentifier')
+            ->willReturn('method_b');
+
+        $siteAccess = new SiteAccess('some_siteaccess');
+
+        $content = $this->createContent(234);
+        $location = $this->createLocation($content, 345);
+
+        $renderMethodMock
+            ->expects($this->once())
+            ->method('render')
+            ->with($this->callback(function (Request $request) use ($siteAccess, $content, $location): bool {
+                $headers = $request->headers;
+                $this->assertSame('some_siteaccess', $headers->get('siteaccess'));
+                $this->assertSame('TEST/1.0', $headers->get('Surrogate-Capability'));
+
+                $attributes = $request->attributes;
+                $this->assertSame('_ez_content_view', $attributes->get('_route'));
+                $this->assertSame('ez_content::viewAction', $attributes->get('_controller'));
+                $this->assertEquals($siteAccess, $attributes->get('siteaccess'));
+                $this->assertSame($content->id, $attributes->get('contentId'));
+                $this->assertSame($location->id, $attributes->get('locationId'));
+                $this->assertSame('awesome', $attributes->get('viewType'));
+
+                return true;
+            }))
+            ->willReturn('some_rendered_content');
+
+        $renderLocationStrategy = $this->createRenderStrategy(
+            RenderLocationStrategy::class,
+            [
+                $this->createRenderMethod('method_a'),
+                $renderMethodMock,
+                $this->createRenderMethod('method_c'),
+            ],
+            'method_a',
+            $siteAccess->name,
+            $request
+        );
+
+        $this->assertSame('some_rendered_content', $renderLocationStrategy->render(
+            $location,
+            new RenderOptions([
+                'method' => 'method_b',
+                'viewType' => 'awesome',
+            ])
+        ));
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderOptionsTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderOptionsTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests;
+
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderOptions;
+use PHPUnit\Framework\TestCase;
+
+class RenderOptionsTest extends TestCase
+{
+    public function testInitialOptions(): void
+    {
+        $renderOptions = new RenderOptions([
+            'a' => 'value_a',
+            'b' => null,
+        ]);
+
+        $this->assertTrue($renderOptions->has('a'));
+        $this->assertSame('value_a', $renderOptions->get('a'));
+        $this->assertFalse($renderOptions->has('b'));
+        $this->assertSame([
+            'a' => 'value_a',
+            'b' => null,
+        ], $renderOptions->all());
+    }
+
+    public function testSettingOptions(): void
+    {
+        $renderOptions = new RenderOptions();
+
+        $renderOptions->set('a', 'value_a');
+        $this->assertTrue($renderOptions->has('a'));
+        $this->assertSame('value_a', $renderOptions->get('a'));
+
+        $this->assertTrue($renderOptions->has('a'));
+        $renderOptions->set('a', 'different_value_a');
+        $this->assertSame('different_value_a', $renderOptions->get('a'));
+
+        $this->assertFalse($renderOptions->has('b'));
+        $renderOptions->set('b', null);
+        $this->assertFalse($renderOptions->has('b'));
+    }
+
+    public function testGettingDefaultOptions(): void
+    {
+        $renderOptions = new RenderOptions([
+            'a' => null,
+            'b' => 'default_value_b',
+        ]);
+
+        $this->assertFalse($renderOptions->has('a'));
+        $this->assertSame('some_default_value', $renderOptions->get('a', 'some_default_value'));
+
+        $this->assertTrue($renderOptions->has('b'));
+        $this->assertSame('default_value_b', $renderOptions->get('b', 'other_default_value'));
+
+        $this->assertFalse($renderOptions->has('c'));
+        $this->assertSame('default_value_c', $renderOptions->get('c', 'default_value_c'));
+    }
+
+    public function testUnsettingOptions(): void
+    {
+        $renderOptions = new RenderOptions([
+            'a' => 'value_a',
+            'b' => 'value_b',
+            'c' => 'value_c',
+        ]);
+
+        $renderOptions->set('a', null);
+        $this->assertFalse($renderOptions->has('a'));
+
+        $renderOptions->remove('b');
+        $this->assertFalse($renderOptions->has('b'));
+
+        $this->assertTrue($renderOptions->has('c'));
+    }
+}

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderStrategyTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderStrategyTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests;
+
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
+use eZ\Publish\API\Repository\Values\ValueObject;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderOptions;
+use eZ\Publish\Core\MVC\Symfony\Templating\RenderStrategy;
+use eZ\Publish\SPI\MVC\Templating\RenderStrategy as SPIRenderStrategy;
+use PHPUnit\Framework\TestCase;
+
+class RenderStrategyTest extends TestCase
+{
+    private function createRenderStrategy(
+        string $rendered,
+        string $supportsClass = ValueObject::class
+    ): SPIRenderStrategy {
+        return new class($rendered, $supportsClass) implements SPIRenderStrategy {
+            /** @var string */
+            private $rendered;
+
+            /** @var string */
+            private $supportsClass;
+
+            public function __construct(string $rendered, string $supportsClass)
+            {
+                $this->rendered = $rendered;
+                $this->supportsClass = $supportsClass;
+            }
+
+            public function supports(ValueObject $valueObject): bool
+            {
+                return $valueObject instanceof $this->supportsClass;
+            }
+
+            public function render(ValueObject $valueObject, RenderOptions $options): string
+            {
+                return $this->rendered;
+            }
+        };
+    }
+
+    public function testNoStrategies(): void
+    {
+        $renderStrategy = new RenderStrategy([]);
+
+        $valueObject = new class() extends ValueObject {
+        };
+        $this->assertFalse($renderStrategy->supports($valueObject));
+
+        $this->expectException(InvalidArgumentException::class);
+        $renderStrategy->render($valueObject, new RenderOptions());
+    }
+
+    public function testNoSupportedStrategy(): void
+    {
+        $renderStrategy = new RenderStrategy([
+            $this->createRenderStrategy('some_rendered_content', 'SomeClass'),
+            $this->createRenderStrategy('other_rendered_content', 'OtherClass'),
+        ]);
+
+        $valueObject = new class() extends ValueObject {
+        };
+        $this->assertFalse($renderStrategy->supports($valueObject));
+
+        $this->expectException(InvalidArgumentException::class);
+        $renderStrategy->render($valueObject, new RenderOptions());
+    }
+
+    public function testSupportStrategy(): void
+    {
+        $renderStrategy = new RenderStrategy([
+            $this->createRenderStrategy('some_rendered_content'),
+        ]);
+
+        $valueObject = new class() extends ValueObject {
+        };
+        $this->assertTrue($renderStrategy->supports($valueObject));
+        $this->assertSame('some_rendered_content', $renderStrategy->render($valueObject, new RenderOptions()));
+    }
+
+    public function testMultipleStrategiesSameValueObjectType(): void
+    {
+        $valueObject = new class() extends ValueObject {
+        };
+        $valueObjectClass = get_class($valueObject);
+
+        $renderStrategy = new RenderStrategy([
+            $this->createRenderStrategy('some_rendered_content', $valueObjectClass),
+            $this->createRenderStrategy('other_rendered_content', $valueObjectClass),
+        ]);
+
+        $this->assertTrue($renderStrategy->supports($valueObject));
+        $this->assertSame('some_rendered_content', $renderStrategy->render($valueObject, new RenderOptions()));
+    }
+
+    public function testMultipleStrategies(): void
+    {
+        $valueObject = new class() extends ValueObject {
+        };
+        $valueObjectClass = get_class($valueObject);
+
+        $renderStrategy = new RenderStrategy([
+            $this->createRenderStrategy('some_rendered_content', 'SomeOtherClass'),
+            $this->createRenderStrategy('other_rendered_content', $valueObjectClass),
+        ]);
+
+        $this->assertTrue($renderStrategy->supports($valueObject));
+        $this->assertSame('other_rendered_content', $renderStrategy->render($valueObject, new RenderOptions()));
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-31851
| **Type**                                   | feature/bug/improvement
| **Target eZ Platform version** | `v3.2` - please update `x` accordingly
| **BC breaks**                          | no
| **Doc needed**                       | no

Missing tests.

Also fixes wrong getter scope resulting in `null` value for header.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
