### PR TITLE
EZP-32214: Made purge type configuration using env vars resolvable at compile time

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -376,9 +376,11 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
     {
         $loader->load('cache.yml');
 
-        $purgeService = null;
         if (isset($config['http_cache']['purge_type'])) {
-            $container->setParameter('ezpublish.http_cache.purge_type', $config['http_cache']['purge_type']);
+            // resolves ENV variable at compile time, needed by ezplatform-http-cache to setup purge driver
+            $purgeType = $container->resolveEnvPlaceholders($config['http_cache']['purge_type'], true);
+
+            $container->setParameter('ezpublish.http_cache.purge_type', $purgeType);
         }
     }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -66,6 +66,8 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
                 'empty_group' => ['var_dir' => 'foo'],
             ],
         ];
+
+        $_ENV['HTTPCACHE_PURGE_TYPE'] = $_SERVER['HTTPCACHE_PURGE_TYPE'] = 'http';
     }
 
     protected function getContainerExtensions(): array
@@ -249,6 +251,12 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
             [
                 [
                     'http_cache' => ['purge_type' => 'http'],
+                ],
+                'http',
+            ],
+            [
+                [
+                    'http_cache' => ['purge_type' => '%env(HTTPCACHE_PURGE_TYPE)%'],
                 ],
                 'http',
             ],


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32214
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.3` - please update `x` accordingly
| **BC breaks**                          | no
| **Doc needed**                       | no

Since we are using ENV variables to setup HTTP Cache purge driver, it's needed to resolve all envs at compile time. This is rather bad solution because ENVs are not designed to be used this way. In order to make it work we need to call `Container::resolveEnvPlaceholders` to get real values. Previously it was working because `config/packages/overrides/*.php` files were used and they resolved values themselves.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
