### PR TITLE
EZP-32101: Added support for DateTimeInterface in ezdate, ezdatetime and eztime

### DIFF
--- a/eZ/Publish/Core/FieldType/Date/Type.php
+++ b/eZ/Publish/Core/FieldType/Date/Type.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\FieldType\Date;
 
+use DateTimeInterface;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
@@ -84,8 +85,8 @@ class Type extends FieldType
             $inputValue = Value::fromTimestamp($inputValue);
         }
 
-        if ($inputValue instanceof DateTime) {
-            $inputValue = new Value($inputValue);
+        if ($inputValue instanceof DateTimeInterface) {
+            $inputValue = Value::fromDateTimeInterface($inputValue);
         }
 
         return $inputValue;

--- a/eZ/Publish/Core/FieldType/Date/Value.php
+++ b/eZ/Publish/Core/FieldType/Date/Value.php
@@ -6,6 +6,8 @@
  */
 namespace eZ\Publish\Core\FieldType\Date;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use eZ\Publish\Core\FieldType\Value as BaseValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 use Exception;
@@ -78,6 +80,18 @@ class Value extends BaseValue
         } catch (Exception $e) {
             throw new InvalidArgumentValue('$timestamp', $timestamp, __CLASS__, $e);
         }
+    }
+
+    /**
+     * Creates a Value from the given DateTimeInterface instance.
+     */
+    public static function fromDateTimeInterface(?DateTimeInterface $dateTime): self
+    {
+        if ($dateTime instanceof DateTimeImmutable) {
+            $dateTime = DateTime::createFromImmutable($dateTime);
+        }
+
+        return new self($dateTime);
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/DateAndTime/Type.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/Type.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\FieldType\DateAndTime;
 
+use DateTimeInterface;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\Core\FieldType\FieldType;
@@ -94,8 +95,8 @@ class Type extends FieldType
             $inputValue = Value::fromTimestamp($inputValue);
         }
 
-        if ($inputValue instanceof DateTime) {
-            $inputValue = new Value($inputValue);
+        if ($inputValue instanceof DateTimeInterface) {
+            $inputValue = Value::fromDateTimeInterface($inputValue);
         }
 
         return $inputValue;

--- a/eZ/Publish/Core/FieldType/DateAndTime/Value.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/Value.php
@@ -6,6 +6,8 @@
  */
 namespace eZ\Publish\Core\FieldType\DateAndTime;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use eZ\Publish\Core\FieldType\Value as BaseValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 use Exception;
@@ -70,6 +72,18 @@ class Value extends BaseValue
         } catch (Exception $e) {
             throw new InvalidArgumentValue('$timestamp', $timestamp, __CLASS__, $e);
         }
+    }
+
+    /**
+     * Creates a Value from the given DateTimeInterface instance.
+     */
+    public static function fromDateTimeInterface(?DateTimeInterface $dateTime): self
+    {
+        if ($dateTime instanceof DateTimeImmutable) {
+            $dateTime = DateTime::createFromImmutable($dateTime);
+        }
+
+        return new self($dateTime);
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
@@ -6,6 +6,8 @@
  */
 namespace eZ\Publish\Core\FieldType\Tests;
 
+use DateTime;
+use DateTimeImmutable;
 use eZ\Publish\Core\FieldType\DateAndTime\Type as DateAndTime;
 use eZ\Publish\Core\FieldType\DateAndTime\Value as DateAndTimeValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
@@ -156,8 +158,16 @@ class DateAndTimeTest extends FieldTypeTest
                 DateAndTimeValue::fromTimestamp(1346149200),
             ],
             [
-                ($dateTime = new \DateTime()),
+                ($dateTime = new DateTime()),
                 new DateAndTimeValue($dateTime),
+            ],
+            [
+                ($dateTime = new DateTime()),
+                DateAndTimeValue::fromDateTimeInterface($dateTime),
+            ],
+            [
+                ($dateTime = new DateTimeImmutable()),
+                DateAndTimeValue::fromDateTimeInterface($dateTime),
             ],
         ];
     }
@@ -205,9 +215,9 @@ class DateAndTimeTest extends FieldTypeTest
                 null,
             ],
             [
-                new DateAndTimeValue($date = new \DateTime('Tue, 28 Aug 2012 12:20:00 +0200')),
+                new DateAndTimeValue($date = new DateTime('Tue, 28 Aug 2012 12:20:00 +0200')),
                 [
-                    'rfc850' => $date->format(\DateTime::RFC850),
+                    'rfc850' => $date->format(DateTime::RFC850),
                     'timestamp' => $date->getTimeStamp(),
                 ],
             ],
@@ -253,7 +263,7 @@ class DateAndTimeTest extends FieldTypeTest
      */
     public function provideInputForFromHash()
     {
-        $date = new \DateTime('Tue, 28 Aug 2012 12:20:00 +0200');
+        $date = new DateTime('Tue, 28 Aug 2012 12:20:00 +0200');
 
         return [
             [
@@ -262,7 +272,7 @@ class DateAndTimeTest extends FieldTypeTest
             ],
             [
                 [
-                    'rfc850' => $date->format(\DateTime::RFC850),
+                    'rfc850' => $date->format(DateTime::RFC850),
                     'timestamp' => $date->getTimeStamp(),
                 ],
                 new DateAndTimeValue($date),
@@ -288,7 +298,7 @@ class DateAndTimeTest extends FieldTypeTest
 
         $fieldType = $this->getFieldTypeUnderTest();
 
-        $expectedResult = new DateAndTimeValue(new \DateTime());
+        $expectedResult = new DateAndTimeValue(new DateTime());
         $expectedResult->value->add(new DateInterval($intervalSpec));
 
         $actualResult = $fieldType->fromHash($inputHash);

--- a/eZ/Publish/Core/FieldType/Tests/DateTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateTest.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\FieldType\Tests;
 
+use DateTimeImmutable;
 use eZ\Publish\Core\FieldType\Date\Type as Date;
 use eZ\Publish\Core\FieldType\Date\Value as DateValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
@@ -156,6 +157,14 @@ class DateTest extends FieldTypeTest
             [
                 ($dateTime = new DateTime()),
                 new DateValue($dateTime),
+            ],
+            [
+                ($dateTime = new DateTime()),
+                DateValue::fromDateTimeInterface($dateTime),
+            ],
+            [
+                ($dateTime = new DateTimeImmutable()),
+                DateValue::fromDateTimeInterface($dateTime),
             ],
         ];
     }

--- a/eZ/Publish/Core/FieldType/Tests/TimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TimeTest.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\FieldType\Tests;
 
+use DateTimeImmutable;
 use eZ\Publish\Core\FieldType\Time\Type as Time;
 use eZ\Publish\Core\FieldType\Time\Value as TimeValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
@@ -174,6 +175,14 @@ class TimeTest extends FieldTypeTest
                 new TimeValue(
                     $dateTime->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp()
                 ),
+            ],
+            [
+                ($dateTime = new DateTime()),
+                TimeValue::fromDateTimeInterface($dateTime),
+            ],
+            [
+                ($dateTimeImmutable = new DateTimeImmutable()),
+                TimeValue::fromDateTimeInterface($dateTimeImmutable),
             ],
         ];
     }

--- a/eZ/Publish/Core/FieldType/Time/Type.php
+++ b/eZ/Publish/Core/FieldType/Time/Type.php
@@ -7,6 +7,7 @@
 namespace eZ\Publish\Core\FieldType\Time;
 
 use DateTime;
+use DateTimeInterface;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
@@ -92,8 +93,8 @@ class Type extends FieldType
             $inputValue = Value::fromTimestamp($inputValue);
         }
 
-        if ($inputValue instanceof DateTime) {
-            $inputValue = Value::fromDateTime($inputValue);
+        if ($inputValue instanceof DateTimeInterface) {
+            $inputValue = Value::fromDateTimeInterface($inputValue);
         }
 
         return $inputValue;

--- a/eZ/Publish/Core/FieldType/Time/Value.php
+++ b/eZ/Publish/Core/FieldType/Time/Value.php
@@ -6,6 +6,8 @@
  */
 namespace eZ\Publish\Core\FieldType\Time;
 
+use DateTimeImmutable;
+use DateTimeInterface;
 use eZ\Publish\Core\FieldType\Value as BaseValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 use Exception;
@@ -52,6 +54,18 @@ class Value extends BaseValue
         $dateTime = clone $dateTime;
 
         return new static($dateTime->getTimestamp() - $dateTime->setTime(0, 0, 0)->getTimestamp());
+    }
+
+    /**
+     * Creates a Value from the given DateTimeInterface instance.
+     */
+    public static function fromDateTimeInterface(DateTimeInterface $dateTime): self
+    {
+        if ($dateTime instanceof DateTimeImmutable) {
+            $dateTime = DateTime::createFromImmutable($dateTime);
+        }
+
+        return self::fromDateTime($dateTime);
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Time/Value.php
+++ b/eZ/Publish/Core/FieldType/Time/Value.php
@@ -59,8 +59,12 @@ class Value extends BaseValue
     /**
      * Creates a Value from the given DateTimeInterface instance.
      */
-    public static function fromDateTimeInterface(DateTimeInterface $dateTime): self
+    public static function fromDateTimeInterface(?DateTimeInterface $dateTime): self
     {
+        if ($dateTime === null) {
+            return new self($dateTime);
+        }
+
         if ($dateTime instanceof DateTimeImmutable) {
             $dateTime = DateTime::createFromImmutable($dateTime);
         }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32101
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | ?

Added support for DateTimeInterface in ezdate, ezdatetime and eztime.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
