### PR TITLE
EZP-32108: Added CustomField sort clause

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/sort_spec.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/sort_spec.yml
@@ -8,6 +8,10 @@ services:
         arguments:
             $parsers: !tagged_iterator ezplatform.query_type.sort_clause_parser
 
+    eZ\Publish\Core\QueryType\BuiltIn\SortSpec\SortClauseParser\CustomFieldSortClauseParser:
+        tags:
+            - { name: ezplatform.query_type.sort_clause_parser }
+
     eZ\Publish\Core\QueryType\BuiltIn\SortSpec\SortClauseParser\FieldSortClauseParser:
         tags:
             - { name: ezplatform.query_type.sort_clause_parser }

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -12,12 +12,11 @@ use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
 use eZ\Publish\API\Repository\Exceptions\ForbiddenException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
-use eZ\Publish\API\Repository\Tests\SetupFactory\Legacy;
+use eZ\Publish\API\Repository\Tests\SetupFactory\Legacy as LegacySetupFactory;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Language;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
-use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use PHPUnit\Framework\TestCase;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\API\Repository\Values\ValueObject;
@@ -170,7 +169,7 @@ abstract class BaseTest extends TestCase
     {
         if (null === $this->setupFactory) {
             if (false === ($setupClass = getenv('setupFactory'))) {
-                $setupClass = Legacy::class;
+                $setupClass = LegacySetupFactory::class;
                 putenv("setupFactory=${setupClass}");
             }
 
@@ -506,15 +505,11 @@ abstract class BaseTest extends TestCase
     /**
      * Calls given Repository's aggregated SearchHandler::refresh().
      *
-     * Currently implemented only in Solr search engine.
-     *
      * @param \eZ\Publish\API\Repository\Repository $repository
      */
     protected function refreshSearch(Repository $repository)
     {
-        $setupFactory = $this->getSetupFactory();
-
-        if (!$setupFactory instanceof LegacySolrSetupFactory) {
+        if ($this->isLegacySearchEngineSetup()) {
             return;
         }
 
@@ -537,6 +532,11 @@ abstract class BaseTest extends TestCase
         $searchHandler = $searchHandlerProperty->getValue($repository);
 
         $searchHandler->commit();
+    }
+
+    protected function isLegacySearchEngineSetup(): bool
+    {
+        return get_class($this->getSetupFactory()) === LegacySetupFactory::class;
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
+use eZ\Publish\API\Repository\Tests\SetupFactory\Legacy as LegacySetupFactory;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use InvalidArgumentException;
@@ -1701,148 +1702,171 @@ class SearchServiceTest extends BaseTest
     {
         $fixtureDir = $this->getFixtureDir();
 
-        return [
-            0 => [
-                [
-                    'filter' => new Criterion\SectionId([2]),
-                    'offset' => 0,
-                    'limit' => 10,
-                    'sortClauses' => [],
-                ],
-                $fixtureDir . 'SortNone.php',
-                // Result having the same sort level should be sorted between them to be system independent
-                function (&$data) {
-                    usort(
-                        $data->searchHits,
-                        function ($a, $b) {
-                            return ($a->valueObject['id'] < $b->valueObject['id']) ? -1 : 1;
-                        }
-                    );
-                },
+        yield [
+            [
+                'filter' => new Criterion\SectionId([2]),
+                'offset' => 0,
+                'limit' => 10,
+                'sortClauses' => [],
             ],
-            1 => [
-                [
-                    'filter' => new Criterion\SectionId([2]),
-                    'offset' => 0,
-                    'limit' => 10,
-                    'sortClauses' => [
-                        new SortClause\DatePublished(),
-                        new SortClause\ContentId(),
-                    ],
+            $fixtureDir . 'SortNone.php',
+            // Result having the same sort level should be sorted between them to be system independent
+            function (&$data) {
+                usort(
+                    $data->searchHits,
+                    function ($a, $b) {
+                        return ($a->valueObject['id'] < $b->valueObject['id']) ? -1 : 1;
+                    }
+                );
+            },
+        ];
+
+        yield [
+            [
+                'filter' => new Criterion\SectionId([2]),
+                'offset' => 0,
+                'limit' => 10,
+                'sortClauses' => [
+                    new SortClause\DatePublished(),
+                    new SortClause\ContentId(),
                 ],
-                $fixtureDir . 'SortDatePublished.php',
             ],
-            2 => [
-                [
-                    'filter' => new Criterion\SectionId([2]),
-                    'offset' => 0,
-                    'limit' => 50,
-                    'sortClauses' => [
-                        new SortClause\DateModified(),
-                        new SortClause\ContentId(),
-                    ],
+            $fixtureDir . 'SortDatePublished.php',
+        ];
+
+        yield [
+            [
+                'filter' => new Criterion\SectionId([2]),
+                'offset' => 0,
+                'limit' => 50,
+                'sortClauses' => [
+                    new SortClause\DateModified(),
+                    new SortClause\ContentId(),
                 ],
-                $fixtureDir . 'SortDateModified.php',
             ],
-            3 => [
-                [
-                    'filter' => new Criterion\SectionId([4, 2, 6, 3]),
-                    'offset' => 0,
-                    'limit' => 50,
-                    'sortClauses' => [
-                        new SortClause\SectionIdentifier(),
-                        new SortClause\ContentId(),
-                    ],
+            $fixtureDir . 'SortDateModified.php',
+        ];
+
+        yield [
+            [
+                'filter' => new Criterion\SectionId([4, 2, 6, 3]),
+                'offset' => 0,
+                'limit' => 50,
+                'sortClauses' => [
+                    new SortClause\SectionIdentifier(),
+                    new SortClause\ContentId(),
                 ],
-                $fixtureDir . 'SortSectionIdentifier.php',
             ],
-            4 => [
-                [
-                    'filter' => new Criterion\SectionId([4, 2, 6, 3]),
-                    'offset' => 0,
-                    'limit' => 50,
-                    'sortClauses' => [
-                        new SortClause\SectionName(),
-                        new SortClause\ContentId(),
-                    ],
+            $fixtureDir . 'SortSectionIdentifier.php',
+        ];
+
+        yield [
+            [
+                'filter' => new Criterion\SectionId([4, 2, 6, 3]),
+                'offset' => 0,
+                'limit' => 50,
+                'sortClauses' => [
+                    new SortClause\SectionName(),
+                    new SortClause\ContentId(),
                 ],
-                $fixtureDir . 'SortSectionName.php',
             ],
-            5 => [
-                [
-                    'filter' => new Criterion\SectionId([2, 3]),
-                    'offset' => 0,
-                    'limit' => 50,
-                    'sortClauses' => [
-                        new SortClause\ContentName(),
-                        new SortClause\ContentId(),
-                    ],
+            $fixtureDir . 'SortSectionName.php',
+        ];
+
+        yield [
+            [
+                'filter' => new Criterion\SectionId([2, 3]),
+                'offset' => 0,
+                'limit' => 50,
+                'sortClauses' => [
+                    new SortClause\ContentName(),
+                    new SortClause\ContentId(),
                 ],
-                $fixtureDir . 'SortContentName.php',
             ],
-            6 => [
+            $fixtureDir . 'SortContentName.php',
+        ];
+
+        yield [
+            [
+                'filter' => new Criterion\ContentTypeId(1),
+                'offset' => 0,
+                'limit' => 50,
+                'sortClauses' => [
+                    new SortClause\Field('folder', 'name', Query::SORT_ASC),
+                    new SortClause\ContentId(),
+                ],
+            ],
+            $fixtureDir . 'SortFolderName.php',
+        ];
+
+        yield [
+            [
+                'filter' => new Criterion\ContentTypeId([1, 3]),
+                'offset' => 0,
+                'limit' => 50,
+                'sortClauses' => [
+                    new SortClause\Field('folder', 'name', Query::SORT_ASC),
+                    new SortClause\ContentId(),
+                ],
+            ],
+            $fixtureDir . 'SortFieldMultipleTypes.php',
+        ];
+
+        yield [
+            [
+                'filter' => new Criterion\ContentTypeId([1, 3]),
+                'offset' => 0,
+                'limit' => 50,
+                'sortClauses' => [
+                    new SortClause\Field('folder', 'name', Query::SORT_DESC),
+                    new SortClause\ContentId(),
+                ],
+            ],
+            $fixtureDir . 'SortFieldMultipleTypesReverse.php',
+        ];
+
+        yield [
+            [
+                'filter' => new Criterion\ContentTypeId([1, 3]),
+                'offset' => 3,
+                'limit' => 5,
+                'sortClauses' => [
+                    new SortClause\Field('folder', 'name', Query::SORT_ASC),
+                    new SortClause\Field('user', 'first_name', Query::SORT_ASC),
+                    new SortClause\ContentId(),
+                ],
+            ],
+            $fixtureDir . 'SortFieldMultipleTypesSlice.php',
+        ];
+
+        yield [
+            [
+                'filter' => new Criterion\ContentTypeId([1, 3]),
+                'offset' => 3,
+                'limit' => 5,
+                'sortClauses' => [
+                    new SortClause\Field('folder', 'name', Query::SORT_DESC),
+                    new SortClause\Field('user', 'first_name', Query::SORT_ASC),
+                    new SortClause\ContentId(),
+                ],
+            ],
+            $fixtureDir . 'SortFieldMultipleTypesSliceReverse.php',
+        ];
+
+        if (!$this->isLegacySearchEngineSetup()) {
+            yield [
                 [
                     'filter' => new Criterion\ContentTypeId(1),
                     'offset' => 0,
                     'limit' => 50,
                     'sortClauses' => [
-                        new SortClause\Field('folder', 'name', Query::SORT_ASC),
+                        new SortClause\CustomField('folder_name_value_s', Query::SORT_ASC),
                         new SortClause\ContentId(),
                     ],
                 ],
                 $fixtureDir . 'SortFolderName.php',
-            ],
-            7 => [
-                [
-                    'filter' => new Criterion\ContentTypeId([1, 3]),
-                    'offset' => 0,
-                    'limit' => 50,
-                    'sortClauses' => [
-                        new SortClause\Field('folder', 'name', Query::SORT_ASC),
-                        new SortClause\ContentId(),
-                    ],
-                ],
-                $fixtureDir . 'SortFieldMultipleTypes.php',
-            ],
-            8 => [
-                [
-                    'filter' => new Criterion\ContentTypeId([1, 3]),
-                    'offset' => 0,
-                    'limit' => 50,
-                    'sortClauses' => [
-                        new SortClause\Field('folder', 'name', Query::SORT_DESC),
-                        new SortClause\ContentId(),
-                    ],
-                ],
-                $fixtureDir . 'SortFieldMultipleTypesReverse.php',
-            ],
-            9 => [
-                [
-                    'filter' => new Criterion\ContentTypeId([1, 3]),
-                    'offset' => 3,
-                    'limit' => 5,
-                    'sortClauses' => [
-                        new SortClause\Field('folder', 'name', Query::SORT_ASC),
-                        new SortClause\Field('user', 'first_name', Query::SORT_ASC),
-                        new SortClause\ContentId(),
-                    ],
-                ],
-                $fixtureDir . 'SortFieldMultipleTypesSlice.php',
-            ],
-            10 => [
-                [
-                    'filter' => new Criterion\ContentTypeId([1, 3]),
-                    'offset' => 3,
-                    'limit' => 5,
-                    'sortClauses' => [
-                        new SortClause\Field('folder', 'name', Query::SORT_DESC),
-                        new SortClause\Field('user', 'first_name', Query::SORT_ASC),
-                        new SortClause\ContentId(),
-                    ],
-                ],
-                $fixtureDir . 'SortFieldMultipleTypesSliceReverse.php',
-            ],
-        ];
+            ];
+        }
     }
 
     public function getSortedLocationSearches()
@@ -5007,7 +5031,7 @@ class SearchServiceTest extends BaseTest
 
     private function skipIfSeedNotImplemented()
     {
-        /** @var \eZ\Publish\API\Repository\Tests\SetupFactory\Legacy $setupFactory */
+        /** @var LegacySetupFactory $setupFactory */
         $setupFactory = $this->getSetupFactory();
 
         $db = $setupFactory->getDB();

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -1711,11 +1711,11 @@ class SearchServiceTest extends BaseTest
             ],
             $fixtureDir . 'SortNone.php',
             // Result having the same sort level should be sorted between them to be system independent
-            function (&$data) {
+            static function (&$data): void {
                 usort(
                     $data->searchHits,
-                    function ($a, $b) {
-                        return ($a->valueObject['id'] < $b->valueObject['id']) ? -1 : 1;
+                    static function (SearchHit $a, SearchHit $b): int {
+                        return $a->valueObject['id'] <=> $b->valueObject['id'];
                     }
                 );
             },
@@ -5031,7 +5031,7 @@ class SearchServiceTest extends BaseTest
 
     private function skipIfSeedNotImplemented()
     {
-        /** @var LegacySetupFactory $setupFactory */
+        /** @var \eZ\Publish\API\Repository\Tests\SetupFactory\Legacy $setupFactory */
         $setupFactory = $this->getSetupFactory();
 
         $db = $setupFactory->getDB();

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -6,7 +6,6 @@
  */
 namespace eZ\Publish\API\Repository\Tests;
 
-use eZ\Publish\API\Repository\Tests\SetupFactory\Legacy as LegacySetupFactory;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\Operator;
 use EzSystems\EzPlatformSolrSearchEngine\Tests\SetupFactory\LegacySetupFactory as LegacySolrSetupFactory;
 use InvalidArgumentException;

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/CustomField.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/CustomField.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target\CustomFieldTarget;
+
+/**
+ * Sorts search results by raw search index field.
+ */
+final class CustomField extends SortClause
+{
+    public function __construct(string $field, string $sortDirection = Query::SORT_ASC)
+    {
+        parent::__construct('custom_field', $sortDirection, new CustomFieldTarget($field));
+    }
+}

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/CustomFieldTarget.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/CustomFieldTarget.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target;
+
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\Target;
+
+final class CustomFieldTarget extends Target
+{
+    /** @var string */
+    public $fieldName;
+
+    public function __construct(string $fieldName)
+    {
+        $this->fieldName = $fieldName;
+    }
+}

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParser/CustomFieldSortClauseParser.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParser/CustomFieldSortClauseParser.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\QueryType\BuiltIn\SortSpec\SortClauseParser;
+
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\CustomField;
+use eZ\Publish\Core\QueryType\BuiltIn\SortSpec\SortClauseParserInterface;
+use eZ\Publish\Core\QueryType\BuiltIn\SortSpec\SortSpecParserInterface;
+use eZ\Publish\Core\QueryType\BuiltIn\SortSpec\Token;
+
+/**
+ * Parser for \eZ\Publish\API\Repository\Values\Content\Query\SortClause\RawField sort clause.
+ *
+ * Example of correct input:
+ *
+ *      custom_field custom_field_name ASC
+ */
+final class CustomFieldSortClauseParser implements SortClauseParserInterface
+{
+    private const SUPPORTED_CLAUSE_NAME = 'custom_field';
+
+    public function parse(SortSpecParserInterface $parser, string $name): SortClause
+    {
+        $args = [];
+        $args[] = $parser->match(Token::TYPE_ID)->getValue();
+        $args[] = $parser->parseSortDirection();
+
+        return new CustomField(...$args);
+    }
+
+    public function supports(string $name): bool
+    {
+        return $name === self::SUPPORTED_CLAUSE_NAME;
+    }
+}

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortSpecParser.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortSpecParser.php
@@ -17,8 +17,9 @@ use eZ\Publish\Core\QueryType\BuiltIn\SortSpec\Exception\SyntaxErrorException;
  *
  *    <sort-clauses-list> ::= <sort-clause> ("," <sort-clause>)?
  *    <sort-clause> ::= <id> <sort-clause-args>? <sort-direction>?
- *    <sort-clause-args> ::= <sort-clause-field-args> | <sort-clause-map-distance-args> | <sort-clause-random-args>
+ *    <sort-clause-args> ::= <sort-clause-field-args> | <sort-clause-map-distance-args> | <sort-clause-random-args> | <sort-clause-custom-field-args>
  *    <sort-clause-field-args> ::= <id> "." <id>
+ *    <sort-clause-custom-field-args> ::= <id>
  *    <sort-clause-map-distance-args> ::=  <id> "." <id> <float> <float>
  *    <sort-clause-random-args> ::= <int>?
  *    <sort-clause-sort-direction> ::= "asc" | "desc"

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortClauseParser/CustomFieldSortClauseParserTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortClauseParser/CustomFieldSortClauseParserTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\QueryType\BuiltIn\SortSpec\Tests\SortClauseParser;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause\CustomField;
+use eZ\Publish\Core\QueryType\BuiltIn\SortSpec\SortClauseParser\CustomFieldSortClauseParser;
+use eZ\Publish\Core\QueryType\BuiltIn\SortSpec\SortSpecParserInterface;
+use eZ\Publish\Core\QueryType\BuiltIn\SortSpec\Token;
+use PHPUnit\Framework\TestCase;
+
+final class CustomFieldSortClauseParserTest extends TestCase
+{
+    private const EXAMPLE_SEARCH_INDEX_FIELD = 'custom_field_s';
+
+    /** @var \eZ\Publish\Core\QueryType\BuiltIn\SortSpec\SortClauseParser\CustomFieldSortClauseParser */
+    private $parser;
+
+    protected function setUp(): void
+    {
+        $this->parser = new CustomFieldSortClauseParser();
+    }
+
+    public function testParse(): void
+    {
+        $parser = $this->createMock(SortSpecParserInterface::class);
+        $parser
+            ->method('match')
+            ->with(Token::TYPE_ID)
+            ->willReturn(
+                new Token(
+                    Token::TYPE_ID,
+                    self::EXAMPLE_SEARCH_INDEX_FIELD
+                ),
+            );
+
+        $parser->method('parseSortDirection')->willReturn(Query::SORT_ASC);
+
+        $this->assertEquals(
+            new CustomField(
+                self::EXAMPLE_SEARCH_INDEX_FIELD,
+                Query::SORT_ASC
+            ),
+            $this->parser->parse($parser, 'custom_field')
+        );
+    }
+
+    public function testSupports(): void
+    {
+        $this->assertTrue($this->parser->supports('custom_field'));
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32108
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | yes
| **Related PRs**                      | https://github.com/ezsystems/ezplatform-elastic-search-engine/pull/23 <br /> https://github.com/ezsystems/ezplatform-solr-search-engine/pull/204 |

Added `\eZ\Publish\API\Repository\Values\Content\Query\SortClause\CustomField` which allows sort search results using raw search index field. 

```php
$query = new Query([
    'query' => new Criterion\MatchAll(),
    'sortClauses' => [
        new SortClause\CustomField('my_custom_field_s'),
    ],
]);
```

This sort clause is can be used in ad hoc tools and testing but should be avoid in production code. 

#### Checklist:
- [X] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
