### PR TITLE
EZP-32250: Exposed PasswordHashService APIs

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -7,13 +7,13 @@
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;
 
 use eZ\Publish\API\Repository\LanguageResolver;
+use eZ\Publish\API\Repository\PasswordHashService;
 use eZ\Publish\API\Repository\PermissionService;
 use eZ\Publish\API\Repository\Repository;
 use eZ\Publish\Core\FieldType\FieldTypeRegistry;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\Repository\Permission\LimitationService;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
-use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use eZ\Publish\Core\Repository\Helper\RelationProcessor;
 use eZ\Publish\Core\Repository\Mapper;
 use eZ\Publish\Core\Repository\User\PasswordValidatorInterface;
@@ -78,7 +78,7 @@ class RepositoryFactory implements ContainerAwareInterface
         BackgroundIndexer $backgroundIndexer,
         RelationProcessor $relationProcessor,
         FieldTypeRegistry $fieldTypeRegistry,
-        PasswordHashServiceInterface $passwordHashService,
+        PasswordHashService $passwordHashService,
         ThumbnailStrategy $thumbnailStrategy,
         ProxyDomainMapperFactoryInterface $proxyDomainMapperFactory,
         Mapper\ContentDomainMapper $contentDomainMapper,

--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/ValidatePasswordHashesCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/ValidatePasswordHashesCommand.php
@@ -6,8 +6,8 @@
  */
 namespace EzSystems\PlatformInstallerBundle\Command;
 
+use eZ\Publish\API\Repository\PasswordHashService;
 use eZ\Publish\Core\FieldType\User\UserStorage;
-use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -17,12 +17,12 @@ final class ValidatePasswordHashesCommand extends Command
     /** @var \eZ\Publish\Core\FieldType\User\UserStorage */
     private $userStorage;
 
-    /** @var \eZ\Publish\Core\Repository\User\PasswordHashServiceInterface */
+    /** @var \eZ\Publish\API\Repository\PasswordHashService */
     private $passwordHashService;
 
     public function __construct(
         UserStorage $userStorage,
-        PasswordHashServiceInterface $passwordHashService
+        PasswordHashService $passwordHashService
     ) {
         $this->userStorage = $userStorage;
         $this->passwordHashService = $passwordHashService;

--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/ValidatePasswordHashesCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/ValidatePasswordHashesCommand.php
@@ -7,6 +7,7 @@
 namespace EzSystems\PlatformInstallerBundle\Command;
 
 use eZ\Publish\Core\FieldType\User\UserStorage;
+use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -16,10 +17,16 @@ final class ValidatePasswordHashesCommand extends Command
     /** @var \eZ\Publish\Core\FieldType\User\UserStorage */
     private $userStorage;
 
+    /** @var \eZ\Publish\Core\Repository\User\PasswordHashServiceInterface */
+    private $passwordHashService;
+
     public function __construct(
-        UserStorage $userStorage
+        UserStorage $userStorage,
+        PasswordHashServiceInterface $passwordHashService
     ) {
         $this->userStorage = $userStorage;
+        $this->passwordHashService = $passwordHashService;
+
         parent::__construct();
     }
 
@@ -30,7 +37,9 @@ final class ValidatePasswordHashesCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        $unsupportedHashesCounter = $this->userStorage->countUsersWithUnsupportedHashType();
+        $unsupportedHashesCounter = $this->userStorage->countUsersWithUnsupportedHashType(
+            $this->passwordHashService->getSupportedHashTypes()
+        );
 
         if ($unsupportedHashesCounter > 0) {
             $output->writeln(sprintf('<error>Found %s users with unsupported password hash types</error>', $unsupportedHashesCounter));

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -29,6 +29,6 @@ services:
     EzSystems\PlatformInstallerBundle\Command\ValidatePasswordHashesCommand:
         arguments:
             $userStorage: '@ezpublish.fieldType.ezuser.externalStorage'
-            $passwordHashService: '@eZ\Publish\Core\Repository\User\PasswordHashServiceInterface'
+            $passwordHashService: '@eZ\Publish\API\Repository\PasswordHashService'
         tags:
             - { name: console.command, command: ezplatform:user:validate-password-hashes }

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -29,6 +29,6 @@ services:
     EzSystems\PlatformInstallerBundle\Command\ValidatePasswordHashesCommand:
         arguments:
             $userStorage: '@ezpublish.fieldType.ezuser.externalStorage'
-
+            $passwordHashService: '@eZ\Publish\Core\Repository\User\PasswordHashServiceInterface'
         tags:
             - { name: console.command, command: ezplatform:user:validate-password-hashes }

--- a/eZ/Publish/API/Repository/PasswordHashService.php
+++ b/eZ/Publish/API/Repository/PasswordHashService.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository;
+
+interface PasswordHashService
+{
+    /**
+     * Returns default password hash type.
+     *
+     * @return int
+     */
+    public function getDefaultHashType(): int;
+
+    /**
+     * Returns list of supported password hash types.
+     *
+     * @return int[]
+     */
+    public function getSupportedHashTypes(): array;
+
+    /**
+     * Shortcut method to check if given hash type is supported.
+     */
+    public function isHashTypeSupported(int $hashType): bool;
+
+    /**
+     * Create hash from given plain password.
+     *
+     * If non-provided, the default password hash type will be used.
+     */
+    public function createPasswordHash(string $plainPassword, ?int $hashType = null): string;
+
+    /**
+     * Validates given $plainPassword against $passwordHash.
+     *
+     * If non-provided, the default password hash type will be used.
+     */
+    public function isValidPassword(string $plainPassword, string $passwordHash, ?int $hashType = null): bool;
+}

--- a/eZ/Publish/API/Repository/Values/User/User.php
+++ b/eZ/Publish/API/Repository/Values/User/User.php
@@ -24,6 +24,9 @@ use eZ\Publish\API\Repository\Values\Content\Content;
  */
 abstract class User extends Content implements UserReference
 {
+    /**
+     * @var int[] List of supported (by default) hash types.
+     */
     public const SUPPORTED_PASSWORD_HASHES = [
         self::PASSWORD_HASH_BCRYPT,
         self::PASSWORD_HASH_PHP_DEFAULT,

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -8,10 +8,10 @@ namespace eZ\Publish\Core\Base\Container\ApiLoader;
 
 use eZ\Publish\API\Repository\LanguageResolver;
 use eZ\Publish\API\Repository\PermissionService;
+use eZ\Publish\API\Repository\PasswordHashService;
 use eZ\Publish\Core\FieldType\FieldTypeRegistry;
 use eZ\Publish\Core\Repository\Permission\LimitationService;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
-use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use eZ\Publish\Core\Repository\Helper\RelationProcessor;
 use eZ\Publish\Core\Repository\Mapper;
 use eZ\Publish\Core\Repository\User\PasswordValidatorInterface;
@@ -68,7 +68,7 @@ class RepositoryFactory implements ContainerAwareInterface
         BackgroundIndexer $backgroundIndexer,
         RelationProcessor $relationProcessor,
         FieldTypeRegistry $fieldTypeRegistry,
-        PasswordHashServiceInterface $passwordHashService,
+        PasswordHashService $passwordHashService,
         ThumbnailStrategy $thumbnailStrategy,
         ProxyDomainMapperFactoryInterface $proxyDomainMapperFactory,
         Mapper\ContentDomainMapper $contentDomainMapper,

--- a/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/UserStorageGatewayTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/UserStorageGatewayTest.php
@@ -75,7 +75,7 @@ abstract class UserStorageGatewayTest extends BaseCoreFieldTypeIntegrationTest
             $importer->import(new YamlFixture($fixtureFilePath));
         }
 
-        $actualCount = $this->getGateway()->countUsersWithUnsupportedHashType();
+        $actualCount = $this->getGateway()->countUsersWithUnsupportedHashType(User::SUPPORTED_PASSWORD_HASHES);
         self::assertEquals($expectedCount, $actualCount);
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/UserTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/UserTest.php
@@ -8,6 +8,7 @@ namespace eZ\Publish\Core\FieldType\Tests;
 
 use DateTimeImmutable;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\API\Repository\PasswordHashService;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\FieldType\User\Type;
 use eZ\Publish\Core\FieldType\User\Type as UserType;
@@ -16,7 +17,6 @@ use eZ\Publish\Core\Repository\Values\User\User as RepositoryUser;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\FieldType\ValidationError;
 use eZ\Publish\Core\Persistence\Cache\UserHandler;
-use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use eZ\Publish\Core\Repository\User\PasswordValidatorInterface;
 use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition as CoreFieldDefinition;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
@@ -29,6 +29,8 @@ use PHPUnit\Framework\MockObject\Builder\InvocationMocker;
  */
 class UserTest extends FieldTypeTest
 {
+    private const UNSUPPORTED_HASH_TYPE = 0xDEADBEEF;
+
     /**
      * Returns the field type under test.
      *
@@ -44,7 +46,7 @@ class UserTest extends FieldTypeTest
     {
         $fieldType = new UserType(
             $this->createMock(UserHandler::class),
-            $this->createMock(PasswordHashServiceInterface::class),
+            $this->createMock(PasswordHashService::class),
             $this->createMock(PasswordValidatorInterface::class)
         );
         $fieldType->setTransformationProcessor($this->getTransformationProcessorMock());
@@ -415,7 +417,7 @@ class UserTest extends FieldTypeTest
 
         $userType = new UserType(
             $userHandlerMock,
-            $this->createMock(PasswordHashServiceInterface::class),
+            $this->createMock(PasswordHashService::class),
             $this->createMock(PasswordValidatorInterface::class)
         );
 
@@ -457,7 +459,7 @@ class UserTest extends FieldTypeTest
 
         $userType = new UserType(
             $userHandlerMock,
-            $this->createMock(PasswordHashServiceInterface::class),
+            $this->createMock(PasswordHashService::class),
             $this->createMock(PasswordValidatorInterface::class)
         );
 
@@ -504,7 +506,7 @@ class UserTest extends FieldTypeTest
 
         $userType = new UserType(
             $userHandlerMock,
-            $this->createMock(PasswordHashServiceInterface::class),
+            $this->createMock(PasswordHashService::class),
             $this->createMock(PasswordValidatorInterface::class)
         );
 
@@ -556,7 +558,7 @@ class UserTest extends FieldTypeTest
 
         $userType = new UserType(
             $userHandlerMock,
-            $this->createMock(PasswordHashServiceInterface::class),
+            $this->createMock(PasswordHashService::class),
             $this->createMock(PasswordValidatorInterface::class)
         );
 
@@ -588,7 +590,7 @@ class UserTest extends FieldTypeTest
      */
     public function testCreatePersistenceValue(array $userValueDate, array $expectedFieldValueExternalData): void
     {
-        $passwordHashServiceMock = $this->createMock(PasswordHashServiceInterface::class);
+        $passwordHashServiceMock = $this->createMock(PasswordHashService::class);
         $passwordHashServiceMock->method('getDefaultHashType')->willReturn(RepositoryUser::DEFAULT_PASSWORD_HASH);
         $userType = new UserType(
             $this->createMock(UserHandler::class),
@@ -643,7 +645,7 @@ class UserTest extends FieldTypeTest
         ];
         yield 'when password hash type is unsupported' => [
             $userValueData = [
-                    'passwordHashType' => '__UNSUPPORTED_HASH_TYPE__',
+                    'passwordHashType' => self::UNSUPPORTED_HASH_TYPE,
                 ] + $userData,
             $expectedFieldValueExternalData = [
                     'passwordHashType' => RepositoryUser::DEFAULT_PASSWORD_HASH,
@@ -682,7 +684,7 @@ class UserTest extends FieldTypeTest
 
         $userType = new UserType(
             $userHandlerMock,
-            $this->createMock(PasswordHashServiceInterface::class),
+            $this->createMock(PasswordHashService::class),
             $this->createMock(PasswordValidatorInterface::class)
         );
 

--- a/eZ/Publish/Core/FieldType/User/Type.php
+++ b/eZ/Publish/Core/FieldType/User/Type.php
@@ -11,13 +11,13 @@ use DateTimeInterface;
 use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\Core\FieldType\ValidationError;
 use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
-use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use eZ\Publish\Core\Repository\User\PasswordValidatorInterface;
 use eZ\Publish\SPI\FieldType\Value as SPIValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 use eZ\Publish\Core\FieldType\Value as BaseValue;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
+use eZ\Publish\API\Repository\PasswordHashService;
 use LogicException;
 
 /**
@@ -85,7 +85,7 @@ class Type extends FieldType
     /** @var \eZ\Publish\SPI\Persistence\User\Handler */
     private $userHandler;
 
-    /** @var \eZ\Publish\Core\Repository\User\PasswordHashServiceInterface */
+    /** @var \eZ\Publish\API\Repository\PasswordHashService */
     private $passwordHashService;
 
     /** @var \eZ\Publish\Core\Repository\User\PasswordValidatorInterface */
@@ -93,7 +93,7 @@ class Type extends FieldType
 
     public function __construct(
         SPIUserHandler $userHandler,
-        PasswordHashServiceInterface $passwordHashGenerator,
+        PasswordHashService $passwordHashGenerator,
         PasswordValidatorInterface $passwordValidator
     ) {
         $this->userHandler = $userHandler;

--- a/eZ/Publish/Core/FieldType/User/Type.php
+++ b/eZ/Publish/Core/FieldType/User/Type.php
@@ -10,7 +10,6 @@ use DateTimeImmutable;
 use DateTimeInterface;
 use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\Core\FieldType\ValidationError;
-use eZ\Publish\Core\Repository\Values\User\User;
 use eZ\Publish\SPI\Persistence\User\Handler as SPIUserHandler;
 use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use eZ\Publish\Core\Repository\User\PasswordValidatorInterface;
@@ -276,7 +275,7 @@ class Type extends FieldType
             return $this->passwordHashService->getDefaultHashType();
         }
 
-        if (!in_array($value->passwordHashType, User::SUPPORTED_PASSWORD_HASHES, true)) {
+        if (!$this->passwordHashService->isHashTypeSupported($value->passwordHashType)) {
             return $this->passwordHashService->getDefaultHashType();
         }
 

--- a/eZ/Publish/Core/FieldType/User/UserStorage.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage.php
@@ -113,8 +113,11 @@ class UserStorage extends GatewayBasedStorage
     {
     }
 
-    public function countUsersWithUnsupportedHashType(): int
+    /**
+     * @param int[] $supportedHashTypes
+     */
+    public function countUsersWithUnsupportedHashType(array $supportedHashTypes): int
     {
-        return $this->gateway->countUsersWithUnsupportedHashType();
+        return $this->gateway->countUsersWithUnsupportedHashType($supportedHashTypes);
     }
 }

--- a/eZ/Publish/Core/FieldType/User/UserStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage/Gateway.php
@@ -50,5 +50,8 @@ abstract class Gateway extends StorageGateway
      */
     abstract public function deleteFieldData(VersionInfo $versionInfo, array $fieldIds): bool;
 
-    abstract public function countUsersWithUnsupportedHashType(): int;
+    /**
+     * @param int[] $supportedHashTypes
+     */
+    abstract public function countUsersWithUnsupportedHashType(array $supportedHashTypes): int;
 }

--- a/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/DoctrineStorage.php
@@ -9,7 +9,6 @@ namespace eZ\Publish\Core\FieldType\User\UserStorage\Gateway;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\ParameterType;
-use eZ\Publish\API\Repository\Values\User\User;
 use eZ\Publish\Core\Base\Exceptions\ForbiddenException;
 use eZ\Publish\Core\FieldType\User\UserStorage\Gateway;
 use eZ\Publish\SPI\Persistence\Content\Field;
@@ -26,9 +25,6 @@ class DoctrineStorage extends Gateway
 
     /** @var \Doctrine\DBAL\Connection */
     protected $connection;
-
-    /** @var Z\Publish\Core\Repository\User\PasswordHashServiceInterface */
-    private $passwordHashService;
 
     /**
      * Default values for user fields.

--- a/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/DoctrineStorage.php
@@ -27,6 +27,9 @@ class DoctrineStorage extends Gateway
     /** @var \Doctrine\DBAL\Connection */
     protected $connection;
 
+    /** @var Z\Publish\Core\Repository\User\PasswordHashServiceInterface */
+    private $passwordHashService;
+
     /**
      * Default values for user fields.
      *
@@ -422,7 +425,7 @@ class DoctrineStorage extends Gateway
         return $numRows === 0;
     }
 
-    public function countUsersWithUnsupportedHashType(): int
+    public function countUsersWithUnsupportedHashType(array $supportedHashTypes): int
     {
         $selectQuery = $this->connection->createQueryBuilder();
 
@@ -434,7 +437,7 @@ class DoctrineStorage extends Gateway
             ->andWhere(
                 $selectQuery->expr()->notIn('u.password_hash_type', ':supportedPasswordHashes')
             )
-            ->setParameter('supportedPasswordHashes', User::SUPPORTED_PASSWORD_HASHES, Connection::PARAM_INT_ARRAY);
+            ->setParameter('supportedPasswordHashes', $supportedHashTypes, Connection::PARAM_INT_ARRAY);
 
         return $selectQuery
             ->execute()

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -30,12 +30,12 @@ use eZ\Publish\API\Repository\URLService as URLServiceInterface;
 use eZ\Publish\API\Repository\URLWildcardService as URLWildcardServiceInterface;
 use eZ\Publish\API\Repository\UserPreferenceService as UserPreferenceServiceInterface;
 use eZ\Publish\API\Repository\UserService as UserServiceInterface;
+use eZ\Publish\API\Repository\PasswordHashService;
 use eZ\Publish\Core\FieldType\FieldTypeRegistry;
 use eZ\Publish\Core\Repository\Helper\NameSchemaService;
 use eZ\Publish\Core\Repository\Permission\LimitationService;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperInterface;
-use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use eZ\Publish\Core\Repository\Helper\RelationProcessor;
 use eZ\Publish\Core\Repository\User\PasswordValidatorInterface;
 use eZ\Publish\Core\Search\Common\BackgroundIndexer;
@@ -230,7 +230,7 @@ class Repository implements RepositoryInterface
     /** @var \Psr\Log\LoggerInterface */
     private $logger;
 
-    /** @var \eZ\Publish\Core\Repository\User\PasswordHashServiceInterface */
+    /** @var \eZ\Publish\API\Repository\PasswordHashService */
     private $passwordHashService;
 
     /** @var \eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy */
@@ -269,7 +269,7 @@ class Repository implements RepositoryInterface
         BackgroundIndexer $backgroundIndexer,
         RelationProcessor $relationProcessor,
         FieldTypeRegistry $fieldTypeRegistry,
-        PasswordHashServiceInterface $passwordHashGenerator,
+        PasswordHashService $passwordHashGenerator,
         ThumbnailStrategy $thumbnailStrategy,
         ProxyDomainMapperFactoryInterface $proxyDomainMapperFactory,
         Mapper\ContentDomainMapper $contentDomainMapper,

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -14,7 +14,7 @@ use eZ\Publish\Core\Repository\Mapper\RoleDomainMapper;
 use eZ\Publish\Core\Repository\Permission\LimitationService;
 use eZ\Publish\Core\Repository\ProxyFactory\ProxyDomainMapperFactoryInterface;
 use eZ\Publish\Core\Repository\Strategy\ContentValidator\ContentValidatorStrategy;
-use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
+use eZ\Publish\API\Repository\PasswordHashService;
 use eZ\Publish\Core\FieldType\FieldTypeRegistry;
 use eZ\Publish\Core\Repository\Helper\RelationProcessor;
 use eZ\Publish\Core\Repository\User\PasswordValidatorInterface;
@@ -110,7 +110,7 @@ abstract class Base extends TestCase
                 new NullIndexer(),
                 $this->getRelationProcessorMock(),
                 $this->getFieldTypeRegistryMock(),
-                $this->createMock(PasswordHashServiceInterface::class),
+                $this->createMock(PasswordHashService::class),
                 $this->getThumbnailStrategy(),
                 $this->createMock(ProxyDomainMapperFactoryInterface::class),
                 $this->getContentDomainMapperMock(),

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UserTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UserTest.php
@@ -10,7 +10,7 @@ use eZ\Publish\API\Repository\Values\User\User as APIUser;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo as APIContentInfo;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\API\Repository\ContentService as APIContentService;
-use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
+use eZ\Publish\API\Repository\PasswordHashService;
 use eZ\Publish\Core\Repository\Tests\Service\Mock\Base as BaseServiceMockTest;
 use eZ\Publish\Core\Repository\User\PasswordValidatorInterface;
 use eZ\Publish\Core\Repository\UserService;
@@ -153,7 +153,7 @@ class UserTest extends BaseServiceMockTest
                     $this->getPermissionResolverMock(),
                     $this->getPersistenceMock()->userHandler(),
                     $this->getPersistenceMock()->locationHandler(),
-                    $this->createMock(PasswordHashServiceInterface::class),
+                    $this->createMock(PasswordHashService::class),
                     $this->createMock(PasswordValidatorInterface::class),
                 ]
             )

--- a/eZ/Publish/Core/Repository/Tests/User/PasswordHashServiceTest.php
+++ b/eZ/Publish/Core/Repository/Tests/User/PasswordHashServiceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Repository\Tests\User;
+
+use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\Core\Repository\User\PasswordHashService;
+use PHPUnit\Framework\TestCase;
+
+final class PasswordHashServiceTest extends TestCase
+{
+    private const NON_EXISTING_PASSWORD_HASH = PHP_INT_MAX;
+
+    /** @var \eZ\Publish\Core\Repository\User\PasswordHashService */
+    private $passwordHashService;
+
+    protected function setUp(): void
+    {
+        $this->passwordHashService = new PasswordHashService();
+    }
+
+    public function testGetSupportedHashTypes(): void
+    {
+        $this->assertEquals(
+            [
+                User::PASSWORD_HASH_BCRYPT,
+                User::PASSWORD_HASH_PHP_DEFAULT,
+            ],
+            $this->passwordHashService->getSupportedHashTypes()
+        );
+    }
+
+    public function testIsHashTypeSupported(): void
+    {
+        $this->assertTrue($this->passwordHashService->isHashTypeSupported(User::DEFAULT_PASSWORD_HASH));
+        $this->assertFalse($this->passwordHashService->isHashTypeSupported(self::NON_EXISTING_PASSWORD_HASH));
+    }
+}

--- a/eZ/Publish/Core/Repository/User/PasswordHashService.php
+++ b/eZ/Publish/Core/Repository/User/PasswordHashService.php
@@ -17,16 +17,26 @@ use eZ\Publish\Core\Repository\User\Exception\UnsupportedPasswordHashType;
 final class PasswordHashService implements PasswordHashServiceInterface
 {
     /** @var int */
-    private $hashType;
+    private $defaultHashType;
 
     public function __construct(int $hashType = User::DEFAULT_PASSWORD_HASH)
     {
-        $this->hashType = $hashType;
+        $this->defaultHashType = $hashType;
+    }
+
+    public function getSupportedHashTypes(): array
+    {
+        return User::SUPPORTED_PASSWORD_HASHES;
+    }
+
+    public function isHashTypeSupported(int $hashType): bool
+    {
+        return in_array($hashType, $this->getSupportedHashTypes(), true);
     }
 
     public function getDefaultHashType(): int
     {
-        return $this->hashType;
+        return $this->defaultHashType;
     }
 
     /**
@@ -34,7 +44,7 @@ final class PasswordHashService implements PasswordHashServiceInterface
      */
     public function createPasswordHash(string $password, ?int $hashType = null): string
     {
-        $hashType = $hashType ?? $this->hashType;
+        $hashType = $hashType ?? $this->defaultHashType;
 
         switch ($hashType) {
             case User::PASSWORD_HASH_BCRYPT:

--- a/eZ/Publish/Core/Repository/User/PasswordHashServiceInterface.php
+++ b/eZ/Publish/Core/Repository/User/PasswordHashServiceInterface.php
@@ -8,12 +8,13 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Repository\User;
 
-/**
- * @internal
- */
 interface PasswordHashServiceInterface
 {
     public function getDefaultHashType(): int;
+
+    public function getSupportedHashTypes(): array;
+
+    public function isHashTypeSupported(int $hashType): bool;
 
     public function createPasswordHash(string $password, ?int $hashType = null): string;
 

--- a/eZ/Publish/Core/Repository/User/PasswordHashServiceInterface.php
+++ b/eZ/Publish/Core/Repository/User/PasswordHashServiceInterface.php
@@ -8,15 +8,12 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Repository\User;
 
-interface PasswordHashServiceInterface
+use eZ\Publish\API\Repository\PasswordHashService;
+
+/**
+ * @deprecated since eZ Platform 3.3.0, to be removed in eZ Platform 4.0.0. Use
+ * \eZ\Publish\API\Repository\PasswordHashService directly instead.
+ */
+interface PasswordHashServiceInterface extends PasswordHashService
 {
-    public function getDefaultHashType(): int;
-
-    public function getSupportedHashTypes(): array;
-
-    public function isHashTypeSupported(int $hashType): bool;
-
-    public function createPasswordHash(string $password, ?int $hashType = null): string;
-
-    public function isValidPassword(string $plainPassword, string $passwordHash, ?int $hashType = null): bool;
 }

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -13,6 +13,7 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
 use Exception;
+use eZ\Publish\API\Repository\PasswordHashService;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\UserService as UserServiceInterface;
@@ -34,7 +35,6 @@ use eZ\Publish\Core\Base\Exceptions\ContentFieldValidationException;
 use eZ\Publish\Core\Base\Exceptions\MissingUserFieldTypeException;
 use eZ\Publish\Core\Repository\User\PasswordValidatorInterface;
 use eZ\Publish\Core\Repository\Validator\UserPasswordValidator;
-use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use eZ\Publish\Core\Repository\Values\User\UserCreateStruct;
 use eZ\Publish\API\Repository\Values\User\UserCreateStruct as APIUserCreateStruct;
 use eZ\Publish\API\Repository\Values\User\UserUpdateStruct;
@@ -83,7 +83,7 @@ class UserService implements UserServiceInterface
     /** @var \eZ\Publish\API\Repository\PermissionResolver */
     private $permissionResolver;
 
-    /** @var \eZ\Publish\Core\Repository\User\PasswordHashServiceInterface */
+    /** @var \eZ\Publish\API\Repository\PasswordHashService */
     private $passwordHashService;
 
     /** @var PasswordValidatorInterface */
@@ -96,21 +96,13 @@ class UserService implements UserServiceInterface
 
     /**
      * Setups service with reference to repository object that created it & corresponding handler.
-     *
-     * @param \eZ\Publish\API\Repository\Repository $repository
-     * @param \eZ\Publish\API\Repository\PermissionResolver $permissionResolver
-     * @param \eZ\Publish\SPI\Persistence\User\Handler $userHandler
-     * @param \eZ\Publish\SPI\Persistence\Content\Location\Handler $locationHandler
-     * @param \eZ\Publish\Core\Repository\User\PasswordHashServiceInterface $passwordHashGenerator
-     * @param \eZ\Publish\Core\Repository\User\PasswordValidatorInterface $passwordValidator
-     * @param array $settings
      */
     public function __construct(
         RepositoryInterface $repository,
         PermissionResolver $permissionResolver,
         Handler $userHandler,
         LocationHandler $locationHandler,
-        PasswordHashServiceInterface $passwordHashGenerator,
+        PasswordHashService $passwordHashGenerator,
         PasswordValidatorInterface $passwordValidator,
         array $settings = []
     ) {

--- a/eZ/Publish/Core/settings/fieldtype_services.yml
+++ b/eZ/Publish/Core/settings/fieldtype_services.yml
@@ -62,7 +62,7 @@ services:
 
     eZ\Publish\Core\Repository\User\PasswordHashService: ~
 
-    eZ\Publish\Core\Repository\User\PasswordHashServiceInterface:
+    eZ\Publish\API\Repository\PasswordHashService:
         alias: eZ\Publish\Core\Repository\User\PasswordHashService
 
     eZ\Publish\Core\Repository\User\PasswordValidator: ~

--- a/eZ/Publish/Core/settings/fieldtype_services.yml
+++ b/eZ/Publish/Core/settings/fieldtype_services.yml
@@ -62,6 +62,9 @@ services:
 
     eZ\Publish\Core\Repository\User\PasswordHashService: ~
 
+    eZ\Publish\Core\Repository\User\PasswordHashServiceInterface:
+        alias: eZ\Publish\Core\Repository\User\PasswordHashService
+
     eZ\Publish\Core\Repository\User\PasswordValidator: ~
 
     eZ\Publish\Core\Repository\User\PasswordValidatorInterface:

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -398,8 +398,8 @@ services:
         parent: ezpublish.fieldType
         arguments:
             - "@ezpublish.spi.persistence.cache.userHandler"
-            - '@eZ\Publish\Core\Repository\User\PasswordHashService'
-            - '@eZ\Publish\Core\Repository\User\PasswordValidator'
+            - '@eZ\Publish\Core\Repository\User\PasswordHashServiceInterface'
+            - '@eZ\Publish\Core\Repository\User\PasswordValidatorInterface'
         tags:
             - {name: ezplatform.field_type, alias: ezuser}
 

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -398,7 +398,7 @@ services:
         parent: ezpublish.fieldType
         arguments:
             - "@ezpublish.spi.persistence.cache.userHandler"
-            - '@eZ\Publish\Core\Repository\User\PasswordHashServiceInterface'
+            - '@eZ\Publish\API\Repository\PasswordHashService'
             - '@eZ\Publish\Core\Repository\User\PasswordValidatorInterface'
         tags:
             - {name: ezplatform.field_type, alias: ezuser}

--- a/eZ/Publish/SPI/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/UserIntegrationTest.php
@@ -6,9 +6,9 @@
  */
 namespace eZ\Publish\SPI\Tests\FieldType;
 
+use eZ\Publish\API\Repository\PasswordHashService;
 use eZ\Publish\Core\Persistence\Legacy;
 use eZ\Publish\Core\FieldType;
-use eZ\Publish\Core\Repository\User\PasswordHashServiceInterface;
 use eZ\Publish\Core\Repository\User\PasswordValidatorInterface;
 use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\Field;
@@ -55,7 +55,7 @@ class UserIntegrationTest extends BaseIntegrationTest
     public function getCustomHandler()
     {
         $userHandler = $this->createMock(User\Handler::class);
-        $passwordHashGenerator = $this->createMock(PasswordHashServiceInterface::class);
+        $passwordHashGenerator = $this->createMock(PasswordHashService::class);
         $passwordHashGenerator
             ->method('getDefaultHashType')
             ->willReturn(0);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32250
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | yes

Added methods

* `getSupportedHashTypes(): array`
* `isHashTypeSupported(int $hashType): bool`

to `\eZ\Publish\Core\Repository\User\PasswordHashServiceInterface` and refactor existing `\eZ\Publish\API\Repository\Values\User\User::SUPPORTED_PASSWORD_HASHES` usages

This allows to decorate `PasswordHashService` in 3rd-party bundles and add support for custom password hash types.

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [x] Provided automated test coverage.
- [X] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
