### PR TITLE
EZP-31462: Removed password hash types break login

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -9,6 +9,7 @@ namespace eZ\Publish\API\Repository\Tests;
 use DateInterval;
 use DateTime;
 use DateTimeImmutable;
+use Doctrine\DBAL\ParameterType;
 use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
@@ -24,6 +25,7 @@ use eZ\Publish\API\Repository\Values\User\UserUpdateStruct;
 use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\Core\FieldType\User\Type;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\Core\Persistence\Legacy\User\Gateway;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Values\User\UserGroup;
@@ -2047,6 +2049,30 @@ class UserServiceTest extends BaseTest
     }
 
     /**
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \ErrorException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testUpdateUserPasswordWithUnsupportedHashType(): void
+    {
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+
+        $user = $this->createUser('john.doe', 'John', 'Doe');
+        $oldPasswordHash = $user->passwordHash;
+
+        $wrongHashType = 1;
+        $this->updateRawPasswordHash($user->getUserId(), $wrongHashType);
+        $newPassword = 'new_secret123';
+        // no need to invalidate cache since there was no load between create & raw database update
+        $user = $userService->updateUserPassword($user, $newPassword);
+
+        self::assertTrue($userService->checkUserCredentials($user, $newPassword));
+        self::assertNotEquals($oldPasswordHash, $user->passwordHash);
+    }
+
+    /**
      * Test for the loadUserGroupsOfUser() method.
      *
      * @covers \eZ\Publish\API\Repository\UserService::loadUserGroupsOfUser
@@ -3191,5 +3217,23 @@ class UserServiceTest extends BaseTest
         $contentTypeService->publishContentTypeDraft($contentTypeDraft);
 
         return $contentTypeService->loadContentTypeByIdentifier($identifier);
+    }
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     * @throws \ErrorException
+     */
+    protected function updateRawPasswordHash(int $userId, int $newHashType): void
+    {
+        $connection = $this->getRawDatabaseConnection();
+        $queryBuilder = $connection->createQueryBuilder();
+        $queryBuilder
+            ->update(Gateway::USER_TABLE)
+            ->set('password_hash_type', ':wrong_hash_type')
+            ->where('contentobject_id = :user_id')
+            ->setParameter('wrong_hash_type', $newHashType, ParameterType::INTEGER)
+            ->setParameter('user_id', $userId);
+
+        $queryBuilder->execute();
     }
 }

--- a/eZ/Publish/Core/Repository/User/PasswordHashServiceInterface.php
+++ b/eZ/Publish/Core/Repository/User/PasswordHashServiceInterface.php
@@ -15,6 +15,9 @@ interface PasswordHashServiceInterface
 {
     public function getDefaultHashType(): int;
 
+    /**
+     * @throws \eZ\Publish\Core\Repository\User\Exception\UnsupportedPasswordHashType
+     */
     public function createPasswordHash(string $password, ?int $hashType = null): string;
 
     public function isValidPassword(string $plainPassword, string $passwordHash, ?int $hashType = null): bool;

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -740,13 +740,13 @@ class UserService implements UserServiceInterface
     /**
      * Validates and updates just the user's password.
      *
-     * @param \eZ\Publish\API\Repository\Values\User\User $user
-     * @param string $newPassword
+     * @return \eZ\Publish\API\Repository\Values\User\User
      *
-     * @throws \eZ\Publish\Core\Base\Exceptions\ContentFieldValidationException
-     * @throws \eZ\Publish\Core\Base\Exceptions\MissingUserFieldTypeException
-     * @throws \eZ\Publish\Core\Base\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\Core\Repository\User\Exception\UnsupportedPasswordHashType
      */
     public function updateUserPassword(APIUser $user, string $newPassword): APIUser
     {

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -740,8 +740,6 @@ class UserService implements UserServiceInterface
     /**
      * Validates and updates just the user's password.
      *
-     * @return \eZ\Publish\API\Repository\Values\User\User
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-31462
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.2`+
| **BC breaks**                          | no
| **Doc needed**                       | yes

The previous fixes are incomplete. When an invalid hash type is detected, we expire the password and ask the user to enter a new password. But when we save this new password, we don't update the hash type, which means the password isn't saved, and the user ends up in a redirect loop.

However, cache can mask the issue. If you test by manually changing hash type to an invalid one in the db, you have to clear caches before you go through the test steps.

This fix catches when the type is invalid, and sets it to the default type in that case.

DOC: Once fixed, I suggest the relevant doc should mention that you have to upgrade to at least version x for this to work.
https://github.com/ezsystems/developer-documentation/blob/03a7cc0ea04f3e6bf7ebf22a8bea53840123196e/docs/releases/ez_platform_v3.0_deprecations.md#password-hashes

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
