### PR TITLE
EZP-32219: Fix ContentType sorting defaults has no effect on new created objects

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -320,6 +320,32 @@ class ContentServiceTest extends BaseContentServiceTest
     }
 
     /**
+     * Test for the createContent() method with utilizing ContentType default options.
+     *
+     * @covers \eZ\Publish\API\Repository\ContentService::createContent
+     */
+    public function testCreateContentWithContentTypeDefaultOptions(): void
+    {
+        $contentType = $this->getRepository()->getContentTypeService()
+            ->loadContentTypeByIdentifier(self::FORUM_IDENTIFIER);
+
+        $contentCreate = $this->contentService->newContentCreateStruct($contentType, self::ENG_GB);
+        $contentCreate->setField('name', 'Sorting Test');
+
+        $content = $this->contentService->createContent(
+            $contentCreate,
+            [$this->locationService->newLocationCreateStruct(2)]
+        );
+        $publishedContent = $this->contentService->publishVersion($content->getVersionInfo());
+
+        $location = $publishedContent->contentInfo->getMainLocation();
+
+        $this->assertEquals($contentType->defaultSortField, $location->sortField);
+        $this->assertEquals($contentType->defaultSortOrder, $location->sortOrder);
+        $this->assertEquals($contentType->defaultAlwaysAvailable, $publishedContent->contentInfo->alwaysAvailable);
+    }
+
+    /**
      * Test for the createContent() method.
      *
      * @see \eZ\Publish\API\Repository\ContentService::createContent()

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -637,7 +637,10 @@ class ContentService implements ContentServiceInterface
             throw new ContentFieldValidationException($errors);
         }
 
-        $spiLocationCreateStructs = $this->buildSPILocationCreateStructs($locationCreateStructs);
+        $spiLocationCreateStructs = $spiLocationCreateStructs = $this->buildSPILocationCreateStructs(
+            $locationCreateStructs,
+            $contentCreateStruct->contentType
+        );
 
         $languageCodes = $this->contentMapper->getLanguageCodesForCreate($contentCreateStruct);
         $fields = $this->contentMapper->mapFieldsForCreate($contentCreateStruct);
@@ -775,11 +778,14 @@ class ContentService implements ContentServiceInterface
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      *
      * @param \eZ\Publish\API\Repository\Values\Content\LocationCreateStruct[] $locationCreateStructs
+     * @param \eZ\Publish\API\Repository\Values\ContentType\ContentType|null $contentType
      *
      * @return \eZ\Publish\SPI\Persistence\Content\Location\CreateStruct[]
      */
-    protected function buildSPILocationCreateStructs(array $locationCreateStructs): array
-    {
+    protected function buildSPILocationCreateStructs(
+        array $locationCreateStructs,
+        ?ContentType $contentType = null
+    ): array {
         $spiLocationCreateStructs = [];
         $parentLocationIdSet = [];
         $mainLocation = true;
@@ -792,12 +798,11 @@ class ContentService implements ContentServiceInterface
                 );
             }
 
-            if (!array_key_exists($locationCreateStruct->sortField, Location::SORT_FIELD_MAP)) {
-                $locationCreateStruct->sortField = Location::SORT_FIELD_NAME;
+            if ($locationCreateStruct->sortField === null) {
+                $locationCreateStruct->sortField = $contentType->defaultSortField ?? Location::SORT_FIELD_NAME;
             }
-
-            if (!array_key_exists($locationCreateStruct->sortOrder, Location::SORT_ORDER_MAP)) {
-                $locationCreateStruct->sortOrder = Location::SORT_ORDER_ASC;
+            if ($locationCreateStruct->sortOrder === null) {
+                $locationCreateStruct->sortOrder = $contentType->defaultSortOrder ?? Location::SORT_ORDER_ASC;
             }
 
             $parentLocationIdSet[$locationCreateStruct->parentLocationId] = true;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32219
| **Type**                                   | bug
| **Target eZ Platform version** | v3.2
| **BC breaks**                          | no
| **Doc needed**                       | yes

**Steps to reproduce:**
1. Create new ContentType i.e. "News".
2. Add a single Textline field i.e. "Title".
3. Set "Sort children by default by" to "Location priority"
4. Set "Sort children by default in order" to "Descending".
5. Create new News content anywhere.
6. Observe Sub-items sorting order in the Details tab for this content.

**Expected result:**
Sub-items sorting for new content should have the same value as one that has been set in ContentType.

**Actual result:**
Sub-items sorting for new content is not the same as one that has been set in this ContentType.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
