### PR TITLE
EZP-32111: Added ContentTranslatedName sort clause

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/sort_spec.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/sort_spec.yml
@@ -29,6 +29,7 @@ services:
             $valueObjectClassMap:
                 content_id: \eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentId
                 content_name: \eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentName
+                content_translated_name: \eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentTranslatedName
                 date_modified: \eZ\Publish\API\Repository\Values\Content\Query\SortClause\DateModified
                 date_published: \eZ\Publish\API\Repository\Values\Content\Query\SortClause\DatePublished
                 section_identifier: \eZ\Publish\API\Repository\Values\Content\Query\SortClause\SectionIdentifier

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -822,6 +822,20 @@ abstract class BaseTest extends TestCase
         return $languageService->createLanguage($languageStruct);
     }
 
+    protected function createLanguageIfNotExists(
+        string $languageCode,
+        string $name,
+        bool $enabled = true
+    ): Language {
+        $repository = $this->getRepository(false);
+
+        try {
+            return $repository->getContentLanguageService()->loadLanguage($languageCode);
+        } catch (NotFoundException $e) {
+            return $this->createLanguage($languageCode, $name, $enabled);
+        }
+    }
+
     /**
      * @param string $identifier Content Type identifier
      * @param string $mainTranslation main translation language code

--- a/eZ/Publish/API/Repository/Tests/SearchService/SortClause/AbstractSortClauseTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/SortClause/AbstractSortClauseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\SearchService\SortClause;
+
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+
+abstract class AbstractSortClauseTest extends BaseTest
+{
+    protected function assertSearchResultOrderByRemoteId(
+        array $expectedOrderedIds,
+        SearchResult $actualSearchResults
+    ): void {
+        self::assertEquals(
+            count($expectedOrderedIds),
+            $actualSearchResults->totalCount
+        );
+
+        $actualIds = array_map(
+            static function (SearchHit $searchHit): string {
+                return $searchHit->valueObject->remoteId;
+            },
+            $actualSearchResults->searchHits
+        );
+
+        self::assertEquals($expectedOrderedIds, $actualIds);
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/SearchService/SortClause/ContentTranslatedNameTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/SortClause/ContentTranslatedNameTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\SearchService\SortClause;
+
+use DateTime;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+
+final class ContentTranslatedNameTest extends AbstractSortClauseTest
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->isLegacySearchEngineSetup()) {
+            self::markTestSkipped("Legacy search engine doesn't support ContentTranslatedName");
+        }
+    }
+
+    /**
+     * @param string[] $values
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\Exception
+     *
+     * @dataProvider dataProviderForTestSortingByContentTranslatedName
+     */
+    public function testContentSortingByContentTranslatedName(
+        iterable $inputValues,
+        SortClause $sortClause,
+        array $languageFilter,
+        array $expectedOrderedRemoteIds
+    ): void {
+        $this->createContentForContentTranslatedNameTesting($inputValues);
+
+        $query = new Query([
+            'filter' => new Criterion\ContentTypeIdentifier('content_translated_name_test'),
+            'sortClauses' => [
+                $sortClause,
+                new SortClause\ContentId(Query::SORT_ASC),
+            ],
+        ]);
+
+        $searchService = $this->getRepository()->getSearchService();
+        $actualResults = $searchService->findContentInfo($query, $languageFilter);
+
+        $this->assertSearchResultOrderByRemoteId($expectedOrderedRemoteIds, $actualResults);
+    }
+
+    /**
+     * @param string[] $values
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\Exception
+     *
+     * @dataProvider dataProviderForTestSortingByContentTranslatedName
+     */
+    public function testLocationSortingByContentTranslatedName(
+        iterable $inputValues,
+        SortClause $sortClause,
+        array $languageFilter,
+        array $expectedOrderedRemoteIds
+    ): void {
+        $this->createContentForContentTranslatedNameTesting($inputValues);
+
+        $query = new LocationQuery([
+            'filter' => new Criterion\ContentTypeIdentifier('content_translated_name_test'),
+            'sortClauses' => [
+                $sortClause,
+                new SortClause\ContentId(Query::SORT_ASC),
+            ],
+        ]);
+
+        $searchService = $this->getRepository()->getSearchService();
+        $actualResults = $searchService->findLocations($query, $languageFilter);
+
+        $this->assertSearchResultOrderByRemoteId($expectedOrderedRemoteIds, $actualResults);
+    }
+
+    public function dataProviderForTestSortingByContentTranslatedName(): iterable
+    {
+        $inputValues = [
+            'foo' => [
+                'eng-GB' => 'A',
+                'pol-PL' => 'C',
+            ],
+            'bar' => [
+                'eng-GB' => 'B',
+                'pol-PL' => 'B',
+            ],
+            'baz' => [
+                'eng-GB' => 'C',
+                'pol-PL' => 'A',
+            ],
+        ];
+
+        yield 'eng-GB, ASC' => [
+            $inputValues,
+            new SortClause\ContentTranslatedName(Query::SORT_ASC),
+            [
+                'languages' => [
+                    'eng-GB',
+                ],
+                'useAlwaysAvailable' => false,
+            ],
+            ['foo', 'bar', 'baz'],
+        ];
+
+        yield 'eng-GB, DESC' => [
+            $inputValues,
+            new SortClause\ContentTranslatedName(Query::SORT_DESC),
+            [
+                'languages' => [
+                    'eng-GB',
+                ],
+                'useAlwaysAvailable' => false,
+            ],
+            ['baz', 'bar', 'foo'],
+        ];
+
+        yield 'pol-PL, ASC' => [
+            $inputValues,
+            new SortClause\ContentTranslatedName(Query::SORT_ASC),
+            [
+                'languages' => [
+                    'pol-PL',
+                ],
+                'useAlwaysAvailable' => false,
+            ],
+            ['baz', 'bar', 'foo'],
+        ];
+
+        yield 'pol-PL, DESC' => [
+            $inputValues,
+            new SortClause\ContentTranslatedName(Query::SORT_DESC),
+            [
+                'languages' => [
+                    'pol-PL',
+                ],
+                'useAlwaysAvailable' => false,
+            ],
+            ['foo', 'bar', 'baz'],
+        ];
+
+        // Content name from main translation should be used ("C")
+        unset($inputValues['baz']['pol-PL']);
+
+        yield 'eng-GB + pol-PL, ASC' => [
+            $inputValues,
+            new SortClause\ContentTranslatedName(Query::SORT_ASC),
+            [
+                'languages' => [
+                    'pol-PL', 'eng-GB',
+                ],
+                'useAlwaysAvailable' => true,
+            ],
+            ['bar', 'foo', 'baz'],
+        ];
+
+        yield 'eng-GB + pol-PL, DESC' => [
+            $inputValues,
+            new SortClause\ContentTranslatedName(Query::SORT_DESC),
+            [
+                'languages' => [
+                    'pol-PL', 'eng-GB',
+                ],
+                'useAlwaysAvailable' => true,
+            ],
+            ['foo', 'baz', 'bar'],
+        ];
+    }
+
+    private function createContentForContentTranslatedNameTesting(iterable $values): void
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+        $locationService = $repository->getLocationService();
+        $contentTypeService = $repository->getContentTypeService();
+
+        $contentTypeCreateStruct = $contentTypeService->newContentTypeCreateStruct('content_translated_name_test');
+        $contentTypeCreateStruct->mainLanguageCode = 'eng-GB';
+        $contentTypeCreateStruct->names = ['eng-GB' => 'content_translated_name_test'];
+        $contentTypeCreateStruct->creatorId = 14;
+        $contentTypeCreateStruct->creationDate = new DateTime();
+        $contentTypeCreateStruct->nameSchema = '<value>';
+        $contentTypeCreateStruct->defaultAlwaysAvailable = true;
+
+        $fieldCreate = $contentTypeService->newFieldDefinitionCreateStruct('value', 'ezstring');
+        $fieldCreate->names = ['eng-GB' => 'value'];
+        $fieldCreate->fieldGroup = 'main';
+        $fieldCreate->position = 1;
+
+        $contentTypeCreateStruct->addFieldDefinition($fieldCreate);
+
+        $contentGroup = $contentTypeService->loadContentTypeGroupByIdentifier('Content');
+        $contentTypeDraft = $contentTypeService->createContentType($contentTypeCreateStruct, [$contentGroup]);
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+        $contentType = $contentTypeService->loadContentType($contentTypeDraft->id);
+
+        foreach ($values as $remoteId => $translations) {
+            $contentCreateStruct = $contentService->newContentCreateStruct($contentType, 'eng-GB');
+            $contentCreateStruct->remoteId = $remoteId;
+            $contentCreateStruct->alwaysAvailable = false;
+            foreach ($translations as $languageCode => $value) {
+                $this->createLanguageIfNotExists($languageCode, $languageCode);
+
+                $contentCreateStruct->setField('value', $value, $languageCode);
+            }
+
+            $locationCreateStruct = $locationService->newLocationCreateStruct(2);
+            $locationCreateStruct->remoteId = $remoteId;
+
+            $draft = $contentService->createContent(
+                $contentCreateStruct,
+                [
+                    $locationCreateStruct,
+                ]
+            );
+
+            $contentService->publishVersion($draft->getVersionInfo());
+        }
+
+        $this->refreshSearch($repository);
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/SearchService/SortClause/ScoreTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/SortClause/ScoreTest.php
@@ -9,15 +9,12 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Tests\SearchService\SortClause;
 
 use eZ\Publish\API\Repository\SearchService;
-use eZ\Publish\API\Repository\Tests\BaseTest;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
-use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
-use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 
-final class ScoreTest extends BaseTest
+final class ScoreTest extends AbstractSortClauseTest
 {
     protected function setUp(): void
     {
@@ -102,25 +99,6 @@ final class ScoreTest extends BaseTest
             ]),
             ['foo foo foo', 'foo foo', 'foo'],
         ];
-    }
-
-    private function assertSearchResultOrderByRemoteId(
-        array $expectedOrderedIds,
-        SearchResult $actualSearchResults
-    ): void {
-        self::assertEquals(
-            count($expectedOrderedIds),
-            $actualSearchResults->totalCount
-        );
-
-        $actualIds = array_map(
-            static function (SearchHit $searchHit): string {
-                return $searchHit->valueObject->remoteId;
-            },
-            $actualSearchResults->searchHits
-        );
-
-        self::assertEquals($expectedOrderedIds, $actualIds);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentTranslatedName.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentTranslatedName.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+
+final class ContentTranslatedName extends SortClause
+{
+    public function __construct(string $sortDirection = Query::SORT_ASC)
+    {
+        parent::__construct('content_translated_name', $sortDirection);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32111
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | yes

Added `\eZ\Publish\API\Repository\Values\Content\Query\SortClause\ContentTranslatedName` which allows sort search results using translated content name

```php
$query = new Query([
    'query' => new Criterion\MatchAll(),
    'sortClauses' => [
        new SortClause\ContentTranslatedName(),
    ],
]);
```

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [X] Provided automated test coverage.
- [X] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x]  Drop https://github.com/ezsystems/ezplatform-kernel/pull/143/commits/bcd7039c44b6eed5b0af7ff1ce03e4f780c7726f after https://github.com/ezsystems/ezplatform-kernel/pull/135 merge
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
