### PR TITLE
EZP-32128: Thumbnails are no longer generated for removed image asset relation

### DIFF
--- a/eZ/Publish/Core/FieldType/ImageAsset/ImageAssetThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/ImageAssetThumbnailStrategy.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\FieldType\ImageAsset;
 
 use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field\FieldTypeBasedThumbnailStrategy;
@@ -42,7 +43,11 @@ class ImageAssetThumbnailStrategy implements FieldTypeBasedThumbnailStrategy
 
     public function getThumbnail(Field $field): ?Thumbnail
     {
-        $content = $this->contentService->loadContent($field->value->destinationContentId);
+        try {
+            $content = $this->contentService->loadContent((int) $field->value->destinationContentId);
+        } catch (NotFoundException $e) {
+            return null;
+        }
 
         return $this->thumbnailStrategy->getThumbnail(
             $content->getContentType(),


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32128
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.1`
| **BC breaks**                          | no
| **Doc needed**                       | no

This not fix _exactly_ issue described in jira ticket, but as steps to reproduce are that same and int affects similar scope I solved both of issues at that same time. As this refers to failure with obtaining content thumbnail it also affects `3.1` (in opposition to https://github.com/ezsystems/ezplatform-rest/pull/59)

#### Checklist:
- [ ] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
