### PR TITLE
EZP-32151: Added Pagerfanta adapters for Repository Filtering API

### DIFF
--- a/eZ/Publish/Core/Pagination/Pagerfanta/ContentFilteringAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/ContentFilteringAdapter.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Filter\Filter;
+use Pagerfanta\Adapter\AdapterInterface;
+
+/**
+ * Pagerfanta adapter for content filtering.
+ */
+final class ContentFilteringAdapter implements AdapterInterface
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\Values\Filter\Filter */
+    private $filter;
+
+    /** @var array|null */
+    private $languageFilter;
+
+    /** @var int|null */
+    private $totalCount;
+
+    public function __construct(
+        ContentService $contentService,
+        Filter $filter,
+        ?array $languageFilter = null
+    ) {
+        $this->contentService = $contentService;
+        $this->filter = $filter;
+        $this->languageFilter = $languageFilter;
+    }
+
+    public function getNbResults(): int
+    {
+        if ($this->totalCount === null) {
+            $filter = clone $this->filter;
+            $filter->sliceBy(0, 0);
+
+            $this->totalCount = $this->contentService->find(
+                $filter,
+                $this->languageFilter
+            )->getTotalCount();
+        }
+
+        return $this->totalCount;
+    }
+
+    public function getSlice($offset, $length): iterable
+    {
+        $filter = clone $this->filter;
+        $filter->sliceBy($length, $offset);
+
+        $results = $this->contentService->find($filter, $this->languageFilter);
+        if ($this->totalCount === null) {
+            $this->totalCount = $results->getTotalCount();
+        }
+
+        return $results;
+    }
+}

--- a/eZ/Publish/Core/Pagination/Pagerfanta/ContentFilteringAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/ContentFilteringAdapter.php
@@ -42,11 +42,11 @@ final class ContentFilteringAdapter implements AdapterInterface
     public function getNbResults(): int
     {
         if ($this->totalCount === null) {
-            $filter = clone $this->filter;
-            $filter->sliceBy(0, 0);
+            $countFilter = clone $this->filter;
+            $countFilter->sliceBy(0, 0);
 
             $this->totalCount = $this->contentService->find(
-                $filter,
+                $countFilter,
                 $this->languageFilter
             )->getTotalCount();
         }
@@ -56,10 +56,10 @@ final class ContentFilteringAdapter implements AdapterInterface
 
     public function getSlice($offset, $length): iterable
     {
-        $filter = clone $this->filter;
-        $filter->sliceBy($length, $offset);
+        $selectFilter = clone $this->filter;
+        $selectFilter->sliceBy($length, $offset);
 
-        $results = $this->contentService->find($filter, $this->languageFilter);
+        $results = $this->contentService->find($selectFilter, $this->languageFilter);
         if ($this->totalCount === null) {
             $this->totalCount = $results->getTotalCount();
         }

--- a/eZ/Publish/Core/Pagination/Pagerfanta/LocationFilteringAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/LocationFilteringAdapter.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Filter\Filter;
+use Pagerfanta\Adapter\AdapterInterface;
+
+final class LocationFilteringAdapter implements AdapterInterface
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /** @var \eZ\Publish\API\Repository\Values\Filter\Filter */
+    private $filter;
+
+    /** @var array|null */
+    private $languageFilter;
+
+    /** @var int|null */
+    private $totalCount;
+
+    public function __construct(
+        LocationService $locationService,
+        Filter $filter,
+        ?array $languageFilter = null
+    ) {
+        $this->locationService = $locationService;
+        $this->filter = $filter;
+        $this->languageFilter = $languageFilter;
+    }
+
+    public function getNbResults(): int
+    {
+        if ($this->totalCount === null) {
+            $filter = clone $this->filter;
+            $filter->sliceBy(0, 0);
+
+            $this->totalCount = $this->locationService->find(
+                $filter,
+                $this->languageFilter
+            )->totalCount;
+        }
+
+        return $this->totalCount;
+    }
+
+    public function getSlice($offset, $length): iterable
+    {
+        $filter = clone $this->filter;
+        $filter->sliceBy($length, $offset);
+
+        $results = $this->locationService->find($filter, $this->languageFilter);
+        if ($this->totalCount === null) {
+            $this->totalCount = $results->totalCount;
+        }
+
+        return $results;
+    }
+}

--- a/eZ/Publish/Core/Pagination/Pagerfanta/LocationFilteringAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/LocationFilteringAdapter.php
@@ -39,11 +39,11 @@ final class LocationFilteringAdapter implements AdapterInterface
     public function getNbResults(): int
     {
         if ($this->totalCount === null) {
-            $filter = clone $this->filter;
-            $filter->sliceBy(0, 0);
+            $countFilter = clone $this->filter;
+            $countFilter->sliceBy(0, 0);
 
             $this->totalCount = $this->locationService->find(
-                $filter,
+                $countFilter,
                 $this->languageFilter
             )->totalCount;
         }
@@ -53,10 +53,10 @@ final class LocationFilteringAdapter implements AdapterInterface
 
     public function getSlice($offset, $length): iterable
     {
-        $filter = clone $this->filter;
-        $filter->sliceBy($length, $offset);
+        $selectFilter = clone $this->filter;
+        $selectFilter->sliceBy($length, $offset);
 
-        $results = $this->locationService->find($filter, $this->languageFilter);
+        $results = $this->locationService->find($selectFilter, $this->languageFilter);
         if ($this->totalCount === null) {
             $this->totalCount = $results->totalCount;
         }

--- a/eZ/Publish/Core/Pagination/Tests/ContentFilteringAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/ContentFilteringAdapterTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Pagination\Tests;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\ContentList;
+use eZ\Publish\API\Repository\Values\Filter\Filter;
+use eZ\Publish\Core\Pagination\Pagerfanta\ContentFilteringAdapter;
+use eZ\Publish\Core\Search\Tests\TestCase;
+
+final class ContentFilteringAdapterTest extends TestCase
+{
+    private const EXAMPLE_LANGUAGE_FILTER = [
+        'languages' => ['eng-GB', 'pol-PL'],
+        'useAlwaysAvailable' => true,
+    ];
+
+    /** @var \eZ\Publish\API\Repository\ContentService|\PHPUnit\Framework\MockObject\MockObject */
+    private $contentService;
+
+    protected function setUp(): void
+    {
+        $this->contentService = $this->createMock(ContentService::class);
+    }
+
+    public function testGetNbResults(): void
+    {
+        $expectedNumberOfItems = 10;
+
+        $this->contentService
+            ->method('find')
+            ->with(
+                (new Filter())->sliceBy(0, 0), // Make sure that count query doesn't fetch results
+                self::EXAMPLE_LANGUAGE_FILTER
+            )
+            ->willReturn($this->createExpectedContentList($expectedNumberOfItems));
+
+        $adapter = new ContentFilteringAdapter(
+            $this->contentService,
+            (new Filter())->sliceBy(10, 0),
+            self::EXAMPLE_LANGUAGE_FILTER
+        );
+
+        $this->assertEquals(
+            $expectedNumberOfItems,
+            $adapter->getNbResults()
+        );
+    }
+
+    public function testGetSlice(): void
+    {
+        $expectedContentList = $this->createExpectedContentList(10);
+
+        $filter = new Filter();
+        $filter->sliceBy(20, 10);
+
+        $this->contentService
+            ->method('find')
+            ->with($filter, self::EXAMPLE_LANGUAGE_FILTER)
+            ->willReturn($expectedContentList);
+
+        $adapter = new ContentFilteringAdapter(
+            $this->contentService,
+            $filter,
+            self::EXAMPLE_LANGUAGE_FILTER
+        );
+
+        $this->assertEquals(
+            $expectedContentList,
+            $adapter->getSlice(10, 20)
+        );
+    }
+
+    private function createExpectedContentList(int $numberOfItems): ContentList
+    {
+        $items = [];
+        for ($i = 0; $i < $numberOfItems; ++$i) {
+            $items[] = $this->createMock(Content::class);
+        }
+
+        return new ContentList($numberOfItems, $items);
+    }
+}

--- a/eZ/Publish/Core/Pagination/Tests/LocationFilteringAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/LocationFilteringAdapterTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Pagination\Tests;
+
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\LocationList;
+use eZ\Publish\API\Repository\Values\Filter\Filter;
+use eZ\Publish\Core\Pagination\Pagerfanta\LocationFilteringAdapter;
+use eZ\Publish\Core\Search\Tests\TestCase;
+
+final class LocationFilteringAdapterTest extends TestCase
+{
+    private const EXAMPLE_LANGUAGE_FILTER = [
+        'languages' => ['eng-GB', 'pol-PL'],
+        'useAlwaysAvailable' => true,
+    ];
+
+    /** @var \eZ\Publish\API\Repository\LocationService|\PHPUnit\Framework\MockObject\MockObject */
+    private $locationService;
+
+    protected function setUp(): void
+    {
+        $this->locationService = $this->createMock(LocationService::class);
+    }
+
+    public function testGetNbResults(): void
+    {
+        $expectedNumberOfItems = 10;
+
+        $this->locationService
+            ->method('find')
+            ->with(
+                (new Filter())->sliceBy(0, 0), // Make sure that count query doesn't fetch results
+                self::EXAMPLE_LANGUAGE_FILTER
+            )
+            ->willReturn($this->createExpectedLocationList($expectedNumberOfItems));
+
+        $adapter = new LocationFilteringAdapter(
+            $this->locationService,
+            (new Filter())->sliceBy(10, 0),
+            self::EXAMPLE_LANGUAGE_FILTER
+        );
+
+        $this->assertEquals(
+            $expectedNumberOfItems,
+            $adapter->getNbResults()
+        );
+    }
+
+    public function testGetSlice(): void
+    {
+        $expectedContentList = $this->createExpectedLocationList(10);
+
+        $filter = new Filter();
+        $filter->sliceBy(20, 10);
+
+        $this->locationService
+            ->method('find')
+            ->with($filter, self::EXAMPLE_LANGUAGE_FILTER)
+            ->willReturn($expectedContentList);
+
+        $adapter = new LocationFilteringAdapter(
+            $this->locationService,
+            $filter,
+            self::EXAMPLE_LANGUAGE_FILTER
+        );
+
+        $this->assertEquals(
+            $expectedContentList,
+            $adapter->getSlice(10, 20)
+        );
+    }
+
+    private function createExpectedLocationList(int $numberOfItems): LocationList
+    {
+        $items = [];
+        for ($i = 0; $i < $numberOfItems; ++$i) {
+            $items[] = $this->createMock(Location::class);
+        }
+
+        return new LocationList([
+            'totalCount' => $numberOfItems,
+            'locations' => $items,
+        ]);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32151
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | yes

Impl. Pagerfanta adapters for Repository Filtering API.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
