### PR TITLE
EZEE-3356: Added JsonSerializableNormalizer for Serializer to handle Serializable interface

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\MVC\Symfony\Component\Serializer;
 
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\JsonSerializableNormalizer;
 use Symfony\Component\Serializer\Normalizer\PropertyNormalizer;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -29,6 +30,7 @@ trait SerializerTrait
                 new RegexNormalizer(),
                 new URIElementNormalizer(),
                 new SimplifiedRequestNormalizer(),
+                new JsonSerializableNormalizer(),
                 new PropertyNormalizer(),
             ],
             [new JsonEncoder()]


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZEE-3356
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.1`
| **BC breaks**                          | no
| **Doc needed**                       | no
| **Related PR**                       | https://github.com/ezsystems/ezplatform-site-factory/pull/100


JsonSerializableNormalizer needs to be added to deal with objects implementing the JsonSerializable interface. 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
