### PR TITLE
EZP-32181: Exposed Site Access Limitation type persistence value generation

### DIFF
--- a/eZ/Publish/Core/Limitation/SiteAccessLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SiteAccessLimitationType.php
@@ -32,12 +32,8 @@ class SiteAccessLimitationType implements SPILimitationTypeInterface
 
     /**
      * Generates the SiteAccess value as CRC32.
-     *
-     * @param string $sa
-     *
-     * @return string
      */
-    private function generateSiteAccessValue($sa)
+    public function generateSiteAccessValue(string $sa): string
     {
         return sprintf('%u', crc32($sa));
     }

--- a/eZ/Publish/Core/Limitation/Tests/SiteAccessLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SiteAccessLimitationTypeTest.php
@@ -297,4 +297,14 @@ class SiteAccessLimitationTypeTest extends Base
     {
         self::markTestSkipped('Method valueSchema() is not implemented');
     }
+
+    /**
+     * @depends testConstruct
+     */
+    public function testGenerateSiteAccessValue(SiteAccessLimitationType $limitationType): void
+    {
+        self::assertSame('341347141', $limitationType->generateSiteAccessValue('ger'));
+        self::assertSame('2582995467', $limitationType->generateSiteAccessValue('eng'));
+        self::assertSame('1817462202', $limitationType->generateSiteAccessValue('behat_site'));
+    }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32181
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no

This PR exposes currently internal `eZ\Publish\Core\Limitation\SiteAccessLimitationType::generateSiteAccessValue`.
It is needed for tools like ezmigration, which duplicates the implementation in places where mapping between value stored in persistence is needed to be mapped to an existing SiteAccess.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
