### PR TITLE
EZP-32045: Added support for AuthorTermAggregation

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceAggregationTest.php
@@ -968,8 +968,4 @@ final class SearchServiceAggregationTest extends BaseTest
 
         return $contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
     }
-
-    private function getExampleAuthorFieldValues(): array
-    {
-    }
 }

--- a/eZ/Publish/API/Repository/Tests/SearchServiceAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceAggregationTest.php
@@ -15,6 +15,7 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ContentTypeGroupTermAggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ContentTypeTermAggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\DateMetadataRangeAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\AuthorTermAggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CheckboxTermAggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\CountryTermAggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\DateRangeAggregation;
@@ -47,8 +48,10 @@ use eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\TermAggreg
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
+use eZ\Publish\Core\FieldType\Author\Author;
 use eZ\Publish\Core\FieldType\Checkbox\Value as CheckboxValue;
 use eZ\Publish\Core\FieldType\Time\Value as TimeValue;
+use eZ\Publish\Core\FieldType\Author\Value as AuthorValue;
 
 /**
  * Test case for aggregations in the SearchService.
@@ -414,6 +417,84 @@ final class SearchServiceAggregationTest extends BaseTest
 
     public function dataProviderForTestFieldAggregation(): iterable
     {
+        yield AuthorTermAggregation::class => [
+            new AuthorTermAggregation('author_term', 'content_type', 'author'),
+            'ezauthor',
+            [
+                new AuthorValue([
+                    new Author([
+                        'name' => 'Boba Fett',
+                        'email' => 'boba.fett@example.com',
+                    ]),
+                    new Author([
+                        'name' => 'Luke Skywalker',
+                        'email' => 'luke.skywalker@example.com',
+                    ]),
+                ]),
+                new AuthorValue([
+                    new Author([
+                        'name' => 'Anakin Skywalker',
+                        'email' => 'anakin.skywalker@example.com',
+                    ]),
+                ]),
+                new AuthorValue([
+                    new Author([
+                        'name' => 'Boba Fett',
+                        'email' => 'boba.fett@example.com',
+                    ]),
+                ]),
+                new AuthorValue([
+                    new Author([
+                        'name' => 'Luke Skywalker',
+                        'email' => 'luke.skywalker@example.com',
+                    ]),
+                    new Author([
+                        'name' => 'Leia Organa',
+                        'email' => 'leia.organa@example.com',
+                    ]),
+                ]),
+                new AuthorValue([
+                    new Author([
+                        'name' => 'Leia Organa',
+                        'email' => 'leia.organa@example.com',
+                    ]),
+                ]),
+            ],
+            new TermAggregationResult(
+                'author_term',
+                [
+                    new TermAggregationResultEntry(
+                        new Author([
+                            'name' => 'Boba Fett',
+                            'email' => 'boba.fett@example.com',
+                        ]),
+                        2
+                    ),
+                    new TermAggregationResultEntry(
+                        new Author([
+                            'name' => 'Leia Organa',
+                            'email' => 'leia.organa@example.com',
+                        ]),
+                        2
+                    ),
+                    new TermAggregationResultEntry(
+                        new Author([
+                            'name' => 'Luke Skywalker',
+                            'email' => 'luke.skywalker@example.com',
+                        ]),
+                        2
+                    ),
+                    new TermAggregationResultEntry(
+                        new Author([
+                            'name' => 'Anakin Skywalker',
+                            'email' => 'anakin.skywalker@example.com',
+                        ]),
+                        1
+                    ),
+                ]
+            ),
+        ];
+
         yield CheckboxTermAggregation::class => [
             new CheckboxTermAggregation('checkbox_term', 'content_type', 'boolean'),
             'ezboolean',
@@ -886,5 +967,9 @@ final class SearchServiceAggregationTest extends BaseTest
         $contentTypeService->publishContentTypeDraft($contentTypeDraft);
 
         return $contentTypeService->loadContentTypeByIdentifier($contentTypeIdentifier);
+    }
+
+    private function getExampleAuthorFieldValues(): array
+    {
     }
 }

--- a/eZ/Publish/Core/FieldType/Author/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Author/SearchField.php
@@ -10,6 +10,7 @@ use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use eZ\Publish\SPI\FieldType\Indexable;
 use eZ\Publish\SPI\Search;
+use eZ\Publish\SPI\Search\FieldType\MultipleIdentifierField;
 
 /**
  * Indexable definition for Author field type.
@@ -29,11 +30,17 @@ class SearchField implements Indexable
         $name = [];
         $id = [];
         $email = [];
+        $aggregationValues = [];
 
         foreach ($field->value->data as $author) {
             $name[] = $author['name'];
             $id[] = $author['id'];
             $email[] = $author['email'];
+
+            $aggregationValues[] = json_encode([
+                'name' => $author['name'],
+                'email' => $author['email'],
+            ]);
         }
 
         return [
@@ -56,6 +63,11 @@ class SearchField implements Indexable
                 'count',
                 count($field->value->data),
                 new Search\FieldType\IntegerField()
+            ),
+            new Search\Field(
+                'aggregation_value',
+                $aggregationValues,
+                new MultipleIdentifierField(['raw' => true]),
             ),
             new Search\Field(
                 'sort_value',
@@ -82,6 +94,7 @@ class SearchField implements Indexable
             'id' => new Search\FieldType\MultipleIntegerField(),
             'email' => new Search\FieldType\MultipleStringField(),
             'count' => new Search\FieldType\IntegerField(),
+            'aggregation_value' => new MultipleIdentifierField(['raw' => true]),
             'sort_value' => new Search\FieldType\StringField(),
         ];
     }


### PR DESCRIPTION
| Question | Answer |
| --- | --- |
| **JIRA issue** | EZP-32045 |
| **Type** | feature |
| **Target eZ Platform version** | `v3.2` |
| **BC breaks** | no |
| **Doc needed** | yes |

Added support for `\eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\AuthorTermAggregation`. Usage is exact the same as in case of other field based aggregations:

```php
$query = new Query();
$query->aggregations[] = new AuthorTermAggregation('group_by_author', 'article', 'author');
```

The result of the aggregation is `\eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\TermAggregationResult`. Key of `\eZ\Publish\API\Repository\Values\Content\Search\AggregationResult\TermAggregationResultEntry` is `\eZ\Publish\Core\FieldType\Author\Author`.

```php
$results = $searchService->findContent();

$authors = $results->aggregations->get('group_by_author');

/** @var \eZ\Publish\Core\FieldType\Author\Author $author */
foreach ($authors as $author => $count) {
    // e.g. "John Doe <john.doe@ez.no> is author of 3 article(s)"
    printf("%s <%s> is author of %d article(s)", $author->name, $author->email, $count);
}
```

### Implementation comments

*   `AuthorTermAggregation` is based on a new `aggregation_value` field which contains author data as serialized JSON. Existing fields are suitable for aggregation.

#### Checklist:

*   [x] Provided PR description.
*   [x] Tested the solution manually.
*   [x] Provided automated test coverage.
*   [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
*   [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
*   [x] Asked for a review (ping `@ezsystems/php-dev-team`).