### PR TITLE
[EZEE-3357] Fixed so that we can get VersionInfo for internal drafts

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -361,7 +361,8 @@ class Mapper
                 $versionInfo->creationDate = (int)$row['ezcontentobject_version_created'];
                 $versionInfo->modificationDate = (int)$row['ezcontentobject_version_modified'];
                 $versionInfo->status = (int)$row['ezcontentobject_version_status'];
-                $versionInfo->names = $nameData[$versionId];
+                // Versions with VersionInfo::STATUS_INTERNAL_DRAFT might not have a row in ezcontentobject_name
+                $versionInfo->names = isset($nameData[$versionId]) ? $nameData[$versionId] : null;
                 $versionInfoList[$versionId] = $versionInfo;
                 $versionInfo->languageCodes = $this->extractLanguageCodesFromMask(
                     (int)$row['ezcontentobject_version_language_mask'],


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZEE-3357
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.2`
| **BC breaks**                          | no
| **Doc needed**                       | no

During migration from landing page to pagebuilder, I discovered the kernel is not able to create VersionInfo objects for internal drafts without throwing a notice.
In my use-case, the fix applies to ezpublish-kernel, but I assume ezplatform kernel should also be able to deal with internal drafts too.

The corresponding [ezpublish-kernel PR](https://github.com/ezsystems/ezpublish-kernel/pull/3078)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [X] Asked for a review (ping `@ezsystems/php-dev-team`).
