### PR TITLE
Fixed tests after Symfony 5.2 release

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
@@ -103,7 +103,7 @@ class BinaryLoaderTest extends TestCase
             ->with($binaryFile->id)
             ->will($this->returnValue($mimeType));
 
-        $expected = new Binary($content, $mimeType, 'jpeg');
+        $expected = new Binary($content, $mimeType, 'jpg');
         $this->assertEquals($expected, $this->binaryLoader->find($path));
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
@@ -74,7 +74,7 @@ class RememberMeRepositoryAuthenticationProviderTest extends TestCase
 
     public function testAuthenticateWrongSecret()
     {
-        $this->expectException(\Symfony\Component\Security\Core\Exception\BadCredentialsException::class);
+        $this->expectException(\Symfony\Component\Security\Core\Exception\AuthenticationException::class);
 
         $user = $this->createMock(UserInterface::class);
         $user


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | None
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.1`
| **BC breaks**                          | no
| **Doc needed**                       | no

Fixes tests breaking after Symfony 5.2 release.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
