### PR TITLE
EZP-32110: Exposed more search result data from Pagefanta adapters

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/query_controller.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/query_controller.feature
@@ -92,7 +92,7 @@ Scenario: A content view can be configured to run and render a query and return 
       }
       """
     When I view a content matched by the view configuration above
-    Then the Query results assigned to the "children" twig variable is a "Pagerfanta\Pagerfanta" object
+    Then the Query results assigned to the "children" twig variable is a "\eZ\Publish\Core\Pagination\Pagerfanta\Pagerfanta" object
 
 Scenario: A content view can be configured to run and render a query return a PagerFanta Object and set limit and page name
     Given a content item that matches the view configuration block below

--- a/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/query_controller.feature
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/QueryController/query_controller.feature
@@ -92,7 +92,7 @@ Scenario: A content view can be configured to run and render a query and return 
       }
       """
     When I view a content matched by the view configuration above
-    Then the Query results assigned to the "children" twig variable is a "\eZ\Publish\Core\Pagination\Pagerfanta\Pagerfanta" object
+    Then the Query results assigned to the "children" twig variable is a "eZ\Publish\Core\Pagination\Pagerfanta\Pagerfanta" object
 
 Scenario: A content view can be configured to run and render a query return a PagerFanta Object and set limit and page name
     Given a content item that matches the view configuration block below

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/QueryController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/QueryController.php
@@ -10,11 +10,11 @@ use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\Core\MVC\Symfony\View\ContentView;
+use eZ\Publish\Core\Pagination\Pagerfanta\Pagerfanta;
 use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchHitAdapter;
 use eZ\Publish\Core\Pagination\Pagerfanta\LocationSearchHitAdapter;
 use eZ\Publish\Core\QueryType\ContentViewQueryTypeMapper;
 use Pagerfanta\Adapter\AdapterInterface;
-use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\Request;
 
 /**

--- a/eZ/Publish/Core/MVC/Symfony/Controller/QueryRenderController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/QueryRenderController.php
@@ -9,10 +9,10 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\MVC\Symfony\Controller;
 
 use eZ\Publish\Core\MVC\Symfony\View\QueryView;
+use eZ\Publish\Core\Pagination\Pagerfanta\Pagerfanta;
 use eZ\Publish\Core\Pagination\Pagerfanta\AdapterFactory\SearchHitAdapterFactoryInterface;
+use eZ\Publish\Core\Pagination\Pagerfanta\SearchResultAdapter;
 use eZ\Publish\Core\Query\QueryFactoryInterface;
-use Pagerfanta\Adapter\AdapterInterface;
-use Pagerfanta\Pagerfanta;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -92,7 +92,7 @@ final class QueryRenderController
         return $resolver->resolve($options);
     }
 
-    private function getAdapter(array $options): AdapterInterface
+    private function getAdapter(array $options): SearchResultAdapter
     {
         $query = $this->queryFactory->create(
             $options['query']['query_type'],

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/QueryRenderControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/QueryRenderControllerTest.php
@@ -12,9 +12,10 @@ use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\Core\MVC\Symfony\Controller\QueryRenderController;
 use eZ\Publish\Core\MVC\Symfony\View\QueryView;
 use eZ\Publish\Core\Pagination\Pagerfanta\AdapterFactory\SearchHitAdapterFactoryInterface;
+use eZ\Publish\Core\Pagination\Pagerfanta\Pagerfanta;
+use eZ\Publish\Core\Pagination\Pagerfanta\SearchResultAdapter;
 use eZ\Publish\Core\Query\QueryFactoryInterface;
 use Pagerfanta\Adapter\AdapterInterface;
-use Pagerfanta\Pagerfanta;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -113,7 +114,7 @@ final class QueryRenderControllerTest extends TestCase
             )
             ->willReturn($query);
 
-        $adapter = $this->createMock(AdapterInterface::class);
+        $adapter = $this->createMock(SearchResultAdapter::class);
 
         $this->searchHitAdapterFactory
             ->method('createAdapter')

--- a/eZ/Publish/Core/Pagination/Pagerfanta/AbstractSearchResultAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/AbstractSearchResultAdapter.php
@@ -1,0 +1,149 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResultCollection;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use Pagerfanta\Adapter\AdapterInterface;
+
+abstract class AbstractSearchResultAdapter implements AdapterInterface, SearchResultAdapter
+{
+    /** @var \eZ\Publish\API\Repository\SearchService */
+    private $searchService;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Query */
+    private $query;
+
+    /** @var array */
+    private $languageFilter;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Search\AggregationResultCollection|null */
+    private $aggregations;
+
+    /** @var float|null */
+    private $time;
+
+    /** @var bool|null */
+    private $timedOut;
+
+    /** @var float|null */
+    private $maxScore;
+
+    /** @var int|null */
+    private $totalCount;
+
+    public function __construct(Query $query, SearchService $searchService, array $languageFilter = [])
+    {
+        $this->query = $query;
+        $this->searchService = $searchService;
+        $this->languageFilter = $languageFilter;
+    }
+
+    /**
+     * Returns the number of results.
+     *
+     * @return int The number of results.
+     */
+    public function getNbResults()
+    {
+        if (isset($this->totalCount)) {
+            return $this->totalCount;
+        }
+
+        $countQuery = clone $this->query;
+        $countQuery->limit = 0;
+        // Skip facets/aggregations computing
+        $countQuery->facetBuilders = [];
+        $countQuery->aggregations = [];
+
+        $searchResults = $this->executeQuery(
+            $this->searchService,
+            $countQuery,
+            $this->languageFilter
+        );
+
+        return $this->totalCount = $searchResults->totalCount;
+    }
+
+    /**
+     * Returns a slice of the results, as SearchHit objects.
+     *
+     * @param int $offset The offset.
+     * @param int $length The length.
+     *
+     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchHit[]
+     */
+    public function getSlice($offset, $length)
+    {
+        $query = clone $this->query;
+        $query->offset = $offset;
+        $query->limit = $length;
+        $query->performCount = false;
+
+        $searchResult = $this->executeQuery(
+            $this->searchService,
+            $query,
+            $this->languageFilter
+        );
+
+        $this->aggregations = $searchResult->aggregations;
+        $this->time = $searchResult->time;
+        $this->timedOut = $searchResult->timedOut;
+        $this->maxScore = $searchResult->maxScore;
+
+        // Set count for further use if returned by search engine despite !performCount (Solr, ES)
+        if (!isset($this->totalCount) && isset($searchResult->totalCount)) {
+            $this->totalCount = $searchResult->totalCount;
+        }
+
+        return $searchResult->searchHits;
+    }
+
+    public function getAggregations(): AggregationResultCollection
+    {
+        if ($this->aggregations === null) {
+            $aggregationQuery = clone $this->query;
+            $aggregationQuery->offset = 0;
+            $aggregationQuery->limit = 0;
+
+            $searchResults = $this->executeQuery(
+                $this->searchService,
+                $aggregationQuery,
+                $this->languageFilter
+            );
+
+            $this->aggregations = $searchResults->aggregations;
+        }
+
+        return $this->aggregations;
+    }
+
+    public function getTime(): ?float
+    {
+        return $this->time;
+    }
+
+    public function getTimedOut(): ?bool
+    {
+        return $this->timedOut;
+    }
+
+    public function getMaxScore(): ?float
+    {
+        return $this->maxScore;
+    }
+
+    abstract protected function executeQuery(
+        SearchService $searchService,
+        Query $query,
+        array $languageFilter
+    ): SearchResult;
+}

--- a/eZ/Publish/Core/Pagination/Pagerfanta/AdapterFactory/SearchHitAdapterFactory.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/AdapterFactory/SearchHitAdapterFactory.php
@@ -12,9 +12,9 @@ use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchHitAdapter;
+use eZ\Publish\Core\Pagination\Pagerfanta\FixedSearchResultHitAdapter;
 use eZ\Publish\Core\Pagination\Pagerfanta\LocationSearchHitAdapter;
 use Pagerfanta\Adapter\AdapterInterface;
-use Pagerfanta\Adapter\FixedAdapter;
 
 /**
  * @internal
@@ -46,9 +46,6 @@ final class SearchHitAdapterFactory implements SearchHitAdapterFactoryInterface
             $searchResults = $this->searchService->findContent($query, $languageFilter);
         }
 
-        return new FixedAdapter(
-            $searchResults->totalCount,
-            $searchResults->searchHits
-        );
+        return new FixedSearchResultHitAdapter($searchResults);
     }
 }

--- a/eZ/Publish/Core/Pagination/Pagerfanta/ContentSearchHitAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/ContentSearchHitAdapter.php
@@ -7,81 +7,20 @@
 namespace eZ\Publish\Core\Pagination\Pagerfanta;
 
 use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\API\Repository\SearchService;
-use Pagerfanta\Adapter\AdapterInterface;
 
 /**
  * Pagerfanta adapter for eZ Publish content search.
  * Will return results as SearchHit objects.
  */
-class ContentSearchHitAdapter implements AdapterInterface
+class ContentSearchHitAdapter extends AbstractSearchResultAdapter
 {
-    /** @var \eZ\Publish\API\Repository\Values\Content\Query */
-    private $query;
-
-    /** @var \eZ\Publish\API\Repository\SearchService */
-    private $searchService;
-
-    /** @var array */
-    private $languageFilter;
-
-    /** @var int */
-    private $nbResults;
-
-    public function __construct(
-        Query $query,
+    protected function executeQuery(
         SearchService $searchService,
-        array $languageFilter = []
-    ) {
-        $this->query = $query;
-        $this->searchService = $searchService;
-        $this->languageFilter = $languageFilter;
-    }
-
-    /**
-     * Returns the number of results.
-     *
-     * @return int The number of results.
-     */
-    public function getNbResults()
-    {
-        if (isset($this->nbResults)) {
-            return $this->nbResults;
-        }
-
-        $countQuery = clone $this->query;
-        $countQuery->limit = 0;
-
-        $searchResult = $this->searchService->findContent(
-            $countQuery,
-            $this->languageFilter
-        );
-
-        return $this->nbResults = $searchResult->totalCount;
-    }
-
-    /**
-     * Returns a slice of the results, as SearchHit objects.
-     *
-     * @param int $offset The offset.
-     * @param int $length The length.
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchHit[]
-     */
-    public function getSlice($offset, $length)
-    {
-        $query = clone $this->query;
-        $query->offset = $offset;
-        $query->limit = $length;
-        $query->performCount = false;
-
-        $searchResult = $this->searchService->findContent($query, $this->languageFilter);
-
-        // Set count for further use if returned by search engine despite !performCount (Solr, ES)
-        if (!isset($this->nbResults) && isset($searchResult->totalCount)) {
-            $this->nbResults = $searchResult->totalCount;
-        }
-
-        return $searchResult->searchHits;
+        Query $query,
+        array $languageFilter
+    ): SearchResult {
+        return $searchService->findContent($query, $languageFilter);
     }
 }

--- a/eZ/Publish/Core/Pagination/Pagerfanta/FixedSearchResultHitAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/FixedSearchResultHitAdapter.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResultCollection;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+
+final class FixedSearchResultHitAdapter implements SearchResultAdapter
+{
+    /** @var \eZ\Publish\API\Repository\Values\Content\Search\SearchResult */
+    private $searchResult;
+
+    public function __construct(SearchResult $searchResult)
+    {
+        $this->searchResult = $searchResult;
+    }
+
+    public function getNbResults(): int
+    {
+        return $this->searchResult->totalCount ?? -1;
+    }
+
+    public function getSlice($offset, $length)
+    {
+        return $this->searchResult->searchHits;
+    }
+
+    public function getAggregations(): AggregationResultCollection
+    {
+        return $this->searchResult->aggregations;
+    }
+
+    public function getTime(): ?float
+    {
+        return $this->searchResult->time;
+    }
+
+    public function getTimedOut(): ?bool
+    {
+        return $this->searchResult->timedOut;
+    }
+
+    public function getMaxScore(): ?float
+    {
+        return $this->searchResult->maxScore;
+    }
+}

--- a/eZ/Publish/Core/Pagination/Pagerfanta/LocationSearchHitAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/LocationSearchHitAdapter.php
@@ -8,72 +8,25 @@ namespace eZ\Publish\Core\Pagination\Pagerfanta;
 
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
 use eZ\Publish\API\Repository\SearchService;
-use Pagerfanta\Adapter\AdapterInterface;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 
 /**
  * Pagerfanta adapter for eZ Publish location search.
  * Will return results as SearchHit objects.
  */
-class LocationSearchHitAdapter implements AdapterInterface
+class LocationSearchHitAdapter extends AbstractSearchResultAdapter
 {
-    /** @var \eZ\Publish\API\Repository\Values\Content\LocationQuery */
-    private $query;
-
-    /** @var \eZ\Publish\API\Repository\SearchService */
-    private $searchService;
-
-    /** @var array */
-    private $languageFilter;
-
-    /** @var int */
-    private $nbResults;
-
     public function __construct(LocationQuery $query, SearchService $searchService, array $languageFilter = [])
     {
-        $this->query = $query;
-        $this->searchService = $searchService;
-        $this->languageFilter = $languageFilter;
+        parent::__construct($query, $searchService, $languageFilter);
     }
 
     /**
-     * Returns the number of results.
-     *
-     * @return int The number of results.
+     * @param \eZ\Publish\API\Repository\Values\Content\LocationQuery $query
      */
-    public function getNbResults()
+    protected function executeQuery(SearchService $searchService, Query $query, array $languageFilter): SearchResult
     {
-        if (isset($this->nbResults)) {
-            return $this->nbResults;
-        }
-
-        $countQuery = clone $this->query;
-        $countQuery->limit = 0;
-
-        return $this->nbResults = $this->searchService->findLocations($countQuery)->totalCount;
-    }
-
-    /**
-     * Returns a slice of the results, as SearchHit objects.
-     *
-     * @param int $offset The offset.
-     * @param int $length The length.
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Search\SearchHit[]
-     */
-    public function getSlice($offset, $length)
-    {
-        $query = clone $this->query;
-        $query->offset = $offset;
-        $query->limit = $length;
-        $query->performCount = false;
-
-        $searchResult = $this->searchService->findLocations($query, $this->languageFilter);
-
-        // Set count for further use if returned by search engine despite !performCount (Solr, ES)
-        if (!isset($this->nbResults) && isset($searchResult->totalCount)) {
-            $this->nbResults = $searchResult->totalCount;
-        }
-
-        return $searchResult->searchHits;
+        return $searchService->findLocations($query, $languageFilter);
     }
 }

--- a/eZ/Publish/Core/Pagination/Pagerfanta/Pagerfanta.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/Pagerfanta.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResultCollection;
+use Pagerfanta\Pagerfanta as BasePagerfanta;
+
+final class Pagerfanta extends BasePagerfanta
+{
+    public function __construct(SearchResultAdapter $adapter)
+    {
+        parent::__construct($adapter);
+    }
+
+    public function getAggregations(): AggregationResultCollection
+    {
+        return $this->getAdapter()->getAggregations();
+    }
+
+    public function getTime(): ?float
+    {
+        return $this->getAdapter()->getTime();
+    }
+
+    public function getTimedOut(): ?bool
+    {
+        return $this->getAdapter()->getTimedOut();
+    }
+
+    public function getMaxScore(): ?float
+    {
+        return $this->getAdapter()->getMaxScore();
+    }
+}

--- a/eZ/Publish/Core/Pagination/Pagerfanta/SearchResultAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/SearchResultAdapter.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Pagination\Pagerfanta;
+
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResultCollection;
+use Pagerfanta\Adapter\AdapterInterface;
+
+/**
+ * Contract for \eZ\Publish\API\Repository\SearchService based adapters.
+ */
+interface SearchResultAdapter extends AdapterInterface
+{
+    /**
+     * Get results of aggregations associated with search query.
+     *
+     * Generates addition query if called before AdapterInterface::getSlice or AdapterInterface::getNbResults.
+     */
+    public function getAggregations(): AggregationResultCollection;
+
+    /**
+     * Get the duration of the search processing for current results slice (in s).
+     *
+     * Returns null if called before AdapterInterface::getSlice.
+     */
+    public function getTime(): ?float;
+
+    /**
+     * Indicates if the search has timed out for current results slice.
+     *
+     * Returns null if called before AdapterInterface::getSlice.
+     */
+    public function getTimedOut(): ?bool;
+
+    /**
+     * Return the maximum score or `null` if query wasn't executed.
+     *
+     * Returns null if called before AdapterInterface::getSlice.
+     */
+    public function getMaxScore(): ?float;
+}

--- a/eZ/Publish/Core/Pagination/Tests/AdapterFactory/SearchHitAdapterFactoryTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/AdapterFactory/SearchHitAdapterFactoryTest.php
@@ -15,8 +15,8 @@ use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\Pagination\Pagerfanta\AdapterFactory\SearchHitAdapterFactory;
 use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchHitAdapter;
+use eZ\Publish\Core\Pagination\Pagerfanta\FixedSearchResultHitAdapter;
 use eZ\Publish\Core\Pagination\Pagerfanta\LocationSearchHitAdapter;
-use Pagerfanta\Adapter\FixedAdapter;
 use PHPUnit\Framework\TestCase;
 
 final class SearchHitAdapterFactoryTest extends TestCase
@@ -76,19 +76,19 @@ final class SearchHitAdapterFactoryTest extends TestCase
             new SearchHit(),
         ];
 
+        $searchResult = new SearchResult([
+            'searchHits' => $hits,
+            'totalCount' => count($hits),
+        ]);
+
         $this->searchService
             ->expects($this->once())
             ->method($expectedSearchMethod)
             ->with($query, self::EXAMPLE_LANGUAGE_FILTER)
-            ->willReturn(
-                new SearchResult([
-                    'searchHits' => $hits,
-                    'totalCount' => count($hits),
-                ])
-            );
+            ->willReturn($searchResult);
 
         $this->assertEquals(
-            new FixedAdapter(count($hits), $hits),
+            new FixedSearchResultHitAdapter($searchResult),
             $this->searchHitAdapterFactory->createFixedAdapter($query, self::EXAMPLE_LANGUAGE_FILTER)
         );
     }

--- a/eZ/Publish/Core/Pagination/Tests/ContentSearchHitAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/ContentSearchHitAdapterTest.php
@@ -9,8 +9,10 @@ namespace eZ\Publish\Core\Pagination\Tests;
 use eZ\Publish\API\Repository\Values\Content\Content as APIContent;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResultCollection;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchHitAdapter;
@@ -18,6 +20,16 @@ use PHPUnit\Framework\TestCase;
 
 class ContentSearchHitAdapterTest extends TestCase
 {
+    private const EXAMPLE_LIMIT = 40;
+    private const EXAMPLE_OFFSET = 10;
+    private const EXAMPLE_LANGUAGE_FILTER = [
+        'languages' => ['eng-GB', 'pol-PL'],
+        'useAlwaysAvailable' => true,
+    ];
+
+    private const EXAMPLE_RESULT_MAX_SCORE = 5.123;
+    private const EXAMPLE_RESULT_TIME = 30.0;
+
     /** @var \eZ\Publish\API\Repository\SearchService|\PHPUnit\Framework\MockObject\MockObject */
     protected $searchService;
 
@@ -45,33 +57,22 @@ class ContentSearchHitAdapterTest extends TestCase
     {
         $nbResults = 123;
 
-        $languageFilter = [
-            'languages' => ['eng-GB', 'pol-PL'],
-            'useAlwaysAvailable' => true,
-        ];
+        $query = $this->createTestQuery();
 
-        $query = new Query();
-        $query->query = $this->createMock(CriterionInterface::class);
-        $query->sortClauses = $this
-            ->getMockBuilder(SortClause::class)
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
-
-        // Count query will necessarily have a 0 limit.
+        // Count query will necessarily have a 0 limit and empty aggregations/facet builders.
         $countQuery = clone $query;
         $countQuery->limit = 0;
+        $countQuery->aggregations = [];
 
         $searchResult = new SearchResult(['totalCount' => $nbResults]);
         $this->searchService
             ->expects($this->once())
             ->method('findContent')
-            ->with(
-                $this->equalTo($countQuery),
-                $this->equalTo($languageFilter)
-            )
-            ->will($this->returnValue($searchResult));
+            ->with($countQuery, self::EXAMPLE_LANGUAGE_FILTER)
+            ->willReturn($searchResult);
 
-        $adapter = $this->getAdapter($query, $this->searchService, $languageFilter);
+        $adapter = $this->getAdapter($query, $this->searchService, self::EXAMPLE_LANGUAGE_FILTER);
+
         $this->assertSame($nbResults, $adapter->getNbResults());
         // Running a 2nd time to ensure SearchService::findContent() is called only once.
         $this->assertSame($nbResults, $adapter->getNbResults());
@@ -79,49 +80,84 @@ class ContentSearchHitAdapterTest extends TestCase
 
     public function testGetSlice()
     {
-        $offset = 20;
-        $limit = 25;
         $nbResults = 123;
+        $aggregationsResults = new AggregationResultCollection();
 
-        $languageFilter = [
-            'languages' => ['eng-GB', 'pol-PL'],
-            'useAlwaysAvailable' => true,
-        ];
-
-        $query = new Query();
-        $query->query = $this->createMock(CriterionInterface::class);
-        $query->sortClauses = $this
-            ->getMockBuilder(SortClause::class)
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+        $query = $this->createTestQuery(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT);
 
         // Injected query is being cloned to modify offset/limit,
         // so we need to do the same here for our assertions.
         $searchQuery = clone $query;
-        $searchQuery->offset = $offset;
-        $searchQuery->limit = $limit;
+        $searchQuery->offset = self::EXAMPLE_OFFSET;
+        $searchQuery->limit = self::EXAMPLE_LIMIT;
         $searchQuery->performCount = false;
 
         $hits = [];
-        for ($i = 0; $i < $limit; ++$i) {
-            $content = $this->getMockForAbstractClass(APIContent::class);
-            $hits[] = new SearchHit(['valueObject' => $content]);
+        for ($i = 0; $i < self::EXAMPLE_LIMIT; ++$i) {
+            $hits[] = new SearchHit([
+                'valueObject' => $this->createMock(APIContent::class),
+            ]);
         }
-        $finalResult = $this->getExpectedFinalResultFromHits($hits);
-        $searchResult = new SearchResult(['searchHits' => $hits, 'totalCount' => $nbResults]);
+
+        $searchResult = new SearchResult([
+            'searchHits' => $hits,
+            'totalCount' => $nbResults,
+            'aggregations' => $aggregationsResults,
+            'maxScore' => self::EXAMPLE_RESULT_MAX_SCORE,
+            'timedOut' => true,
+            'time' => self::EXAMPLE_RESULT_TIME,
+        ]);
+
         $this
             ->searchService
             ->expects($this->once())
             ->method('findContent')
-            ->with(
-                $this->equalTo($searchQuery),
-                $this->equalTo($languageFilter)
-            )
-            ->will($this->returnValue($searchResult));
+            ->with($searchQuery, self::EXAMPLE_LANGUAGE_FILTER)
+            ->willReturn($searchResult);
 
-        $adapter = $this->getAdapter($query, $this->searchService, $languageFilter);
-        $this->assertSame($finalResult, $adapter->getSlice($offset, $limit));
+        $adapter = $this->getAdapter($query, $this->searchService, self::EXAMPLE_LANGUAGE_FILTER);
+
+        $this->assertSame(
+            $this->getExpectedFinalResultFromHits($hits),
+            $adapter->getSlice(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT)
+        );
         $this->assertSame($nbResults, $adapter->getNbResults());
+        $this->assertSame($aggregationsResults, $adapter->getAggregations());
+        $this->assertSame(self::EXAMPLE_RESULT_MAX_SCORE, $adapter->getMaxScore());
+        $this->assertTrue($adapter->getTimedOut());
+        $this->assertSame(self::EXAMPLE_RESULT_TIME, $adapter->getTime());
+    }
+
+    public function testGetAggregations(): void
+    {
+        $exceptedAggregationsResults = new AggregationResultCollection();
+
+        $query = $this->createTestQuery(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT);
+
+        // Injected query is being cloned to modify offset/limit,
+        // so we need to do the same here for our assertions.
+        $aggregationQuery = clone $query;
+        $aggregationQuery->offset = 0;
+        $aggregationQuery->limit = 0;
+
+        $searchResult = new SearchResult([
+            'searchHits' => [],
+            'totalCount' => 0,
+            'aggregations' => $exceptedAggregationsResults,
+        ]);
+
+        $this
+            ->searchService
+            ->expects($this->once())
+            ->method('findContent')
+            ->with($aggregationQuery, self::EXAMPLE_LANGUAGE_FILTER)
+            ->willReturn($searchResult);
+
+        $adapter = $this->getAdapter($query, $this->searchService, self::EXAMPLE_LANGUAGE_FILTER);
+
+        $this->assertSame($exceptedAggregationsResults, $adapter->getAggregations());
+        // Running a 2nd time to ensure SearchService::findContent() is called only once.
+        $this->assertSame($exceptedAggregationsResults, $adapter->getAggregations());
     }
 
     /**
@@ -134,5 +170,17 @@ class ContentSearchHitAdapterTest extends TestCase
     protected function getExpectedFinalResultFromHits($hits)
     {
         return $hits;
+    }
+
+    private function createTestQuery(int $limit = 25, int $offset = 0): Query
+    {
+        $query = new Query();
+        $query->query = $this->createMock(CriterionInterface::class);
+        $query->aggregations[] = $this->createMock(Aggregation::class);
+        $query->sortClauses[] = $this->createMock(SortClause::class);
+        $query->offset = $offset;
+        $query->limit = $limit;
+
+        return $query;
     }
 }

--- a/eZ/Publish/Core/Pagination/Tests/FixedSearchResultHitAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/FixedSearchResultHitAdapterTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Pagination\Tests;
+
+use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use eZ\Publish\Core\Pagination\Pagerfanta\FixedSearchResultHitAdapter;
+use PHPUnit\Framework\TestCase;
+
+final class FixedSearchResultHitAdapterTest extends TestCase
+{
+    public function testFixedSearchResultHitAdapter(): void
+    {
+        $searchResult = $this->createExampleSearchResult();
+
+        $adapter = new FixedSearchResultHitAdapter($searchResult);
+
+        $this->assertEquals($searchResult->totalCount, $adapter->getNbResults());
+        $this->assertEquals($searchResult->searchHits, $adapter->getSlice(0, 10));
+        $this->assertEquals($searchResult->aggregations, $adapter->getAggregations());
+        $this->assertEquals($searchResult->maxScore, $adapter->getMaxScore());
+        $this->assertEquals($searchResult->time, $adapter->getTime());
+        $this->assertEquals($searchResult->timedOut, $adapter->getTimedOut());
+    }
+
+    private function createExampleSearchResult(): SearchResult
+    {
+        $searchResult = new SearchResult();
+        $searchResult->totalCount = 3;
+        $searchResult->searchHits = [
+            new SearchHit(),
+            new SearchHit(),
+            new SearchHit(),
+        ];
+        $searchResult->timedOut = true;
+        $searchResult->time = 30;
+        $searchResult->maxScore = 5.234;
+
+        return $searchResult;
+    }
+}

--- a/eZ/Publish/Core/Pagination/Tests/LocationSearchAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/LocationSearchAdapterTest.php
@@ -18,9 +18,9 @@ class LocationSearchAdapterTest extends LocationSearchHitAdapterTest
      *
      * @return LocationSearchAdapter
      */
-    protected function getAdapter(LocationQuery $query, SearchService $searchService)
+    protected function getAdapter(LocationQuery $query, SearchService $searchService, array $languageFilter = [])
     {
-        return new LocationSearchAdapter($query, $searchService);
+        return new LocationSearchAdapter($query, $searchService, $languageFilter);
     }
 
     /**

--- a/eZ/Publish/Core/Pagination/Tests/LocationSearchHitAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/LocationSearchHitAdapterTest.php
@@ -9,8 +9,11 @@ namespace eZ\Publish\Core\Pagination\Tests;
 use eZ\Publish\API\Repository\Values\Content\Location as APILocation;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Aggregation;
 use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use eZ\Publish\API\Repository\Values\Content\Query\SortClause;
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResultCollection;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchHit;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use eZ\Publish\Core\Pagination\Pagerfanta\LocationSearchHitAdapter;
@@ -18,6 +21,16 @@ use PHPUnit\Framework\TestCase;
 
 class LocationSearchHitAdapterTest extends TestCase
 {
+    private const EXAMPLE_LIMIT = 40;
+    private const EXAMPLE_OFFSET = 10;
+    private const EXAMPLE_LANGUAGE_FILTER = [
+        'languages' => ['eng-GB', 'pol-PL'],
+        'useAlwaysAvailable' => true,
+    ];
+
+    private const EXAMPLE_RESULT_MAX_SCORE = 5.123;
+    private const EXAMPLE_RESULT_TIME = 30.0;
+
     /** @var \eZ\Publish\API\Repository\SearchService|\PHPUnit\Framework\MockObject\MockObject */
     protected $searchService;
 
@@ -32,36 +45,37 @@ class LocationSearchHitAdapterTest extends TestCase
      *
      * @param LocationQuery $query
      * @param SearchService $searchService
+     * @param array $languageFilter
      *
      * @return LocationSearchHitAdapter
      */
-    protected function getAdapter(LocationQuery $query, SearchService $searchService)
+    protected function getAdapter(LocationQuery $query, SearchService $searchService, array $languageFilter = [])
     {
-        return new LocationSearchHitAdapter($query, $searchService);
+        return new LocationSearchHitAdapter($query, $searchService, $languageFilter);
     }
 
     public function testGetNbResults()
     {
         $nbResults = 123;
-        $query = new LocationQuery();
-        $query->filter = $this->createMock(CriterionInterface::class);
-        $query->sortClauses = $this
-            ->getMockBuilder(SortClause::class)
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+        $query = $this->createTestQuery();
 
         // Count query will necessarily have a 0 limit.
         $countQuery = clone $query;
+        $countQuery->aggregations = [];
         $countQuery->limit = 0;
 
-        $searchResult = new SearchResult(['totalCount' => $nbResults]);
+        $searchResult = new SearchResult([
+            'totalCount' => $nbResults,
+        ]);
+
         $this->searchService
             ->expects($this->once())
             ->method('findLocations')
-            ->with($this->equalTo($countQuery))
-            ->will($this->returnValue($searchResult));
+            ->with($countQuery, self::EXAMPLE_LANGUAGE_FILTER)
+            ->willReturn($searchResult);
 
-        $adapter = $this->getAdapter($query, $this->searchService);
+        $adapter = $this->getAdapter($query, $this->searchService, self::EXAMPLE_LANGUAGE_FILTER);
+
         $this->assertSame($nbResults, $adapter->getNbResults());
         // Running a 2nd time to ensure SearchService::findContent() is called only once.
         $this->assertSame($nbResults, $adapter->getNbResults());
@@ -69,41 +83,85 @@ class LocationSearchHitAdapterTest extends TestCase
 
     public function testGetSlice()
     {
-        $offset = 20;
-        $limit = 25;
         $nbResults = 123;
+        $aggregationsResults = new AggregationResultCollection();
 
-        $query = new LocationQuery();
-        $query->filter = $this->createMock(CriterionInterface::class);
-        $query->sortClauses = $this
-            ->getMockBuilder(SortClause::class)
-            ->disableOriginalConstructor()
-            ->getMockForAbstractClass();
+        $query = $this->createTestQuery();
 
         // Injected query is being cloned to modify offset/limit,
         // so we need to do the same here for our assertions.
         $searchQuery = clone $query;
-        $searchQuery->offset = $offset;
-        $searchQuery->limit = $limit;
+        $searchQuery->offset = self::EXAMPLE_OFFSET;
+        $searchQuery->limit = self::EXAMPLE_LIMIT;
         $searchQuery->performCount = false;
 
         $hits = [];
-        for ($i = 0; $i < $limit; ++$i) {
-            $location = $this->getMockForAbstractClass(APILocation::class);
-            $hits[] = new SearchHit(['valueObject' => $location]);
+        for ($i = 0; $i < self::EXAMPLE_LIMIT; ++$i) {
+            $hits[] = new SearchHit([
+                'valueObject' => $this->createMock(APILocation::class),
+            ]);
         }
-        $finalResult = $this->getExpectedFinalResultFromHits($hits);
-        $searchResult = new SearchResult(['searchHits' => $hits, 'totalCount' => $nbResults]);
+
+        $searchResult = new SearchResult([
+            'searchHits' => $hits,
+            'totalCount' => $nbResults,
+            'aggregations' => $aggregationsResults,
+            'maxScore' => self::EXAMPLE_RESULT_MAX_SCORE,
+            'timedOut' => true,
+            'time' => self::EXAMPLE_RESULT_TIME,
+        ]);
+
         $this
             ->searchService
             ->expects($this->once())
             ->method('findLocations')
-            ->with($this->equalTo($searchQuery))
-            ->will($this->returnValue($searchResult));
+            ->with($searchQuery, self::EXAMPLE_LANGUAGE_FILTER)
+            ->willReturn($searchResult);
 
-        $adapter = $this->getAdapter($query, $this->searchService);
-        $this->assertSame($finalResult, $adapter->getSlice($offset, $limit));
+        $adapter = $this->getAdapter($query, $this->searchService, self::EXAMPLE_LANGUAGE_FILTER);
+
+        $this->assertSame(
+            $this->getExpectedFinalResultFromHits($hits),
+            $adapter->getSlice(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT)
+        );
+
         $this->assertSame($nbResults, $adapter->getNbResults());
+        $this->assertSame($aggregationsResults, $adapter->getAggregations());
+        $this->assertSame(self::EXAMPLE_RESULT_MAX_SCORE, $adapter->getMaxScore());
+        $this->assertTrue($adapter->getTimedOut());
+        $this->assertSame(self::EXAMPLE_RESULT_TIME, $adapter->getTime());
+    }
+
+    public function testGetAggregations(): void
+    {
+        $exceptedAggregationsResults = new AggregationResultCollection();
+
+        $query = $this->createTestQuery(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT);
+
+        // Injected query is being cloned to modify offset/limit,
+        // so we need to do the same here for our assertions.
+        $aggregationQuery = clone $query;
+        $aggregationQuery->offset = 0;
+        $aggregationQuery->limit = 0;
+
+        $searchResult = new SearchResult([
+            'searchHits' => [],
+            'totalCount' => 0,
+            'aggregations' => $exceptedAggregationsResults,
+        ]);
+
+        $this
+            ->searchService
+            ->expects($this->once())
+            ->method('findLocations')
+            ->with($aggregationQuery, self::EXAMPLE_LANGUAGE_FILTER)
+            ->willReturn($searchResult);
+
+        $adapter = $this->getAdapter($query, $this->searchService, self::EXAMPLE_LANGUAGE_FILTER);
+
+        $this->assertSame($exceptedAggregationsResults, $adapter->getAggregations());
+        // Running a 2nd time to ensure SearchService::findContent() is called only once.
+        $this->assertSame($exceptedAggregationsResults, $adapter->getAggregations());
     }
 
     /**
@@ -116,5 +174,17 @@ class LocationSearchHitAdapterTest extends TestCase
     protected function getExpectedFinalResultFromHits($hits)
     {
         return $hits;
+    }
+
+    private function createTestQuery(int $limit = 25, int $offset = 0): LocationQuery
+    {
+        $query = new LocationQuery();
+        $query->query = $this->createMock(CriterionInterface::class);
+        $query->aggregations[] = $this->createMock(Aggregation::class);
+        $query->sortClauses[] = $this->createMock(SortClause::class);
+        $query->offset = $offset;
+        $query->limit = $limit;
+
+        return $query;
     }
 }

--- a/eZ/Publish/Core/Pagination/Tests/PagerfantaTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/PagerfantaTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Pagination\Tests;
+
+use eZ\Publish\API\Repository\Values\Content\Search\AggregationResultCollection;
+use eZ\Publish\Core\Pagination\Pagerfanta\Pagerfanta;
+use eZ\Publish\Core\Pagination\Pagerfanta\SearchResultAdapter;
+use PHPUnit\Framework\TestCase;
+
+final class PagerfantaTest extends TestCase
+{
+    private const EXAMPLE_TIME_RESULT = 30.0;
+    private const EXAMPLE_MAX_SCORE_RESULT = 5.12354;
+
+    /** @var \eZ\Publish\Core\Pagination\Pagerfanta\SearchResultAdapter|\PHPUnit\Framework\MockObject\MockObject */
+    private $adapter;
+
+    /** @var \eZ\Publish\Core\Pagination\Pagerfanta\Pagerfanta */
+    private $pagerfanta;
+
+    protected function setUp(): void
+    {
+        $this->adapter = $this->createMock(SearchResultAdapter::class);
+        $this->pagerfanta = new Pagerfanta($this->adapter);
+    }
+
+    public function testGetAggregations(): void
+    {
+        $aggregations = new AggregationResultCollection();
+
+        $this->adapter->method('getAggregations')->willReturn($aggregations);
+
+        $this->assertEquals(
+            $aggregations,
+            $this->pagerfanta->getAggregations()
+        );
+    }
+
+    public function testGetTime(): void
+    {
+        $this->adapter->method('getTime')->willReturn(self::EXAMPLE_TIME_RESULT);
+
+        $this->assertEquals(
+            self::EXAMPLE_TIME_RESULT,
+            $this->pagerfanta->getTime()
+        );
+    }
+
+    public function testGetTimedOut(): void
+    {
+        $this->adapter->method('getTimedOut')->willReturn(true);
+
+        $this->assertTrue(
+            $this->pagerfanta->getTimedOut()
+        );
+    }
+
+    public function testGetMaxScore(): void
+    {
+        $this->adapter->method('getMaxScore')->willReturn(self::EXAMPLE_MAX_SCORE_RESULT);
+
+        $this->assertEquals(
+            self::EXAMPLE_MAX_SCORE_RESULT,
+            $this->pagerfanta->getMaxScore()
+        );
+    }
+}


### PR DESCRIPTION
| Question | Answer |
| --- | --- |
| **JIRA issue** | EZP-32110 |
| **Type** | feature |
| **Target eZ Platform version** | `v3.3` |
| **BC breaks** | no |
| **Doc needed** | yes |

Introduced `\eZ\Publish\Core\Pagination\Pagerfanta\SearchResultAdapter`

```php
/**
 * Contract for \eZ\Publish\API\Repository\SearchService based adapters.
 */
interface SearchResultAdapter extends AdapterInterface
{
    /**
     * Get results of aggregations associated with search query.
     *
     * Generates addition query if called before AdapterInterface::getSlice or AdapterInterface::getNbResults.
     */
    public function getAggregations(): AggregationResultCollection;

    /**
     * Get the duration of the search processing for current results slice (in s).
     *
     * Returns null if called before AdapterInterface::getSlice.
     */
    public function getTime(): ?float;

    /**
     * Indicates if the search has timed out for current results slice.
     *
     * Returns null if called before AdapterInterface::getSlice.
     */
    public function getTimedOut(): ?bool;

    /**
     * Return the maximum score or `null` if query wasn't executed.
     *
     * Returns null if called before AdapterInterface::getSlice.
     */
    public function getMaxScore(): ?float;
```

in order to be able to access additional search result data

*   Aggregations results
*   Max. score
*   Computation time
*   Timeout flag

from Pagefanta. 

In practice this change allows to use additional search results data when rendering query using built-in query controller, `ez_render_content_query`/`ez_render_location_query` etc.

### Example

#### Query controller

_config/packages/ezplatform.yaml_

```yaml
ezplatform:
    site:
        content_view:
            full:
                folder:
                    controller: 'ez_query::pagingQueryAction'
                    template: full/folder.html.twig
                    match:
                        Identifier\ContentType: folder
                    params:
                        query:
                            query_type: Children
                            parameters:
                                location: '@=location'
                            assign_results_to: items
```

_templates/full/folder.html.twig_

```twig
{# Access SearchResult::$aggregations #}
{{ dump(items.aggregations) }}
{# Access  SearchResult::{$time,timedOut,maxScore}. Requires first to fetch result set #}
{{ dump(items.maxScore) }}
{{ dump(items.timedOut) }}
{{ dump(items.time) }}
```

#### Custom controller

```php
<?php 

namespace App\Controller;

use eZ\Publish\API\Repository\SearchService;
use eZ\Publish\API\Repository\Values\Content\Query;
use eZ\Publish\Core\Pagination\Pagerfanta\ContentSearchAdapter;
use eZ\Publish\Core\Pagination\Pagerfanta\Pagerfanta;
use Symfony\Component\HttpFoundation\Response;

final class CustomController
{
    /** @var \eZ\Publish\API\Repository\SearchService */
    private $searchService;

    public function __construct(SearchService $searchService)
    {
        $this->searchService = $searchService;
    }

    public function searchAction(): Response
    {
        $query = new Query();
        // ... build query as usually

        // $items is instance of \eZ\Publish\Core\Pagination\Pagerfanta\Pagerfanta
        // instead of Pagerfanta\Pagerfanta
        $items = new Pagerfanta(new ContentSearchAdapter($query, $this->searchService));

        foreach ($items as $item) {
            // Iterate over results
        }

        // Access SearchResult::{$aggregations,maxScore,time,timedOUt}
        $items->getAggregations();
        $items->getMaxScore();
        $items->getTime();
        $items->getTimedOut();

        // ...
    }
}
```

### Notes

*   It's also possible to access additional search result data from regular `Pagerfanta\Pagerfanta` object by using `$pagerfanta->getAdapter()->get{Aggregations,MaxScore,Time,TimedOut}`
*   Facets results are not exposed as they were deprecated in v3.2

#### Checklist:

*   [x] Provided PR description.
*   [x] Tested the solution manually.
*   [x] Provided automated test coverage.
*   [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
*   [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
*   [x] Asked for a review (ping `@ezsystems/php-dev-team`).