### PR TITLE
Add +/- 2s error margin for $passwordUpdatedAt in the UserServiceTest::testUpdateUserUpdatesExpectedProperties

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1783,9 +1783,10 @@ class UserServiceTest extends BaseTest
 
         // Make sure passwordUpdatedAt field has been updated together with password
         $this->assertNotNull($user->passwordUpdatedAt);
-        $this->assertGreaterThanOrEqual(
+        $this->assertEqualsWithDelta(
             $user->getVersionInfo()->modificationDate->getTimestamp(),
-            $user->passwordUpdatedAt->getTimestamp()
+            $user->passwordUpdatedAt->getTimestamp(),
+            2.0
         );
     }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.x`
| **BC breaks**                          | no
| **Doc needed**                       | no

Added +/- 2s error margin when asserting  $passwordUpdatedAt in the UserServiceTest::testUpdateUserUpdatesExpectedProperties in order to avoid the following false negatives in CI builds.

```
There was 1 failure:
1) eZ\Publish\API\Repository\Tests\UserServiceTest::testUpdateUserUpdatesExpectedProperties
Failed asserting that 1603055825 is equal to 1603055826 or is greater than 1603055826.
/home/travis/build/ezsystems/ezplatform-kernel/eZ/Publish/API/Repository/Tests/UserServiceTest.php:1788
```

Source: https://travis-ci.com/github/ezsystems/ezplatform-kernel/jobs/401754887

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
