### PR TITLE
Fixed RangeTest namespace

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Values/Content/Query/Aggregation/RangeTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/Query/Aggregation/RangeTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Values\Content\Query\Aggregation;
+namespace eZ\Publish\API\Repository\Tests\Values\Content\Query\Aggregation;
 
 use DateTimeImmutable;
 use eZ\Publish\API\Repository\Values\Content\Query\Aggregation\Range;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.2`
| **BC breaks**                          | no
| **Doc needed**                       |  no

Fixed invalid namespace in RangeTest:  `Values\Content\Query\Aggregatio` => `eZ\Publish\API\Repository\Tests\Values\Content\Query\Aggregation`

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
