### PR TITLE
Added missing type casting in UrlAliasGateway

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -1255,7 +1255,7 @@ final class DoctrineDatabase extends Gateway
                 $updateQueryBuilder->execute();
             } catch (UniqueConstraintViolationException $e) {
                 // edge case: if such row already exists, there's no way to restore history
-                $this->deleteRow($urlAliasData['parent'], $urlAliasData['text_md5']);
+                $this->deleteRow((int)$urlAliasData['parent'], $urlAliasData['text_md5']);
             }
         }
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | none
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.0`
| **BC breaks**                          | no
| **Doc needed**                       | no

because of enabled strict_types $urlAliasData['parent'] has to be type casted in  `eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\Gateway\DoctrineDatabase`

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/php-dev-team`).