### PR TITLE
EZP-32045: Added support for SubtreeTermAggregation

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchServiceAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceAggregationTest.php
@@ -294,11 +294,11 @@ final class SearchServiceAggregationTest extends BaseTest
         $locationService = $this->getRepository()->getLocationService();
 
         yield SubtreeTermAggregation::class => $this->createTermAggregationTestCase(
-            new SubtreeTermAggregation('subtree', '/1/43/'),
+            new SubtreeTermAggregation('subtree', '/1/5/'),
             [
-                51 => 1,
-                52 => 1,
-                53 => 1,
+                5 => 7,
+                13 => 1,
+                44 => 1,
             ],
             [$locationService, 'loadLocation']
         );

--- a/eZ/Publish/API/Repository/Tests/SearchServiceAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceAggregationTest.php
@@ -27,6 +27,7 @@ use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\KeywordTerm
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\SelectionTermAggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Field\TimeRangeAggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\LanguageTermAggregation;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Location\SubtreeTermAggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\ObjectStateTermAggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\RawRangeAggregation;
@@ -288,6 +289,18 @@ final class SearchServiceAggregationTest extends BaseTest
             [
                 true => 18,
             ]
+        );
+
+        $locationService = $this->getRepository()->getLocationService();
+
+        yield SubtreeTermAggregation::class => $this->createTermAggregationTestCase(
+            new SubtreeTermAggregation('subtree', '/1/43/'),
+            [
+                51 => 1,
+                52 => 1,
+                53 => 1,
+            ],
+            [$locationService, 'loadLocation']
         );
 
         yield RawRangeAggregation::class => [

--- a/eZ/Publish/API/Repository/Tests/Values/Content/Query/Aggregation/Location/SubtreeTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/Query/Aggregation/Location/SubtreeTermAggregationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Values\Content\Query\Aggregation\Location;
+
+use eZ\Publish\API\Repository\Exceptions\InvalidArgumentException;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Location\SubtreeTermAggregation;
+use PHPUnit\Framework\TestCase;
+
+final class SubtreeTermAggregationTest extends TestCase
+{
+    private const EXAMPLE_PATH_STRING = '/1/2/';
+    private const EXAMPLE_AGGREGATION_NAME = 'foo';
+
+    public function testConstruct(): void
+    {
+        $aggregation = new SubtreeTermAggregation(
+            self::EXAMPLE_AGGREGATION_NAME,
+            self::EXAMPLE_PATH_STRING
+        );
+
+        $this->assertEquals(self::EXAMPLE_AGGREGATION_NAME, $aggregation->getName());
+        $this->assertEquals(self::EXAMPLE_PATH_STRING, $aggregation->getPathString());
+    }
+
+    public function testConstructThrowsInvalidArgumentExceptionOnInvalidPathString(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectErrorMessage("'/INVALID/PATH' value must follow the path string format, e.g. /1/2/");
+
+        $aggregation = new SubtreeTermAggregation('foo', '/INVALID/PATH');
+    }
+
+    public function testFromLocation(): void
+    {
+        $location = $this->createMock(Location::class);
+        $location->method('__get')->with('pathString')->willReturn(self::EXAMPLE_PATH_STRING);
+
+        $aggregation = SubtreeTermAggregation::fromLocation(self::EXAMPLE_AGGREGATION_NAME, $location);
+
+        $this->assertEquals(self::EXAMPLE_AGGREGATION_NAME, $aggregation->getName());
+        $this->assertEquals(self::EXAMPLE_PATH_STRING, $aggregation->getPathString());
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Location/SubtreeTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Location/SubtreeTermAggregation.php
@@ -8,9 +8,42 @@ declare(strict_types=1);
 
 namespace eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Location;
 
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\AbstractTermAggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\LocationAggregation;
+use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 
 final class SubtreeTermAggregation extends AbstractTermAggregation implements LocationAggregation
 {
+    /** @var string */
+    private $pathString;
+
+    public function __construct(string $name, string $pathString)
+    {
+        parent::__construct($name);
+
+        if (!$this->isValidPathString($pathString)) {
+            throw new InvalidArgumentException(
+                '$pathString',
+                "'$pathString' value must follow the path string format, e.g. /1/2/"
+            );
+        }
+
+        $this->pathString = $pathString;
+    }
+
+    public function getPathString(): string
+    {
+        return $this->pathString;
+    }
+
+    private function isValidPathString(string $pathString): bool
+    {
+        return preg_match('/^(\/\w+)+\/$/', $pathString) === 1;
+    }
+
+    public static function fromLocation(string $name, Location $location): self
+    {
+        return new self($name, $location->pathString);
+    }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32045
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.2`
| **BC breaks**                          | no
| **Doc needed**                       | yes

Added support for SubtreeTermAggregation

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
