### PR TITLE
EZP-32031: Better BinaryBase filename generation

### DIFF
--- a/eZ/Publish/Core/FieldType/BinaryBase/PathGenerator/LegacyPathGenerator.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/PathGenerator/LegacyPathGenerator.php
@@ -17,7 +17,7 @@ class LegacyPathGenerator extends PathGenerator
         $extension = pathinfo($field->value->externalData['fileName'], PATHINFO_EXTENSION);
 
         return $this->getFirstPartOfMimeType($field->value->externalData['mimeType'])
-            . '/' . md5(uniqid(microtime(true), true))
+            . '/' . bin2hex(random_bytes(16))
             . (!empty($extension) ? '.' . $extension : '');
     }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32031
| **Type**                                   | improvement
| **Target eZ Platform version** | master
| **BC breaks**                          | no
| **Doc needed**                       | no

LegacyPathGenerator uses a less than ideal way of generating unpredictable filenames:
https://github.com/ezsystems/ezplatform-kernel/blob/c1750540a0adf09b3242266fc32937bdcc3424fe/eZ/Publish/Core/FieldType/BinaryBase/PathGenerator/LegacyPathGenerator.php#L20

It's an md5 hash of a uniqid prefixed by a microtime float. Code scanners report the md5 usage as a potential security vulnerability. It isn't in this case, but the whole construction is needlessly complicated.

Note that microtime(true) doesn't give microsecond accuracy by default because it's limited by PHP's float precision, see https://jira.ez.no/browse/EZP-30381. Again, that's not a security problem the way it's used here, but it is misleading: It's easier to predict than it looks like.

It is important that filenames are hard to predict in cases where web server permissions are not ideally configured. If the web server allows direct access to binaryfile content, then hard to guess filenames is the only thing preventing download of files that might be supposed to be protected by read policies. This case is not very predictable, but the code smells of bad practices.

We should simply use random_bytes() instead. 16 binary bytes gives 32 hex chars, making it a drop-in replacement for the md5-uniqid-microtime construct, but with secure randomness:
`php -r 'print md5(uniqid(microtime(true), true)) . "\n" . bin2hex(random_bytes(16)) . "\n";'`

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage.~ Nothing to test, the new names are indistinguishable from the old ones.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
