### PR TITLE
EZP-32184: Added warning about possible memory leaks for reindex command

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -212,14 +212,13 @@ EOT
         } else {
             $io = new SymfonyStyle($input, $output);
             $io->warning(<<<EOT
-For optimal performance, before running this command, make sure that:
-- the xdebug extension is disabled,
-- you're running the command in "prod" environment,
-- memory limit for big databases is set to "-1" or an adequately high value,
-- --iteration-count is low enough (default: 50),
-- number of processes for parallel batch operations is high enough (default: 'auto' is a good choice).
-EOT
-            );
+                For optimal performance, before running this command, make sure that:
+                - the xdebug extension is disabled,
+                - you're running the command in "prod" environment,
+                - memory limit for big databases is set to "-1" or an adequately high value,
+                - --iteration-count is low enough (default: 50),
+                - number of processes for parallel batch operations is high enough (default: 'auto' is a good choice).
+            EOT);
 
             if (!$io->confirm('Continue?', true)) {
                 return 0;

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Command;
 
+use Symfony\Component\Console\Style\SymfonyStyle;
 use function count;
 use const DIRECTORY_SEPARATOR;
 use Doctrine\DBAL\Connection;
@@ -209,6 +210,21 @@ EOT
             );
             $this->searchIndexer->createSearchIndex($output, (int) $iterationCount, !$commit);
         } else {
+            $io = new SymfonyStyle($input, $output);
+            $io->warning(<<<EOT
+You might encounter possible memory leaks while running the command under following circumstances:
+- enabled xdebug extension,
+- dev environment set,
+- inadequate memory_limit for big databases (recommended value: -1 that stands for non-limited memory usage),
+- too high --iteration-count value (default: 50),
+- specifying too few child processes for parallel batch operations (default: 'auto').
+EOT
+            );
+
+            if (!$io->confirm('Continue?', true)) {
+                return 0;
+            }
+
             $output->writeln('Re-indexing started for search engine: ' . $this->searchIndexer->getName());
             $output->writeln('');
 

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -212,12 +212,12 @@ EOT
         } else {
             $io = new SymfonyStyle($input, $output);
             $io->warning(<<<EOT
-You might encounter possible memory leaks while running the command under following circumstances:
-- enabled xdebug extension,
-- dev environment set,
-- inadequate memory_limit for big databases (recommended value: -1 that stands for non-limited memory usage),
-- too high --iteration-count value (default: 50),
-- specifying too few child processes for parallel batch operations (default: 'auto').
+For optimal performance, before running this command, make sure that:
+- the xdebug extension is disabled,
+- you're running the command in "prod" environment,
+- memory limit for big databases is set to "-1" or an adequately high value,
+- --iteration-count is low enough (default: 50),
+- number of processes for parallel batch operations is high enough (default: 'auto' is a good choice).
 EOT
             );
 

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -209,21 +209,25 @@ class ReindexCommand extends Command
             EOT);
             $this->searchIndexer->createSearchIndex($output, (int) $iterationCount, !$commit);
         } else {
-            $io = new SymfonyStyle($input, $output);
-            $xdebugState = \extension_loaded('xdebug') ? 'enabled' : 'disabled';
-            $memoryLimit = ini_get('memory_limit');
+            if (\in_array($input->getOption('processes'), ['0', '1'])) {
+                $io = new SymfonyStyle($input, $output);
+                $xdebugState = \extension_loaded('xdebug') ? 'enabled' : 'disabled';
+                $memoryLimit = ini_get('memory_limit');
 
-            $io->warning(<<<EOT
-                For optimal performance, before running this command, make sure that:
-                - the xdebug extension is disabled (you have it $xdebugState),
-                - you're running the command in "prod" environment (default: dev), 
-                - memory limit for big databases is set to "-1" or an adequately high value (your value: $memoryLimit),
-                - --iteration-count is low enough (default: 50),
-                - number of processes for parallel batch operations is high enough (default: 'auto' is a good choice).
-            EOT);
+                $io->warning(<<<EOT
+                    It's not recommended to run this command in a single process mode with a large dataset!
 
-            if (!$io->confirm('Continue?', true)) {
-                return 0;
+                    For optimal performance, before running this command, make sure that:
+                    - the xdebug extension is disabled (you have it $xdebugState),
+                    - you're running the command in "prod" environment (default: dev), 
+                    - memory limit for big databases is set to "-1" or an adequately high value (your value: $memoryLimit),
+                    - --iteration-count is low enough (default: 50),
+                    - number of processes for parallel batch operations is high enough (default: 'auto' is a good choice).
+                EOT);
+
+                if (!$io->confirm('Continue?', true)) {
+                    return 0;
+                }
             }
 
             $output->writeln('Re-indexing started for search engine: ' . $this->searchIndexer->getName());

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -161,25 +161,25 @@ class ReindexCommand extends Command
                 'auto'
             )->setHelp(
                 <<<EOT
-The command <info>%command.name%</info> indexes the current configured database in the configured search engine index.
-
-
-Example usage:
-- Refresh (add/update) index changes since yesterday:
-  <comment>ezplatform:reindex --since=yesterday</comment>
-  See: http://php.net/manual/en/datetime.formats.php
-
-- Refresh (add/update/remove) index on a set of content ID's:
-  <comment>ezplatform:reindex --content-ids=2,34,68</comment>
-
-- Refresh (add/update) index of a subtree:
-  <comment>ezplatform:reindex --subtree=45</comment>
-
-- Refresh (add/update) index, disabling the use of child proccesses and initial purging,
-  and let search engine handle commits using auto commit:
-  <comment>ezplatform:reindex --no-purge --no-commit --processes=0</comment>
-
-EOT
+                    The command <info>%command.name%</info> indexes the current configured database in the configured search engine index.
+                    
+                    
+                    Example usage:
+                    - Refresh (add/update) index changes since yesterday:
+                      <comment>ezplatform:reindex --since=yesterday</comment>
+                      See: http://php.net/manual/en/datetime.formats.php
+                    
+                    - Refresh (add/update/remove) index on a set of content ID's:
+                      <comment>ezplatform:reindex --content-ids=2,34,68</comment>
+                    
+                    - Refresh (add/update) index of a subtree:
+                      <comment>ezplatform:reindex --subtree=45</comment>
+                    
+                    - Refresh (add/update) index, disabling the use of child proccesses and initial purging,
+                      and let search engine handle commits using auto commit:
+                      <comment>ezplatform:reindex --no-purge --no-commit --processes=0</comment>
+                
+                EOT
             );
     }
 
@@ -197,25 +197,27 @@ EOT
 
         if (!$this->searchIndexer instanceof IncrementalIndexer) {
             $output->writeln(<<<EOT
-DEPRECATED:
-Running indexing against an Indexer that has not been updated to use IncrementalIndexer abstract.
-
-Options that won't be taken into account:
-- since
-- content-ids
-- subtree
-- processes
-- no-purge
-EOT
-            );
+                DEPRECATED:
+                Running indexing against an Indexer that has not been updated to use IncrementalIndexer abstract.
+                
+                Options that won't be taken into account:
+                - since
+                - content-ids
+                - subtree
+                - processes
+                - no-purge
+            EOT);
             $this->searchIndexer->createSearchIndex($output, (int) $iterationCount, !$commit);
         } else {
             $io = new SymfonyStyle($input, $output);
+            $xdebugState = \extension_loaded('xdebug') ? 'enabled' : 'disabled';
+            $memoryLimit = ini_get('memory_limit');
+
             $io->warning(<<<EOT
                 For optimal performance, before running this command, make sure that:
-                - the xdebug extension is disabled,
-                - you're running the command in "prod" environment,
-                - memory limit for big databases is set to "-1" or an adequately high value,
+                - the xdebug extension is disabled (you have it $xdebugState),
+                - you're running the command in "prod" environment (default: dev), 
+                - memory limit for big databases is set to "-1" or an adequately high value (your value: $memoryLimit),
                 - --iteration-count is low enough (default: 50),
                 - number of processes for parallel batch operations is high enough (default: 'auto' is a good choice).
             EOT);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32184
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.1`, `v3.2`
| **BC breaks**                          | no
| **Doc needed**                       | no

Excerpt from JIRA:
>Under several circumstances (https://doc.ibexa.co/en/3.1/guide/performance/#reducing-memory-usage) there might be potential memory leaks while running ezplatform:reindex command against big databases. The idea is to put a proper warning explaining several of them.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
