### PR TITLE
[CS] Upgraded Ibexa Code Style to fix copyright header in files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -60,8 +60,7 @@
         "brianium/paratest": "^4.0",
         "jenner/simple_fork": "^1.2",
         "friends-of-behat/mink-extension": "^2.4",
-        "friendsofphp/php-cs-fixer": "^2.16.2",
-        "ezsystems/ezplatform-code-style": "^0.1",
+        "ezsystems/ezplatform-code-style": "^0.2",
         "phpunit/phpunit": "^8.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1"
     },

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/CacheFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/CacheFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/Exception/InvalidRepositoryException.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/Exception/InvalidRepositoryException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader\Exception;

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/Exception/InvalidSearchEngine.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/Exception/InvalidSearchEngine.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader\Exception;

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/Exception/InvalidSearchEngineIndexer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/Exception/InvalidSearchEngineIndexer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader\Exception;

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/Exception/InvalidStorageEngine.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/Exception/InvalidStorageEngine.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader\Exception;

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryConfigurationProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryConfigurationProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/RepositoryFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineIndexerFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineIndexerFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/StorageConnectionFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/StorageConnectionFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/StorageEngineFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/StorageEngineFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\ApiLoader;

--- a/eZ/Bundle/EzPublishCoreBundle/Cache/Warmer/ProxyCacheWarmer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Cache/Warmer/ProxyCacheWarmer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Command/CheckURLsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/CheckURLsCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/CleanupVersionsCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Command;

--- a/eZ/Bundle/EzPublishCoreBundle/Command/CopySubtreeCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/CopySubtreeCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Command;

--- a/eZ/Bundle/EzPublishCoreBundle/Command/DebugConfigResolverCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/DebugConfigResolverCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Command;

--- a/eZ/Bundle/EzPublishCoreBundle/Command/DeleteContentTranslationCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/DeleteContentTranslationCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Command;

--- a/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/RegenerateUrlAliasesCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Command;

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Command;

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ResizeOriginalImagesCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ResizeOriginalImagesCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Command/UpdateTimestampsToUTCCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/UpdateTimestampsToUTCCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Console/Application.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Console/Application.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Console;

--- a/eZ/Bundle/EzPublishCoreBundle/Controller.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Controller.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Converter/ContentParamConverter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Converter/ContentParamConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Converter;

--- a/eZ/Bundle/EzPublishCoreBundle/Converter/LocationParamConverter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Converter/LocationParamConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Converter;

--- a/eZ/Bundle/EzPublishCoreBundle/Converter/RepositoryParamConverter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Converter/RepositoryParamConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Converter;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/BinaryContentDownloadPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/BinaryContentDownloadPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ChainConfigResolverPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ChainConfigResolverPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ChainRoutingPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ChainRoutingPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ConsoleCacheWarmupPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ConsoleCacheWarmupPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ContentViewPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ContentViewPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/FieldTypeParameterProviderRegistryPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/FieldTypeParameterProviderRegistryPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/FragmentPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/FragmentPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ImaginePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ImaginePass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/LocationViewPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/LocationViewPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/NotificationRendererPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/NotificationRendererPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/PlaceholderProviderPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/PlaceholderProviderPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/QueryTypePass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterSearchEngineIndexerPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterSearchEngineIndexerPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterSearchEnginePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterSearchEnginePass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterStorageEnginePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterStorageEnginePass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RouterPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RouterPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SecurityPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SecurityPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SiteAccessMatcherRegistryPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SiteAccessMatcherRegistryPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SlugConverterConfigurationPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/SlugConverterConfigurationPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/StorageConnectionPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/StorageConnectionPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/TranslationCollectorPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/TranslationCollectorPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/URLHandlerPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/URLHandlerPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewManagerPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewManagerPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewMatcherRegistryPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewMatcherRegistryPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewProvidersPass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewProvidersPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/AbstractParser.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/AbstractParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ChainConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ChainConfigResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ComplexSettings/ComplexSettingParser.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ComplexSettings/ComplexSettingParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ComplexSettings;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ComplexSettings/ComplexSettingParserInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ComplexSettings/ComplexSettingParserInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ComplexSettings;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ComplexSettings/ComplexSettingValueResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ComplexSettings/ComplexSettingValueResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\ComplexSettings;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigBuilderInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigBuilderInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigParser.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/ContainerConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/ContainerConfigResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessConfigResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ContainerConfigBuilder.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ContainerConfigBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/FieldTypeParserInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/FieldTypeParserInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/AbstractFieldTypeParser.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/AbstractFieldTypeParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Common.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Content.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Content.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/ContentView.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/ContentView.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldDefinitionEditTemplates.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldDefinitionEditTemplates.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldDefinitionSettingsTemplates.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldDefinitionSettingsTemplates.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldEditTemplates.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldEditTemplates.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldTemplates.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldTemplates.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldType/ImageAsset.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/FieldType/ImageAsset.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/IO.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/IO.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Image.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Image.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Languages.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Languages.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/LocationView.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/LocationView.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Templates.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Templates.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/TwigVariablesParser.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/TwigVariablesParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/UrlChecker.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/UrlChecker.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/View.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/View.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ParserInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ParserInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/Configuration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/Configuration.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ConfigurationMapperInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ConfigurationMapperInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessor.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/Contextualizer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/Contextualizer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ContextualizerInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/ContextualizerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/DynamicSettingParser.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/DynamicSettingParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/DynamicSettingParserInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/DynamicSettingParserInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/HookableConfigurationMapperInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/SiteAccessAware/HookableConfigurationMapperInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\SiteAccessAware;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Collector/SuggestionCollector.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Collector/SuggestionCollector.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\Collector;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Collector/SuggestionCollectorAwareInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Collector/SuggestionCollectorAwareInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\Collector;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Collector/SuggestionCollectorInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Collector/SuggestionCollectorInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\Collector;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/ConfigSuggestion.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/ConfigSuggestion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Formatter/SuggestionFormatterInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Formatter/SuggestionFormatterInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\Formatter;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Formatter/YamlSuggestionFormatter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Formatter/YamlSuggestionFormatter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\Formatter;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Tests/Collector/SuggestionCollectorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Tests/Collector/SuggestionCollectorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\Tests\Collector;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Tests/ConfigSuggestionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Tests/ConfigSuggestionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\Tests;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Tests/Formatter/YamlSuggestionFormatterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Suggestion/Tests/Formatter/YamlSuggestionFormatterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Suggestion\Tests\Formatter;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/HttpBasicFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/HttpBasicFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilder.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/PolicyProviderInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/PolicyProviderInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/RepositoryPolicyProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/RepositoryPolicyProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/YamlPolicyProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/YamlPolicyProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\PolicyProvider;

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/ServiceTags.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/ServiceTags.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/BackgroundIndexingTerminateListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/BackgroundIndexingTerminateListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/CacheViewResponseListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/CacheViewResponseListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ConfigScopeListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ConfigScopeListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ConsoleCommandListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ConsoleCommandListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ContentDownloadRouteReferenceListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ContentDownloadRouteReferenceListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ExceptionListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ExceptionListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/IndexRequestListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/IndexRequestListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/LocaleListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/LocaleListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/OriginalRequestListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/OriginalRequestListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/PreviewRequestListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/PreviewRequestListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/RejectExplicitFrontControllerRequestsListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/RejectExplicitFrontControllerRequestsListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/RequestEventListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/RoutingListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/RoutingListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionInitByPostListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionInitByPostListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionSetDynamicNameListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionSetDynamicNameListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewRendererListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewRendererListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/EventSubscriber/CrowdinRequestLocaleSubscriber.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventSubscriber/CrowdinRequestLocaleSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventSubscriber;

--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle;

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/BasicContentContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/BasicContentContext.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ConsoleContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ConsoleContext.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentContext.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentPreviewContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentPreviewContext.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentTypeContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentTypeContext.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ExceptionContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ExceptionContext.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/FieldTypeContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/FieldTypeContext.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryControllerContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryControllerContext.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/RoleContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/RoleContext.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/YamlConfigurationContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/YamlConfigurationContext.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Features\Context;

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/DecoratedFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/DecoratedFragmentRenderer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Fragment;

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/DirectFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/DirectFragmentRenderer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/FragmentListenerFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/FragmentListenerFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Fragment;

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/InlineFragmentRenderer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Fragment;

--- a/eZ/Bundle/EzPublishCoreBundle/Fragment/SiteAccessSerializationTrait.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Fragment/SiteAccessSerializationTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasCleaner.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasCleaner.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/BinaryLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/BinaryLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/AliasGeneratorDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Cache;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/Resolver/ProxyResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/Resolver/ProxyResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\Resolver;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/Resolver/RelativeResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/Resolver/RelativeResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Cache\Resolver;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/ResolverFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Cache/ResolverFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Cache;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/AbstractFilter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/AbstractFilter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/FilterConfiguration.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/FilterConfiguration.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/FilterInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/FilterInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Gmagick/ReduceNoiseFilter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Gmagick/ReduceNoiseFilter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Gmagick;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Gmagick/SwirlFilter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Gmagick/SwirlFilter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Gmagick;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Imagick/ReduceNoiseFilter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Imagick/ReduceNoiseFilter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Imagick;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Imagick/SwirlFilter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Imagick/SwirlFilter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Imagick;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/BorderFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/BorderFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/CropFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/CropFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/FilterLoaderWrapped.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/FilterLoaderWrapped.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/GrayscaleFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/GrayscaleFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ReduceNoiseFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ReduceNoiseFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleDownOnlyFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleDownOnlyFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleExactFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleExactFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleHeightFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleHeightFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScalePercentFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScalePercentFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleWidthFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/ScaleWidthFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/SwirlFilterLoader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/Loader/SwirlFilterLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/UnsupportedFilter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Filter/UnsupportedFilter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Filter;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/IORepositoryResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/IORepositoryResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/ImageAsset/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/ImageAsset/AliasGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderAliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderAliasGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderAliasGeneratorConfigurator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderAliasGeneratorConfigurator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProvider/GenericProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProvider/GenericProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProvider/RemoteProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProvider/RemoteProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\PlaceholderProvider;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProviderRegistry.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/PlaceholderProviderRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/Variation/ImagineAwareAliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/Variation/ImagineAwareAliasGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\Variation;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPathGenerator;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/IOVariationPurger.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/IOVariationPurger.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileList.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileRowReader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileRowReader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileVariationPurger.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/ImageFileVariationPurger.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileRowReader.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileRowReader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Imagine\VariationPurger;

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/ServiceAwareMatcherFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/ServiceAwareMatcherFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Matcher;

--- a/eZ/Bundle/EzPublishCoreBundle/Matcher/ViewMatcherRegistry.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Matcher/ViewMatcherRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Routing/DefaultRouter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/DefaultRouter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Routing;

--- a/eZ/Bundle/EzPublishCoreBundle/Routing/JsRouting/ExposedRoutesExtractor.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/JsRouting/ExposedRoutesExtractor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Routing\JsRouting;

--- a/eZ/Bundle/EzPublishCoreBundle/Routing/UrlAliasRouter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Routing/UrlAliasRouter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Routing;

--- a/eZ/Bundle/EzPublishCoreBundle/Session/Handler/NativeSessionHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Session/Handler/NativeSessionHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Session\Handler;

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/Config/ComplexConfigProcessor.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/Config/ComplexConfigProcessor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/Config/IOConfigResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/Config/IOConfigResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/LanguageResolver.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/LanguageResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/Matcher.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/Matcher.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/MatcherBuilder.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/MatcherBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessConfigurationFilter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessConfigurationFilter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\SiteAccess;

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistry.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistryInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/SiteAccess/SiteAccessMatcherRegistryInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Templating/Twig/ContextAwareTwigVariablesExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Templating/Twig/ContextAwareTwigVariablesExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/CacheFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/CacheFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\ApiLoader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/RepositoryConfigurationProviderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/RepositoryConfigurationProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\ApiLoader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/StorageConnectionFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/StorageConnectionFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\ApiLoader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/StorageEngineFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ApiLoader/StorageEngineFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\ApiLoader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Cache/Warmer/ProxyCacheWarmerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Cache/Warmer/ProxyCacheWarmerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ChainConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ChainConfigResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/ConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/ConfigResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/AbstractParamConverterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/AbstractParamConverterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Converter;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/ContentParamConverterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/ContentParamConverterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Converter;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/LocationParamConverterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Converter/LocationParamConverterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Converter;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ChainConfigResolverPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ChainConfigResolverPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ChainRoutingPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ChainRoutingPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ContentViewPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ContentViewPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/FieldTypeParameterProviderRegistryPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/FieldTypeParameterProviderRegistryPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/FragmentPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/FragmentPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/LocationViewPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/LocationViewPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/NotificationRendererPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/NotificationRendererPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/PlaceholderProviderPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/PlaceholderProviderPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/QueryTypePassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/RegisterSearchEngineIndexerPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/RegisterSearchEngineIndexerPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/RegisterSearchEnginePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/RegisterSearchEnginePassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/RegisterStorageEnginePassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/RegisterStorageEnginePassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SecurityPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SecurityPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SiteAccessMatcherRegistryPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SiteAccessMatcherRegistryPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SlugConverterConfigurationPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/SlugConverterConfigurationPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/TranslationCollectorPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/TranslationCollectorPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/URLHandlerPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/URLHandlerPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ViewMatcherRegistryPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ViewMatcherRegistryPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ViewProvidersPassTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Compiler/ViewProvidersPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ComplexSettings/ComplexSettingParserTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ComplexSettings/ComplexSettingParserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\ComplexSettings;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ComplexSettings/ComplexSettingValueResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ComplexSettings/ComplexSettingValueResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\ComplexSettings;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigParserTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigParserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/ChainConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/ChainConfigResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/ConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/ConfigResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/DefaultScopeConfigResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/GlobalScopeConfigResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/SiteAccessGroupConfigResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/ConfigResolver/StaticSiteAccessConfigResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/AbstractParserTestCase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/CommonTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ContentTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ContentTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/FieldType/ImageAssetTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/FieldType/ImageAssetTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/IOTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/IOTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ImageTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ImageTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/LanguagesTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/LanguagesTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/TemplatesTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/TemplatesTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ViewTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/ViewTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\Parser;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ConfigurationProcessorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\SiteAccessAware;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ContextualizerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/ContextualizerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\SiteAccessAware;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/DynamicSettingParserTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/SiteAccessAware/DynamicSettingParserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Configuration\SiteAccessAware;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Security\PolicyProvider;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Security/PolicyProvider/YamlPolicyProviderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Security/PolicyProvider/YamlPolicyProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Security\PolicyProvider;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/Filter/CustomCriterionQueryBuilder.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/Filter/CustomCriterionQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/Filter/CustomSortClauseQueryBuilder.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/Filter/CustomSortClauseQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/QueryTypeBundle/QueryType/TestQueryType.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/QueryTypeBundle/QueryType/TestQueryType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryType;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/QueryTypeBundle/QueryTypeBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/QueryTypeBundle/QueryTypeBundle.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/StubPolicyProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/StubPolicyProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/StubYamlPolicyProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/StubYamlPolicyProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/BackgroundIndexingTerminateListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/BackgroundIndexingTerminateListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConfigScopeListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConfigScopeListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConsoleCommandListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ConsoleCommandListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ContentDownloadRouteReferenceListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ContentDownloadRouteReferenceListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ExceptionListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ExceptionListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/IndexRequestListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/IndexRequestListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/LocaleListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/LocaleListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/OriginalRequestListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/OriginalRequestListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RejectExplicitFrontControllerRequestsListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RejectExplicitFrontControllerRequestsListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RequestEventListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RequestEventListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RoutingListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RoutingListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionInitByPostListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionInitByPostListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionSetDynamicNameListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionSetDynamicNameListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SiteAccessListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SiteAccessListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/FooServiceInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/FooServiceInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/TestOutput.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/TestOutput.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/ViewManager.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/ViewManager.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/ViewProvider.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/ViewProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener\Stubs;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventSubscriber/CrowdinRequestLocaleSubscriberTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventSubscriber/CrowdinRequestLocaleSubscriberTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventSubscriber;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/DecoratedFragmentRendererTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/DecoratedFragmentRendererTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/DirectFragmentRendererTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/DirectFragmentRendererTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/FragmentListenerFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/FragmentListenerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/FragmentRendererBaseTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/FragmentRendererBaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/InlineFragmentRendererTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/InlineFragmentRendererTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Fragment;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasCleanerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasCleanerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/AliasGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/Resolver/ProxyResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Cache\Resolver;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/Resolver/RelativeResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/Resolver/RelativeResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Cache\Resolver;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/ResolverFactoryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Cache/ResolverFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Cache;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/AbstractFilterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/AbstractFilterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/FilterConfigurationTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/FilterConfigurationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/BorderFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/BorderFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/CropFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/GrayscaleFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ReduceNoiseFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ReduceNoiseFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleDownOnlyFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleDownOnlyFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleExactFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleExactFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleHeightDownOnlyFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleHeightFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleHeightFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScalePercentFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScalePercentFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleWidthDownOnlyFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleWidthFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/ScaleWidthFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/SwirlFilterLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/Loader/SwirlFilterLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter\Loader;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/UnsupportedFilterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/Filter/UnsupportedFilterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\Filter;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/IORepositoryResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/IORepositoryResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/ImageAsset/AliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/ImageAsset/AliasGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderAliasGeneratorConfiguratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderAliasGeneratorConfiguratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderAliasGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderAliasGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderProvider/GenericProviderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderProvider/GenericProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\PlaceholderProvider;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderProviderRegistryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderProviderRegistryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPathGenerator/AliasDirectoryVariationPathGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPathGenerator;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGeneratorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPathGenerator/OriginalDirectoryVariationPathGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPathGenerator;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/IOVariationPurgerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/IOVariationPurgerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPurger;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/ImageFileVariationPurgerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/ImageFileVariationPurgerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Imagine\VariationPurger;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/LegacyStorageImageFileListTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/VariationPurger/LegacyStorageImageFileListTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Matcher/ViewMatcherRegistryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Matcher/ViewMatcherRegistryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Matcher;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/DefaultRouterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/DefaultRouterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Routing;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/UrlAliasRouterTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Routing/UrlAliasRouterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Routing;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/Config/IOConfigResolverTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/Config/IOConfigResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/MatcherBuilderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/MatcherBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\SiteAccess;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/SiteAccessMatcherRegistryTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/SiteAccess/SiteAccessMatcherRegistryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Translation/GlobCollectorTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Translation/GlobCollectorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\Translation;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/URLChecker/URLCheckerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/URLChecker/URLCheckerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\URLChecker;

--- a/eZ/Bundle/EzPublishCoreBundle/Translation/Collector.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Translation/Collector.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Translation;

--- a/eZ/Bundle/EzPublishCoreBundle/Translation/GlobCollector.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Translation/GlobCollector.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\Translation;

--- a/eZ/Bundle/EzPublishCoreBundle/URLChecker/Handler/AbstractConfigResolverBasedURLHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/URLChecker/Handler/AbstractConfigResolverBasedURLHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\URLChecker\Handler;

--- a/eZ/Bundle/EzPublishCoreBundle/URLChecker/Handler/AbstractURLHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/URLChecker/Handler/AbstractURLHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\URLChecker\Handler;

--- a/eZ/Bundle/EzPublishCoreBundle/URLChecker/Handler/HTTPHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/URLChecker/Handler/HTTPHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\URLChecker\Handler;

--- a/eZ/Bundle/EzPublishCoreBundle/URLChecker/Handler/MailToHandler.php
+++ b/eZ/Bundle/EzPublishCoreBundle/URLChecker/Handler/MailToHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\URLChecker\Handler;

--- a/eZ/Bundle/EzPublishCoreBundle/URLChecker/URLChecker.php
+++ b/eZ/Bundle/EzPublishCoreBundle/URLChecker/URLChecker.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\URLChecker;

--- a/eZ/Bundle/EzPublishCoreBundle/URLChecker/URLCheckerInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/URLChecker/URLCheckerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\URLChecker;

--- a/eZ/Bundle/EzPublishCoreBundle/URLChecker/URLHandlerInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/URLChecker/URLHandlerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\URLChecker;

--- a/eZ/Bundle/EzPublishCoreBundle/URLChecker/URLHandlerRegistry.php
+++ b/eZ/Bundle/EzPublishCoreBundle/URLChecker/URLHandlerRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\URLChecker;

--- a/eZ/Bundle/EzPublishCoreBundle/URLChecker/URLHandlerRegistryInterface.php
+++ b/eZ/Bundle/EzPublishCoreBundle/URLChecker/URLHandlerRegistryInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\URLChecker;

--- a/eZ/Bundle/EzPublishCoreBundle/View/Manager.php
+++ b/eZ/Bundle/EzPublishCoreBundle/View/Manager.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\View;

--- a/eZ/Bundle/EzPublishCoreBundle/View/Provider/Configured.php
+++ b/eZ/Bundle/EzPublishCoreBundle/View/Provider/Configured.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishCoreBundle\View\Provider;

--- a/eZ/Bundle/EzPublishDebugBundle/Collector/EzPublishCoreCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/EzPublishCoreCollector.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishDebugBundle\Collector;

--- a/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/PersistenceCacheCollector.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishDebugBundle\Collector;

--- a/eZ/Bundle/EzPublishDebugBundle/Collector/SiteAccessCollector.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Collector/SiteAccessCollector.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishDebugBundle\Collector;

--- a/eZ/Bundle/EzPublishDebugBundle/DependencyInjection/Compiler/DataCollectorPass.php
+++ b/eZ/Bundle/EzPublishDebugBundle/DependencyInjection/Compiler/DataCollectorPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishDebugBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishDebugBundle/DependencyInjection/EzPublishDebugExtension.php
+++ b/eZ/Bundle/EzPublishDebugBundle/DependencyInjection/EzPublishDebugExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishDebugBundle\DependencyInjection;

--- a/eZ/Bundle/EzPublishDebugBundle/EzPublishDebugBundle.php
+++ b/eZ/Bundle/EzPublishDebugBundle/EzPublishDebugBundle.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishDebugBundle;

--- a/eZ/Bundle/EzPublishDebugBundle/Tests/Collector/EzPublishCoreCollectorTest.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Tests/Collector/EzPublishCoreCollectorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishDebugBundle\Tests\Collector;

--- a/eZ/Bundle/EzPublishDebugBundle/Tests/DependencyInjection/Compiler/DataCollectorPassTest.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Tests/DependencyInjection/Compiler/DataCollectorPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishDebugBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishDebugBundle/Twig/DebugTemplate.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Twig/DebugTemplate.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishDebugBundle\Twig;

--- a/eZ/Bundle/EzPublishIOBundle/ApiLoader/HandlerRegistry.php
+++ b/eZ/Bundle/EzPublishIOBundle/ApiLoader/HandlerRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\ApiLoader;

--- a/eZ/Bundle/EzPublishIOBundle/BinaryStreamResponse.php
+++ b/eZ/Bundle/EzPublishIOBundle/BinaryStreamResponse.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle;

--- a/eZ/Bundle/EzPublishIOBundle/Command/MigrateFilesCommand.php
+++ b/eZ/Bundle/EzPublishIOBundle/Command/MigrateFilesCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Command;

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/Compiler/IOConfigurationPass.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/Compiler/IOConfigurationPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/Compiler/MigrationFileListerPass.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/Compiler/MigrationFileListerPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/Configuration.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/Configuration.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\DependencyInjection;

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\DependencyInjection;

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/BinarydataHandler/Flysystem.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/BinarydataHandler/Flysystem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\DependencyInjection\ConfigurationFactory\BinarydataHandler;

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/Flysystem.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/Flysystem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\DependencyInjection\ConfigurationFactory;

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/MetadataHandler/Flysystem.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/MetadataHandler/Flysystem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\DependencyInjection\ConfigurationFactory\MetadataHandler;

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/MetadataHandler/LegacyDFSCluster.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/ConfigurationFactory/MetadataHandler/LegacyDFSCluster.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\DependencyInjection\ConfigurationFactory\MetadataHandler;

--- a/eZ/Bundle/EzPublishIOBundle/DependencyInjection/EzPublishIOExtension.php
+++ b/eZ/Bundle/EzPublishIOBundle/DependencyInjection/EzPublishIOExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\DependencyInjection;

--- a/eZ/Bundle/EzPublishIOBundle/EventListener/StreamFileListener.php
+++ b/eZ/Bundle/EzPublishIOBundle/EventListener/StreamFileListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\EventListener;

--- a/eZ/Bundle/EzPublishIOBundle/EzPublishIOBundle.php
+++ b/eZ/Bundle/EzPublishIOBundle/EzPublishIOBundle.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle;

--- a/eZ/Bundle/EzPublishIOBundle/Flysystem/Adapter/SiteAccessAwareLocalAdapter.php
+++ b/eZ/Bundle/EzPublishIOBundle/Flysystem/Adapter/SiteAccessAwareLocalAdapter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/BinaryFileLister.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/BinaryFileLister.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIterator/LegacyStorageFileIterator.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIterator/LegacyStorageFileIterator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileIterator;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIteratorInterface.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIteratorInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageBinaryFileRowReader.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageBinaryFileRowReader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileRowReader;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageFileRowReader.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageFileRowReader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileRowReader;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageMediaFileRowReader.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReader/LegacyStorageMediaFileRowReader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister\FileRowReader;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReaderInterface.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileRowReaderInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/ImageFileLister.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/ImageFileLister.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration\FileLister;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileListerInterface.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileListerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileListerRegistry.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileListerRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileListerRegistry/ConfigurableRegistry.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileListerRegistry/ConfigurableRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration\FileListerRegistry;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileMigrator/FileMigrator.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileMigrator/FileMigrator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration\FileMigrator;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileMigratorInterface.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileMigratorInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/MigrationHandler.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/MigrationHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration;

--- a/eZ/Bundle/EzPublishIOBundle/Migration/MigrationHandlerInterface.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/MigrationHandlerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Migration;

--- a/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/Compiler/IOConfigurationPassTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/Compiler/IOConfigurationPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Tests\DependencyInjection\Compiler;

--- a/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/ConfigurationFactory/BaseFlysystemTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/ConfigurationFactory/BaseFlysystemTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Tests\DependencyInjection\ConfigurationFactory;

--- a/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/ConfigurationFactory/BinarydataHandler/FlysystemTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/ConfigurationFactory/BinarydataHandler/FlysystemTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Tests\DependencyInjection\ConfigurationFactory\BinarydataHandler;

--- a/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/ConfigurationFactory/MetadataHandler/FlysystemTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/ConfigurationFactory/MetadataHandler/FlysystemTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Tests\DependencyInjection\ConfigurationFactory\MetadataHandler;

--- a/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/ConfigurationFactory/MetadataHandler/LegacyDFSClusterTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/ConfigurationFactory/MetadataHandler/LegacyDFSClusterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Tests\DependencyInjection\ConfigurationFactory\MetadataHandler;

--- a/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/ConfigurationFactoryTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/ConfigurationFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Tests\DependencyInjection;

--- a/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/EzPublishIOExtensionTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/EzPublishIOExtensionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Tests\DependencyInjection;

--- a/eZ/Bundle/EzPublishIOBundle/Tests/EventListener/StreamFileListenerTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/EventListener/StreamFileListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Tests\EventListener;

--- a/eZ/Bundle/EzPublishIOBundle/Tests/Flysystem/Adapter/SiteAccessAwareLocalAdapterTest.php
+++ b/eZ/Bundle/EzPublishIOBundle/Tests/Flysystem/Adapter/SiteAccessAwareLocalAdapterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishIOBundle\Tests\Flysystem\Adapter;

--- a/eZ/Bundle/EzPublishLegacySearchEngineBundle/ApiLoader/ConnectionFactory.php
+++ b/eZ/Bundle/EzPublishLegacySearchEngineBundle/ApiLoader/ConnectionFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishLegacySearchEngineBundle\ApiLoader;

--- a/eZ/Bundle/EzPublishLegacySearchEngineBundle/DependencyInjection/EzPublishLegacySearchEngineExtension.php
+++ b/eZ/Bundle/EzPublishLegacySearchEngineBundle/DependencyInjection/EzPublishLegacySearchEngineExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishLegacySearchEngineBundle\DependencyInjection;

--- a/eZ/Bundle/EzPublishLegacySearchEngineBundle/EzPublishLegacySearchEngineBundle.php
+++ b/eZ/Bundle/EzPublishLegacySearchEngineBundle/EzPublishLegacySearchEngineBundle.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Bundle\EzPublishLegacySearchEngineBundle;

--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\PlatformInstallerBundle\Command;

--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/ValidatePasswordHashesCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/ValidatePasswordHashesCommand.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\PlatformInstallerBundle\Command;

--- a/eZ/Bundle/PlatformInstallerBundle/src/DependencyInjection/Compiler/InstallerTagPass.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/DependencyInjection/Compiler/InstallerTagPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\PlatformInstallerBundle\DependencyInjection\Compiler;

--- a/eZ/Bundle/PlatformInstallerBundle/src/DependencyInjection/EzSystemsPlatformInstallerExtension.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/DependencyInjection/EzSystemsPlatformInstallerExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\PlatformInstallerBundle\DependencyInjection;

--- a/eZ/Bundle/PlatformInstallerBundle/src/Event/Subscriber/BuildSchemaSubscriber.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Event/Subscriber/BuildSchemaSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/PlatformInstallerBundle/src/EzSystemsPlatformInstallerBundle.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/EzSystemsPlatformInstallerBundle.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\PlatformInstallerBundle;

--- a/eZ/Bundle/PlatformInstallerBundle/src/Installer/CoreInstaller.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Installer/CoreInstaller.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/PlatformInstallerBundle/src/Installer/DbBasedInstaller.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Installer/DbBasedInstaller.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\PlatformInstallerBundle\Installer;

--- a/eZ/Bundle/PlatformInstallerBundle/src/Installer/Installer.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Installer/Installer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace EzSystems\PlatformInstallerBundle\Installer;

--- a/eZ/Bundle/PlatformInstallerBundle/tests/DependencyInjection/Compiler/InstallerTagPassTest.php
+++ b/eZ/Bundle/PlatformInstallerBundle/tests/DependencyInjection/Compiler/InstallerTagPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/PlatformInstallerBundle/tests/DependencyInjection/EzSystemsPlatformInstallerExtensionTest.php
+++ b/eZ/Bundle/PlatformInstallerBundle/tests/DependencyInjection/EzSystemsPlatformInstallerExtensionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Bundle/PlatformInstallerBundle/tests/EzSystemsPlatformInstallerBundleTest.php
+++ b/eZ/Bundle/PlatformInstallerBundle/tests/EzSystemsPlatformInstallerBundleTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Container.php
+++ b/eZ/Publish/API/Container.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API;

--- a/eZ/Publish/API/Repository/BookmarkService.php
+++ b/eZ/Publish/API/Repository/BookmarkService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/ContentTypeService.php
+++ b/eZ/Publish/API/Repository/ContentTypeService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Bookmark/BeforeCreateBookmarkEvent.php
+++ b/eZ/Publish/API/Repository/Events/Bookmark/BeforeCreateBookmarkEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Bookmark/BeforeDeleteBookmarkEvent.php
+++ b/eZ/Publish/API/Repository/Events/Bookmark/BeforeDeleteBookmarkEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Bookmark/CreateBookmarkEvent.php
+++ b/eZ/Publish/API/Repository/Events/Bookmark/CreateBookmarkEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Bookmark/DeleteBookmarkEvent.php
+++ b/eZ/Publish/API/Repository/Events/Bookmark/DeleteBookmarkEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/AddRelationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/AddRelationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforeAddRelationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforeAddRelationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforeCopyContentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforeCopyContentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforeCreateContentDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforeCreateContentDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforeCreateContentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforeCreateContentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforeDeleteContentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforeDeleteContentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforeDeleteRelationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforeDeleteRelationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforeDeleteTranslationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforeDeleteTranslationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforeDeleteVersionEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforeDeleteVersionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforeHideContentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforeHideContentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforePublishVersionEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforePublishVersionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforeRevealContentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforeRevealContentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforeUpdateContentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforeUpdateContentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/BeforeUpdateContentMetadataEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/BeforeUpdateContentMetadataEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/CopyContentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/CopyContentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/CreateContentDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/CreateContentDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/CreateContentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/CreateContentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/DeleteContentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/DeleteContentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/DeleteRelationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/DeleteRelationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/DeleteTranslationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/DeleteTranslationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/DeleteVersionEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/DeleteVersionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/HideContentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/HideContentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/PublishVersionEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/PublishVersionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/RevealContentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/RevealContentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/UpdateContentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/UpdateContentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Content/UpdateContentMetadataEvent.php
+++ b/eZ/Publish/API/Repository/Events/Content/UpdateContentMetadataEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/AddFieldDefinitionEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/AddFieldDefinitionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/AssignContentTypeGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/AssignContentTypeGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeAddFieldDefinitionEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeAddFieldDefinitionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeAssignContentTypeGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeAssignContentTypeGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeCopyContentTypeEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeCopyContentTypeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeCreateContentTypeDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeCreateContentTypeDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeCreateContentTypeEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeCreateContentTypeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeCreateContentTypeGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeCreateContentTypeGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeDeleteContentTypeEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeDeleteContentTypeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeDeleteContentTypeGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeDeleteContentTypeGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforePublishContentTypeDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforePublishContentTypeDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeRemoveContentTypeTranslationEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeRemoveContentTypeTranslationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeRemoveFieldDefinitionEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeRemoveFieldDefinitionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeUnassignContentTypeGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeUnassignContentTypeGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeUpdateContentTypeDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeUpdateContentTypeDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeUpdateContentTypeGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeUpdateContentTypeGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/BeforeUpdateFieldDefinitionEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/BeforeUpdateFieldDefinitionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/CopyContentTypeEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/CopyContentTypeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/CreateContentTypeDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/CreateContentTypeDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/CreateContentTypeEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/CreateContentTypeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/CreateContentTypeGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/CreateContentTypeGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/DeleteContentTypeEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/DeleteContentTypeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/DeleteContentTypeGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/DeleteContentTypeGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/PublishContentTypeDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/PublishContentTypeDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/RemoveContentTypeTranslationEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/RemoveContentTypeTranslationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/RemoveFieldDefinitionEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/RemoveFieldDefinitionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/UnassignContentTypeGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/UnassignContentTypeGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/UpdateContentTypeDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/UpdateContentTypeDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/UpdateContentTypeGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/UpdateContentTypeGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ContentType/UpdateFieldDefinitionEvent.php
+++ b/eZ/Publish/API/Repository/Events/ContentType/UpdateFieldDefinitionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Language/BeforeCreateLanguageEvent.php
+++ b/eZ/Publish/API/Repository/Events/Language/BeforeCreateLanguageEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Language/BeforeDeleteLanguageEvent.php
+++ b/eZ/Publish/API/Repository/Events/Language/BeforeDeleteLanguageEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Language/BeforeDisableLanguageEvent.php
+++ b/eZ/Publish/API/Repository/Events/Language/BeforeDisableLanguageEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Language/BeforeEnableLanguageEvent.php
+++ b/eZ/Publish/API/Repository/Events/Language/BeforeEnableLanguageEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Language/BeforeUpdateLanguageNameEvent.php
+++ b/eZ/Publish/API/Repository/Events/Language/BeforeUpdateLanguageNameEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Language/CreateLanguageEvent.php
+++ b/eZ/Publish/API/Repository/Events/Language/CreateLanguageEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Language/DeleteLanguageEvent.php
+++ b/eZ/Publish/API/Repository/Events/Language/DeleteLanguageEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Language/DisableLanguageEvent.php
+++ b/eZ/Publish/API/Repository/Events/Language/DisableLanguageEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Language/EnableLanguageEvent.php
+++ b/eZ/Publish/API/Repository/Events/Language/EnableLanguageEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Language/UpdateLanguageNameEvent.php
+++ b/eZ/Publish/API/Repository/Events/Language/UpdateLanguageNameEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/BeforeCopySubtreeEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/BeforeCopySubtreeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/BeforeCreateLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/BeforeCreateLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/BeforeDeleteLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/BeforeDeleteLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/BeforeHideLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/BeforeHideLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/BeforeMoveSubtreeEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/BeforeMoveSubtreeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/BeforeSwapLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/BeforeSwapLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/BeforeUnhideLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/BeforeUnhideLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/BeforeUpdateLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/BeforeUpdateLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/CopySubtreeEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/CopySubtreeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/CreateLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/CreateLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/DeleteLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/DeleteLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/HideLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/HideLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/MoveSubtreeEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/MoveSubtreeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/SwapLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/SwapLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/UnhideLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/UnhideLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Location/UpdateLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Location/UpdateLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Notification/BeforeCreateNotificationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Notification/BeforeCreateNotificationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Notification/BeforeDeleteNotificationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Notification/BeforeDeleteNotificationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Notification/BeforeMarkNotificationAsReadEvent.php
+++ b/eZ/Publish/API/Repository/Events/Notification/BeforeMarkNotificationAsReadEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Notification/CreateNotificationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Notification/CreateNotificationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Notification/DeleteNotificationEvent.php
+++ b/eZ/Publish/API/Repository/Events/Notification/DeleteNotificationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Notification/MarkNotificationAsReadEvent.php
+++ b/eZ/Publish/API/Repository/Events/Notification/MarkNotificationAsReadEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/BeforeCreateObjectStateEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/BeforeCreateObjectStateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/BeforeCreateObjectStateGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/BeforeCreateObjectStateGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/BeforeDeleteObjectStateEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/BeforeDeleteObjectStateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/BeforeDeleteObjectStateGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/BeforeDeleteObjectStateGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/BeforeSetContentStateEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/BeforeSetContentStateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/BeforeSetPriorityOfObjectStateEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/BeforeSetPriorityOfObjectStateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/BeforeUpdateObjectStateEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/BeforeUpdateObjectStateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/BeforeUpdateObjectStateGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/BeforeUpdateObjectStateGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/CreateObjectStateEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/CreateObjectStateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/CreateObjectStateGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/CreateObjectStateGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/DeleteObjectStateEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/DeleteObjectStateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/DeleteObjectStateGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/DeleteObjectStateGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/SetContentStateEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/SetContentStateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/SetPriorityOfObjectStateEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/SetPriorityOfObjectStateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/UpdateObjectStateEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/UpdateObjectStateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/ObjectState/UpdateObjectStateGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/ObjectState/UpdateObjectStateGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/AddPolicyByRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/AddPolicyByRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/AssignRoleToUserEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/AssignRoleToUserEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/AssignRoleToUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/AssignRoleToUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeAddPolicyByRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeAddPolicyByRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeAssignRoleToUserEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeAssignRoleToUserEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeAssignRoleToUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeAssignRoleToUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeCopyRoleEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeCopyRoleEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeCreateRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeCreateRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeCreateRoleEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeCreateRoleEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeDeletePolicyEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeDeletePolicyEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeDeleteRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeDeleteRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeDeleteRoleEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeDeleteRoleEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforePublishRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforePublishRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeRemovePolicyByRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeRemovePolicyByRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeRemoveRoleAssignmentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeRemoveRoleAssignmentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeUpdatePolicyByRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeUpdatePolicyByRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/BeforeUpdateRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/BeforeUpdateRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/CopyRoleEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/CopyRoleEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/CreateRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/CreateRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/CreateRoleEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/CreateRoleEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/DeletePolicyEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/DeletePolicyEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/DeleteRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/DeleteRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/DeleteRoleEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/DeleteRoleEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/PublishRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/PublishRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/RemovePolicyByRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/RemovePolicyByRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/RemoveRoleAssignmentEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/RemoveRoleAssignmentEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/UpdatePolicyByRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/UpdatePolicyByRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Role/UpdateRoleDraftEvent.php
+++ b/eZ/Publish/API/Repository/Events/Role/UpdateRoleDraftEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Section/AssignSectionEvent.php
+++ b/eZ/Publish/API/Repository/Events/Section/AssignSectionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Section/AssignSectionToSubtreeEvent.php
+++ b/eZ/Publish/API/Repository/Events/Section/AssignSectionToSubtreeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Section/BeforeAssignSectionEvent.php
+++ b/eZ/Publish/API/Repository/Events/Section/BeforeAssignSectionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Section/BeforeAssignSectionToSubtreeEvent.php
+++ b/eZ/Publish/API/Repository/Events/Section/BeforeAssignSectionToSubtreeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Section/BeforeCreateSectionEvent.php
+++ b/eZ/Publish/API/Repository/Events/Section/BeforeCreateSectionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Section/BeforeDeleteSectionEvent.php
+++ b/eZ/Publish/API/Repository/Events/Section/BeforeDeleteSectionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Section/BeforeUpdateSectionEvent.php
+++ b/eZ/Publish/API/Repository/Events/Section/BeforeUpdateSectionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Section/CreateSectionEvent.php
+++ b/eZ/Publish/API/Repository/Events/Section/CreateSectionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Section/DeleteSectionEvent.php
+++ b/eZ/Publish/API/Repository/Events/Section/DeleteSectionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Section/UpdateSectionEvent.php
+++ b/eZ/Publish/API/Repository/Events/Section/UpdateSectionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Trash/BeforeDeleteTrashItemEvent.php
+++ b/eZ/Publish/API/Repository/Events/Trash/BeforeDeleteTrashItemEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Trash/BeforeEmptyTrashEvent.php
+++ b/eZ/Publish/API/Repository/Events/Trash/BeforeEmptyTrashEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Trash/BeforeRecoverEvent.php
+++ b/eZ/Publish/API/Repository/Events/Trash/BeforeRecoverEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Trash/BeforeTrashEvent.php
+++ b/eZ/Publish/API/Repository/Events/Trash/BeforeTrashEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Trash/DeleteTrashItemEvent.php
+++ b/eZ/Publish/API/Repository/Events/Trash/DeleteTrashItemEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Trash/EmptyTrashEvent.php
+++ b/eZ/Publish/API/Repository/Events/Trash/EmptyTrashEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Trash/RecoverEvent.php
+++ b/eZ/Publish/API/Repository/Events/Trash/RecoverEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/Trash/TrashEvent.php
+++ b/eZ/Publish/API/Repository/Events/Trash/TrashEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URL/BeforeUpdateUrlEvent.php
+++ b/eZ/Publish/API/Repository/Events/URL/BeforeUpdateUrlEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URL/UpdateUrlEvent.php
+++ b/eZ/Publish/API/Repository/Events/URL/UpdateUrlEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLAlias/BeforeCreateGlobalUrlAliasEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLAlias/BeforeCreateGlobalUrlAliasEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLAlias/BeforeCreateUrlAliasEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLAlias/BeforeCreateUrlAliasEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLAlias/BeforeRefreshSystemUrlAliasesForLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLAlias/BeforeRefreshSystemUrlAliasesForLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLAlias/BeforeRemoveAliasesEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLAlias/BeforeRemoveAliasesEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLAlias/CreateGlobalUrlAliasEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLAlias/CreateGlobalUrlAliasEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLAlias/CreateUrlAliasEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLAlias/CreateUrlAliasEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLAlias/RefreshSystemUrlAliasesForLocationEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLAlias/RefreshSystemUrlAliasesForLocationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLAlias/RemoveAliasesEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLAlias/RemoveAliasesEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLWildcard/BeforeCreateEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLWildcard/BeforeCreateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLWildcard/BeforeRemoveEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLWildcard/BeforeRemoveEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLWildcard/BeforeTranslateEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLWildcard/BeforeTranslateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLWildcard/BeforeUpdateEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLWildcard/BeforeUpdateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLWildcard/CreateEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLWildcard/CreateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLWildcard/RemoveEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLWildcard/RemoveEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLWildcard/TranslateEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLWildcard/TranslateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/URLWildcard/UpdateEvent.php
+++ b/eZ/Publish/API/Repository/Events/URLWildcard/UpdateEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/AssignUserToUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/AssignUserToUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/BeforeAssignUserToUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/BeforeAssignUserToUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/BeforeCreateUserEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/BeforeCreateUserEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/BeforeCreateUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/BeforeCreateUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/BeforeDeleteUserEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/BeforeDeleteUserEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/BeforeDeleteUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/BeforeDeleteUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/BeforeMoveUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/BeforeMoveUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/BeforeUnAssignUserFromUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/BeforeUnAssignUserFromUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/BeforeUpdateUserEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/BeforeUpdateUserEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/BeforeUpdateUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/BeforeUpdateUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/BeforeUpdateUserPasswordEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/BeforeUpdateUserPasswordEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/BeforeUpdateUserTokenEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/BeforeUpdateUserTokenEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/CreateUserEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/CreateUserEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/CreateUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/CreateUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/DeleteUserEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/DeleteUserEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/DeleteUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/DeleteUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/MoveUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/MoveUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/UnAssignUserFromUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/UnAssignUserFromUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/UpdateUserEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/UpdateUserEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/UpdateUserGroupEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/UpdateUserGroupEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/UpdateUserPasswordEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/UpdateUserPasswordEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/User/UpdateUserTokenEvent.php
+++ b/eZ/Publish/API/Repository/Events/User/UpdateUserTokenEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/UserPreference/BeforeSetUserPreferenceEvent.php
+++ b/eZ/Publish/API/Repository/Events/UserPreference/BeforeSetUserPreferenceEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Events/UserPreference/SetUserPreferenceEvent.php
+++ b/eZ/Publish/API/Repository/Events/UserPreference/SetUserPreferenceEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/BadStateException.php
+++ b/eZ/Publish/API/Repository/Exceptions/BadStateException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/ContentFieldValidationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/ContentFieldValidationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/ContentTypeFieldDefinitionValidationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/ContentTypeFieldDefinitionValidationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/ContentTypeValidationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/ContentTypeValidationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/ContentValidationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/ContentValidationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/Exception.php
+++ b/eZ/Publish/API/Repository/Exceptions/Exception.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/ForbiddenException.php
+++ b/eZ/Publish/API/Repository/Exceptions/ForbiddenException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/InvalidArgumentException.php
+++ b/eZ/Publish/API/Repository/Exceptions/InvalidArgumentException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/InvalidVariationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/InvalidVariationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/LimitationValidationException.php
+++ b/eZ/Publish/API/Repository/Exceptions/LimitationValidationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/NotFoundException.php
+++ b/eZ/Publish/API/Repository/Exceptions/NotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/NotImplementedException.php
+++ b/eZ/Publish/API/Repository/Exceptions/NotImplementedException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/OutOfBoundsException.php
+++ b/eZ/Publish/API/Repository/Exceptions/OutOfBoundsException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/PasswordInUnsupportedFormatException.php
+++ b/eZ/Publish/API/Repository/Exceptions/PasswordInUnsupportedFormatException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/PropertyNotFoundException.php
+++ b/eZ/Publish/API/Repository/Exceptions/PropertyNotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/PropertyReadOnlyException.php
+++ b/eZ/Publish/API/Repository/Exceptions/PropertyReadOnlyException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Exceptions/UnauthorizedException.php
+++ b/eZ/Publish/API/Repository/Exceptions/UnauthorizedException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/FieldType.php
+++ b/eZ/Publish/API/Repository/FieldType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/FieldTypeService.php
+++ b/eZ/Publish/API/Repository/FieldTypeService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/LanguageResolver.php
+++ b/eZ/Publish/API/Repository/LanguageResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/LanguageService.php
+++ b/eZ/Publish/API/Repository/LanguageService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository;

--- a/eZ/Publish/API/Repository/Lists/UnauthorizedListItem.php
+++ b/eZ/Publish/API/Repository/Lists/UnauthorizedListItem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/NotificationService.php
+++ b/eZ/Publish/API/Repository/NotificationService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/ObjectStateService.php
+++ b/eZ/Publish/API/Repository/ObjectStateService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository;

--- a/eZ/Publish/API/Repository/PermissionCriterionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionCriterionResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/PermissionResolver.php
+++ b/eZ/Publish/API/Repository/PermissionResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/PermissionService.php
+++ b/eZ/Publish/API/Repository/PermissionService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Repository.php
+++ b/eZ/Publish/API/Repository/Repository.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/RoleService.php
+++ b/eZ/Publish/API/Repository/RoleService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace  eZ\Publish\API\Repository;

--- a/eZ/Publish/API/Repository/SearchService.php
+++ b/eZ/Publish/API/Repository/SearchService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/SectionService.php
+++ b/eZ/Publish/API/Repository/SectionService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/BaseContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseContentServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/BaseContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseContentTypeServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/BaseNonRedundantFieldSetTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseNonRedundantFieldSetTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/BaseTrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTrashServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/BaseURLServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseURLServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/BookmarkServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BookmarkServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Common/FacetedSearchProvider.php
+++ b/eZ/Publish/API/Repository/Tests/Common/FacetedSearchProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Common;

--- a/eZ/Publish/API/Repository/Tests/Common/SlugConverter.php
+++ b/eZ/Publish/API/Repository/Tests/Common/SlugConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Common;

--- a/eZ/Publish/API/Repository/Tests/Container/Compiler/SetAllServicesPublicPass.php
+++ b/eZ/Publish/API/Repository/Tests/Container/Compiler/SetAllServicesPublicPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Container\Compiler;

--- a/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/FieldType/AuthorIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/AuthorIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BaseIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/BinaryFileIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/BinaryFileIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/CheckboxIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/CheckboxIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/CountryIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/CountryIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/DateAndTimeIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/DateAndTimeIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/EmailAddressIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/EmailAddressIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/FileSearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/FileSearchBaseIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/ISBNIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/ISBNIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/IntegerIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/IntegerIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/KeywordIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/KeywordIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/MapLocationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/MapLocationIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/MediaIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/MediaIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationListIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationListIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/RelationSearchBaseIntegrationTestTrait.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/RelationSearchBaseIntegrationTestTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchBaseIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchMultivaluedBaseIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchMultivaluedBaseIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchableFloat.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchableFloat.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchableImage.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchableImage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchableMedia.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchableMedia.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/SearchableUrl.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SearchableUrl.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/SelectionMultilingualIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/SelectionMultilingualIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/TextBlockIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/TextBlockIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/TextLineIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/TextLineIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/TimeIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/TimeIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/UrlIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/UrlIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\FieldType;

--- a/eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldTypeServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/Filtering/BaseRepositoryFilteringTestCase.php
+++ b/eZ/Publish/API/Repository/Tests/Filtering/BaseRepositoryFilteringTestCase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Filtering/ContentFilteringTest.php
+++ b/eZ/Publish/API/Repository/Tests/Filtering/ContentFilteringTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Filtering/LocationFilteringTest.php
+++ b/eZ/Publish/API/Repository/Tests/Filtering/LocationFilteringTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Filtering/TestContentProvider.php
+++ b/eZ/Publish/API/Repository/Tests/Filtering/TestContentProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/IdManager.php
+++ b/eZ/Publish/API/Repository/Tests/IdManager.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/IdManager/Php.php
+++ b/eZ/Publish/API/Repository/Tests/IdManager/Php.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\IdManager;

--- a/eZ/Publish/API/Repository/Tests/LanguageServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/LanguageServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php
+++ b/eZ/Publish/API/Repository/Tests/LanguageServiceMaximumSupportedLanguagesTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/LanguageServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LanguageServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/LegacySchemaImporter.php
+++ b/eZ/Publish/API/Repository/Tests/LegacySchemaImporter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/BaseLimitationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/BaseLimitationIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/ContentLimitationsMixIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/ContentLimitationsMixIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LanguageLimitationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LanguageLimitationIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/NonRedundantFieldSetTest.php
+++ b/eZ/Publish/API/Repository/Tests/NonRedundantFieldSetTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/NotificationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/NotificationServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/ObjectStateServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/ObjectStateServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ObjectStateServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/PHPUnitConstraint/AllValidationErrorsOccur.php
+++ b/eZ/Publish/API/Repository/Tests/PHPUnitConstraint/AllValidationErrorsOccur.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/PHPUnitConstraint/ContentItemEquals.php
+++ b/eZ/Publish/API/Repository/Tests/PHPUnitConstraint/ContentItemEquals.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/PHPUnitConstraint/ValidationErrorOccurs.php
+++ b/eZ/Publish/API/Repository/Tests/PHPUnitConstraint/ValidationErrorOccurs.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Parallel/BaseParallelTestCase.php
+++ b/eZ/Publish/API/Repository/Tests/Parallel/BaseParallelTestCase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Parallel/ContentServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/Parallel/ContentServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Parallel/ParallelProcessList.php
+++ b/eZ/Publish/API/Repository/Tests/Parallel/ParallelProcessList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
+++ b/eZ/Publish/API/Repository/Tests/PermissionResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP20018LanguageTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP20018LanguageTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP20018ObjectStateTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP20018ObjectStateTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP20018VisibilityTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP20018VisibilityTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP21069Test.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP21069Test.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP21089Test.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP21089Test.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP21109EzIntegerTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP21109EzIntegerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP21771EzStringTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP21771EzStringTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP21798Test.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP21798Test.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP21906SearchOneContentMultipleLocationsTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP21906SearchOneContentMultipleLocationsTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP22408DeleteRelatedObjectTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP22408DeleteRelatedObjectTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP22409RelationListTypeStateTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP22409RelationListTypeStateTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP22612URLAliasTranslations.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP22612URLAliasTranslations.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP22840RoleLimitations.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP22840RoleLimitations.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP22958SearchSubtreePathstringFormatTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP22958SearchSubtreePathstringFormatTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP26327UrlAliasHistorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP26327UrlAliasHistorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP26367UrlAliasHistoryRedirectLoopTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP26367UrlAliasHistoryRedirectLoopTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP26551DeleteContentTypeDraftTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP26551DeleteContentTypeDraftTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EZP28799SubtreeSearchTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EZP28799SubtreeSearchTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/EnvTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/EnvTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/Regression/PureNegativeQueryTest.php
+++ b/eZ/Publish/API/Repository/Tests/Regression/PureNegativeQueryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Regression;

--- a/eZ/Publish/API/Repository/Tests/RepositoryTest.php
+++ b/eZ/Publish/API/Repository/Tests/RepositoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/RoleServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/RoleServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/RoleServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchEngineIndexingTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/AbstractAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/AbstractAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/ContentTypeGroupTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/ContentTypeGroupTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/ContentTypeTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/ContentTypeTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/DataSetBuilder/TermAggregationDataSetBuilder.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/DataSetBuilder/TermAggregationDataSetBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/DateMetadataRangeAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/DateMetadataRangeAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/AuthorTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/AuthorTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/CheckboxTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/CheckboxTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/CountryTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/CountryTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/DateRangeAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/DateRangeAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/DateTimeRangeAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/DateTimeRangeAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/FloatRangeAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/FloatRangeAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/FloatStatsAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/FloatStatsAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/IntegerRangeAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/IntegerRangeAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/IntegerStatsAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/IntegerStatsAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/KeywordTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/KeywordTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/SelectionTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/SelectionTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/TimeRangeAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/TimeRangeAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/FixtureGenerator/FieldAggregationFixtureGenerator.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/FixtureGenerator/FieldAggregationFixtureGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/LanguageTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/LanguageTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/ObjectStateTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/ObjectStateTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/RawRangeAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/RawRangeAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/RawStatsAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/RawStatsAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/RawTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/RawTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/SectionTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/SectionTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/SubtreeTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/SubtreeTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/UserMetadataTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/UserMetadataTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/VisibilityTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/VisibilityTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/DeleteTranslationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/DeleteTranslationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/RemoteIdIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/RemoteIdIndexingTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchService/SearchServiceFullTextEmbedTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/SearchServiceFullTextEmbedTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/SearchServiceFulltextTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceFulltextTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/SectionServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SectionServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/SetupFactory.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
+++ b/eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\SetupFactory;

--- a/eZ/Publish/API/Repository/Tests/TrashServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/TrashServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/URLAliasService/CustomUrlAliasForMultilingualContentTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasService/CustomUrlAliasForMultilingualContentTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/URLServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/URLServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/URLWildcardServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLWildcardServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/URLWildcardServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLWildcardServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/UserPreferenceServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserPreferenceServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/UserServiceAuthorizationTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceAuthorizationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests;

--- a/eZ/Publish/API/Repository/Tests/Values/Content/LanguageTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/LanguageTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\Content;

--- a/eZ/Publish/API/Repository/Tests/Values/Content/Query/Aggregation/Location/SubtreeTermAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/Query/Aggregation/Location/SubtreeTermAggregationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Values/Content/Query/Aggregation/RangeTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/Query/Aggregation/RangeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Values/Content/SectionTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Content/SectionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\Content;

--- a/eZ/Publish/API/Repository/Tests/Values/Filter/FilterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Filter/FilterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/BaseLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/BaseLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ContentTypeLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ContentTypeLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LocationLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LocationLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/NewObjectStateLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/NewObjectStateLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/NewSectionLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/NewSectionLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ObjectStateLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ObjectStateLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/OwnerLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/OwnerLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ParentContentTypeLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ParentContentTypeLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ParentDepthLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ParentDepthLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ParentOwnerLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ParentOwnerLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ParentUserGroupLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/ParentUserGroupLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/RolePolicyLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/RolePolicyLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/SectionLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/SectionLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/StatusLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/StatusLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/SubtreeLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/SubtreeLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/UserGroupLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/UserGroupLimitationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values\User\Limitation;

--- a/eZ/Publish/API/Repository/Tests/Values/ValueObjectTestTrait.php
+++ b/eZ/Publish/API/Repository/Tests/Values/ValueObjectTestTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Tests\Values;

--- a/eZ/Publish/API/Repository/Translatable.php
+++ b/eZ/Publish/API/Repository/Translatable.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository;

--- a/eZ/Publish/API/Repository/TranslationService.php
+++ b/eZ/Publish/API/Repository/TranslationService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository;

--- a/eZ/Publish/API/Repository/TrashService.php
+++ b/eZ/Publish/API/Repository/TrashService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/URLAliasService.php
+++ b/eZ/Publish/API/Repository/URLAliasService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/URLService.php
+++ b/eZ/Publish/API/Repository/URLService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/URLWildcardService.php
+++ b/eZ/Publish/API/Repository/URLWildcardService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/UserPreferenceService.php
+++ b/eZ/Publish/API/Repository/UserPreferenceService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Bookmark/BookmarkList.php
+++ b/eZ/Publish/API/Repository/Values/Bookmark/BookmarkList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Content.php
+++ b/eZ/Publish/API/Repository/Values/Content/Content.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/ContentCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/ContentDraftList.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentDraftList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/ContentList.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/ContentMetadataUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentMetadataUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/ContentStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/ContentUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/DraftList/ContentDraftListItemInterface.php
+++ b/eZ/Publish/API/Repository/Values/Content/DraftList/ContentDraftListItemInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/DraftList/Item/ContentDraftListItem.php
+++ b/eZ/Publish/API/Repository/Values/Content/DraftList/Item/ContentDraftListItem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/DraftList/Item/UnauthorizedContentDraftListItem.php
+++ b/eZ/Publish/API/Repository/Values/Content/DraftList/Item/UnauthorizedContentDraftListItem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Field.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Language.php
+++ b/eZ/Publish/API/Repository/Values/Content/Language.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/LanguageCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/LanguageCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Location.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/LocationCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/LocationList.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/LocationQuery.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationQuery.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/LocationUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/AbstractRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/AbstractRangeAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/AbstractStatsAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/AbstractStatsAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/AbstractTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/AbstractTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/ContentTypeGroupTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/ContentTypeGroupTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/ContentTypeTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/ContentTypeTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/DateMetadataRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/DateMetadataRangeAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldRangeAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldStatsAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldStatsAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AbstractFieldTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AuthorTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/AuthorTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/CheckboxTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/CheckboxTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/CountryTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/CountryTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/DateRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/DateRangeAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/DateTimeRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/DateTimeRangeAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/FieldAggregationTrait.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/FieldAggregationTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/FloatRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/FloatRangeAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/FloatStatsAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/FloatStatsAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/IntegerRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/IntegerRangeAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/IntegerStatsAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/IntegerStatsAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/KeywordTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/KeywordTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/SelectionTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/SelectionTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/TimeRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Field/TimeRangeAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/FieldAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/FieldAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/LanguageTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/LanguageTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Location/SubtreeTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Location/SubtreeTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/LocationAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/LocationAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/ObjectStateTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/ObjectStateTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Range.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/Range.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawRangeAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawRangeAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawStatsAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawStatsAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/RawTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/SectionTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/SectionTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/UserMetadataTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/UserMetadataTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/VisibilityTermAggregation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Aggregation/VisibilityTermAggregation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/CompositeCriterion.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/CompositeCriterion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeGroupId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeGroupId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ContentTypeIdentifier.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/CustomField.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/CustomField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/DateMetadata.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/DateMetadata.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Field.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FieldRelation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FieldRelation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FullText.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/FullText.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsFieldEmpty.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsFieldEmpty.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsUserBased.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsUserBased.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsUserEnabled.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/IsUserEnabled.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LanguageCode.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LanguageCode.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/Depth.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/Depth.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/IsMainLocation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/IsMainLocation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/Priority.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Location/Priority.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationRemoteId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LocationRemoteId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalAnd.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalAnd.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalNot.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalNot.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOperator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOr.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/LogicalOr.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MapLocationDistance.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MapLocationDistance.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchAll.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchAll.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchNone.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MatchNone.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MoreLikeThis.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/MoreLikeThis.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ObjectStateIdentifier.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Operator.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Operator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Operator/Specifications.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Operator/Specifications.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ParentLocationId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/ParentLocationId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/RemoteId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/RemoteId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/SectionId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/SectionId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/SectionIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/SectionIdentifier.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Sibling.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Sibling.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Subtree.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Subtree.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserEmail.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserEmail.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserLogin.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserLogin.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserMetadata.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/UserMetadata.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Value.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Value/MapLocationValue.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Value/MapLocationValue.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Visibility.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Visibility.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/CriterionInterface.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/CriterionInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/CustomFieldInterface.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/CustomFieldInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/ContentTypeFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/ContentTypeFacetBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/CriterionFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/CriterionFacetBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/DateRangeFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/DateRangeFacetBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Values\Content\Query\FacetBuilder;

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/FieldFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/FieldFacetBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/FieldRangeFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/FieldRangeFacetBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/Location.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/Location/LocationFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/Location/LocationFacetBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/LocationFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/LocationFacetBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/SectionFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/SectionFacetBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/TermFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/TermFacetBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/UserFacetBuilder.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/FacetBuilder/UserFacetBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentId.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentName.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/ContentName.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/DateModified.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/DateModified.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/DatePublished.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/DatePublished.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Field.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Depth.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Depth.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Id.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Id.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/IsMainLocation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/IsMainLocation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Path.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Path.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Priority.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Priority.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Visibility.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Location/Visibility.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/MapLocationDistance.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/MapLocationDistance.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Random.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Random.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/SectionIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/SectionIdentifier.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/SectionName.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/SectionName.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/FieldTarget.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/FieldTarget.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/MapLocationTarget.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/MapLocationTarget.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/RandomTarget.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Target/RandomTarget.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/ContentTypeName.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/ContentTypeName.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/DateTrashed.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/DateTrashed.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/UserLogin.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/SortClause/Trash/UserLogin.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Relation.php
+++ b/eZ/Publish/API/Repository/Values/Content/Relation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/RelationList.php
+++ b/eZ/Publish/API/Repository/Values/Content/RelationList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/RelationList/Item/RelationListItem.php
+++ b/eZ/Publish/API/Repository/Values/Content/RelationList/Item/RelationListItem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/RelationList/Item/UnauthorizedRelationListItem.php
+++ b/eZ/Publish/API/Repository/Values/Content/RelationList/Item/UnauthorizedRelationListItem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/RelationList/RelationListItemInterface.php
+++ b/eZ/Publish/API/Repository/Values/Content/RelationList/RelationListItemInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/RangeAggregationResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/RangeAggregationResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/RangeAggregationResultEntry.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/RangeAggregationResultEntry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/StatsAggregationResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/StatsAggregationResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/TermAggregationResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/TermAggregationResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/TermAggregationResultEntry.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResult/TermAggregationResultEntry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/AggregationResultCollection.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/AggregationResultCollection.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/ContentTypeFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/ContentTypeFacet.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/CriterionFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/CriterionFacet.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/DateRangeFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/DateRangeFacet.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/FieldFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/FieldFacet.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/FieldRangeFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/FieldRangeFacet.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/LocationFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/LocationFacet.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/RangeFacetEntry.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/RangeFacetEntry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/SectionFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/SectionFacet.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/TermFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/TermFacet.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/Facet/UserFacet.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/Facet/UserFacet.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/SearchHit.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/SearchHit.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Section.php
+++ b/eZ/Publish/API/Repository/Values/Content/Section.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/SectionCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/SectionCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/SectionStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/SectionStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/SectionUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/SectionUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Thumbnail.php
+++ b/eZ/Publish/API/Repository/Values/Content/Thumbnail.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Trash/SearchResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Trash/SearchResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResultList.php
+++ b/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResultList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/TrashItem.php
+++ b/eZ/Publish/API/Repository/Values/Content/TrashItem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/URLAlias.php
+++ b/eZ/Publish/API/Repository/Values/Content/URLAlias.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/URLWildcard.php
+++ b/eZ/Publish/API/Repository/Values/Content/URLWildcard.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/URLWildcardStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/URLWildcardStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/URLWildcardTranslationResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/URLWildcardTranslationResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/URLWildcardUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Content/URLWildcardUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Content/VersionInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/VersionInfo.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeDraft.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeDraft.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroup.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroup.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroupCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroupCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroupStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroupStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroupUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeGroupUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentTypeUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentTypeUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinition.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCollection.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCollection.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/FieldDefinitionUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Filter/Filter.php
+++ b/eZ/Publish/API/Repository/Values/Filter/Filter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Notification/CreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/Notification/CreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Notification/Notification.php
+++ b/eZ/Publish/API/Repository/Values/Notification/Notification.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Notification/NotificationList.php
+++ b/eZ/Publish/API/Repository/Values/Notification/NotificationList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectState.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectState.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroup.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroup.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroupCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroupCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroupUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateGroupUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/ObjectState/ObjectStateUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Translation.php
+++ b/eZ/Publish/API/Repository/Values/Translation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/Translation/Message.php
+++ b/eZ/Publish/API/Repository/Values/Translation/Message.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Values\Translation;

--- a/eZ/Publish/API/Repository/Values/Translation/Plural.php
+++ b/eZ/Publish/API/Repository/Values/Translation/Plural.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Values\Translation;

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalAnd.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalAnd.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalNot.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalNot.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalOperator.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalOperator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalOr.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/LogicalOr.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/MatchAll.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/MatchAll.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/MatchNone.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/MatchNone.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/Matcher.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/Matcher.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/Pattern.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/Pattern.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/SectionId.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/SectionId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/SectionIdentifier.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/SectionIdentifier.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/Validity.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/Validity.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/Criterion/VisibleOnly.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/Criterion/VisibleOnly.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/SortClause.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/SortClause.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/SortClause/Id.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/SortClause/Id.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/Query/SortClause/URL.php
+++ b/eZ/Publish/API/Repository/Values/URL/Query/SortClause/URL.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/SearchResult.php
+++ b/eZ/Publish/API/Repository/Values/URL/SearchResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/URL.php
+++ b/eZ/Publish/API/Repository/Values/URL/URL.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/URLQuery.php
+++ b/eZ/Publish/API/Repository/Values/URL/URLQuery.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/URLUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/URL/URLUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/URL/UsageSearchResult.php
+++ b/eZ/Publish/API/Repository/Values/URL/UsageSearchResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/BlockingLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/BlockingLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ContentTypeLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ContentTypeLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/LanguageLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/LanguageLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/LocationLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/LocationLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/NewObjectStateLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/NewObjectStateLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/NewSectionLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/NewSectionLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ObjectStateLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ObjectStateLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/OwnerLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/OwnerLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ParentContentTypeLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ParentContentTypeLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ParentDepthLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ParentDepthLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ParentOwnerLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ParentOwnerLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/ParentUserGroupLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/ParentUserGroupLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/RoleLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/RoleLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/SectionLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/SectionLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/SiteAccessLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/SiteAccessLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/StatusLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/StatusLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/SubtreeLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/SubtreeLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Limitation/UserGroupLimitation.php
+++ b/eZ/Publish/API/Repository/Values/User/Limitation/UserGroupLimitation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/LookupLimitationResult.php
+++ b/eZ/Publish/API/Repository/Values/User/LookupLimitationResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/LookupPolicyLimitations.php
+++ b/eZ/Publish/API/Repository/Values/User/LookupPolicyLimitations.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/PasswordInfo.php
+++ b/eZ/Publish/API/Repository/Values/User/PasswordInfo.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/PasswordValidationContext.php
+++ b/eZ/Publish/API/Repository/Values/User/PasswordValidationContext.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Policy.php
+++ b/eZ/Publish/API/Repository/Values/User/Policy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/PolicyCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/PolicyCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/PolicyDraft.php
+++ b/eZ/Publish/API/Repository/Values/User/PolicyDraft.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/PolicyStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/PolicyStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/PolicyUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/PolicyUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/Role.php
+++ b/eZ/Publish/API/Repository/Values/User/Role.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/RoleAssignment.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleAssignment.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/RoleCopyStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleCopyStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/RoleDraft.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleDraft.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/RoleUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/RoleUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/User.php
+++ b/eZ/Publish/API/Repository/Values/User/User.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/UserCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/UserCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/UserGroup.php
+++ b/eZ/Publish/API/Repository/Values/User/UserGroup.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/UserGroupCreateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/UserGroupCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/UserGroupRoleAssignment.php
+++ b/eZ/Publish/API/Repository/Values/User/UserGroupRoleAssignment.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/UserGroupUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/UserGroupUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/UserReference.php
+++ b/eZ/Publish/API/Repository/Values/User/UserReference.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/UserRoleAssignment.php
+++ b/eZ/Publish/API/Repository/Values/User/UserRoleAssignment.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/UserTokenUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/UserTokenUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/User/UserUpdateStruct.php
+++ b/eZ/Publish/API/Repository/Values/User/UserUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/UserPreference/UserPreference.php
+++ b/eZ/Publish/API/Repository/Values/UserPreference/UserPreference.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/UserPreference/UserPreferenceList.php
+++ b/eZ/Publish/API/Repository/Values/UserPreference/UserPreferenceList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/UserPreference/UserPreferenceSetStruct.php
+++ b/eZ/Publish/API/Repository/Values/UserPreference/UserPreferenceSetStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/API/Repository/Values/ValueObject.php
+++ b/eZ/Publish/API/Repository/Values/ValueObject.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\API\Repository\Values;

--- a/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
+++ b/eZ/Publish/Core/Base/Container/ApiLoader/RepositoryFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Container\ApiLoader;

--- a/eZ/Publish/Core/Base/Container/Compiler/AbstractFieldTypeBasedPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/AbstractFieldTypeBasedPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Container\Compiler;

--- a/eZ/Publish/Core/Base/Container/Compiler/FieldTypeRegistryPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/FieldTypeRegistryPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Container\Compiler;

--- a/eZ/Publish/Core/Base/Container/Compiler/GenericFieldTypeConverterPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/GenericFieldTypeConverterPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Base/Container/Compiler/Persistence/FieldTypeRegistryPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Persistence/FieldTypeRegistryPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Container\Compiler\Persistence;

--- a/eZ/Publish/Core/Base/Container/Compiler/Search/AggregateFieldValueMapperPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Search/AggregateFieldValueMapperPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Container\Compiler\Search;

--- a/eZ/Publish/Core/Base/Container/Compiler/Search/FieldRegistryPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Search/FieldRegistryPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Container\Compiler\Search;

--- a/eZ/Publish/Core/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Search/Legacy/CriteriaConverterPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Container\Compiler\Search\Legacy;

--- a/eZ/Publish/Core/Base/Container/Compiler/Search/Legacy/CriterionFieldValueHandlerRegistryPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Search/Legacy/CriterionFieldValueHandlerRegistryPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Container\Compiler\Search\Legacy;

--- a/eZ/Publish/Core/Base/Container/Compiler/Search/Legacy/SortClauseConverterPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Search/Legacy/SortClauseConverterPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Container\Compiler\Search\Legacy;

--- a/eZ/Publish/Core/Base/Container/Compiler/Storage/ExternalStorageRegistryPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Storage/ExternalStorageRegistryPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Container\Compiler\Storage;

--- a/eZ/Publish/Core/Base/Container/Compiler/Storage/Legacy/FieldValueConverterRegistryPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Storage/Legacy/FieldValueConverterRegistryPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Container\Compiler\Storage\Legacy;

--- a/eZ/Publish/Core/Base/Container/Compiler/Storage/Legacy/RoleLimitationConverterPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Storage/Legacy/RoleLimitationConverterPass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Container\Compiler\Storage\Legacy;

--- a/eZ/Publish/Core/Base/Container/Compiler/TaggedServiceIdsIterator/BackwardCompatibleIterator.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/TaggedServiceIdsIterator/BackwardCompatibleIterator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Base/Exceptions/BadStateException.php
+++ b/eZ/Publish/Core/Base/Exceptions/BadStateException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/ContentTypeFieldDefinitionValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/ContentTypeFieldDefinitionValidationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/ContentTypeValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/ContentTypeValidationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/ContentValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/ContentValidationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/DatabaseException.php
+++ b/eZ/Publish/Core/Base/Exceptions/DatabaseException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Base/Exceptions/ForbiddenException.php
+++ b/eZ/Publish/Core/Base/Exceptions/ForbiddenException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/Httpable.php
+++ b/eZ/Publish/Core/Base/Exceptions/Httpable.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/InvalidArgumentException.php
+++ b/eZ/Publish/Core/Base/Exceptions/InvalidArgumentException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/InvalidArgumentType.php
+++ b/eZ/Publish/Core/Base/Exceptions/InvalidArgumentType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/InvalidArgumentValue.php
+++ b/eZ/Publish/Core/Base/Exceptions/InvalidArgumentValue.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/LimitationValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/LimitationValidationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/MissingClass.php
+++ b/eZ/Publish/Core/Base/Exceptions/MissingClass.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/MissingUserFieldTypeException.php
+++ b/eZ/Publish/Core/Base/Exceptions/MissingUserFieldTypeException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/NotFound/FieldTypeNotFoundException.php
+++ b/eZ/Publish/Core/Base/Exceptions/NotFound/FieldTypeNotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions\NotFound;

--- a/eZ/Publish/Core/Base/Exceptions/NotFound/LimitationNotFoundException.php
+++ b/eZ/Publish/Core/Base/Exceptions/NotFound/LimitationNotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions\NotFound;

--- a/eZ/Publish/Core/Base/Exceptions/NotFoundException.php
+++ b/eZ/Publish/Core/Base/Exceptions/NotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/UnauthorizedException.php
+++ b/eZ/Publish/Core/Base/Exceptions/UnauthorizedException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Exceptions;

--- a/eZ/Publish/Core/Base/Exceptions/UserPasswordValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/UserPasswordValidationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Base/ServiceContainer.php
+++ b/eZ/Publish/Core/Base/ServiceContainer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/FieldTypeRegistryPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/FieldTypeRegistryPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Tests\Container\Compiler;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/GenericFieldTypeConverterPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/GenericFieldTypeConverterPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/FieldTypeRegistryPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/FieldTypeRegistryPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Search;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/Legacy/CriteriaConverterPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/Legacy/CriteriaConverterPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Search\Legacy;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/Legacy/CriterionFieldValueHandlerRegistryPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/Legacy/CriterionFieldValueHandlerRegistryPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Search\Legacy;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/Legacy/SortClauseConverterPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Search/Legacy/SortClauseConverterPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Search\Legacy;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/ExternalStorageRegistryPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/ExternalStorageRegistryPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Storage;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/Legacy/FieldValueConverterRegistryPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/Legacy/FieldValueConverterRegistryPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Storage\Legacy;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/Legacy/RoleLimitationConverterPassTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Storage/Legacy/RoleLimitationConverterPassTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Storage\Legacy;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Stubs/GatewayBasedStorageHandler.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Stubs/GatewayBasedStorageHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Tests\Container\Compiler\Stubs;

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/Stubs/GenericFieldType.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/Stubs/GenericFieldType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/TaggedServiceIdsIterator/BackwardCompatibleIteratorTest.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/TaggedServiceIdsIterator/BackwardCompatibleIteratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Base/Tests/Container/Compiler/TaggedServiceIdsIterator/DeprecationErrorCollector.php
+++ b/eZ/Publish/Core/Base/Tests/Container/Compiler/TaggedServiceIdsIterator/DeprecationErrorCollector.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Base/Tests/PHPUnit5CompatTrait.php
+++ b/eZ/Publish/Core/Base/Tests/PHPUnit5CompatTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Tests;

--- a/eZ/Publish/Core/Base/Translatable.php
+++ b/eZ/Publish/Core/Base/Translatable.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base;

--- a/eZ/Publish/Core/Base/TranslatableBase.php
+++ b/eZ/Publish/Core/Base/TranslatableBase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base;

--- a/eZ/Publish/Core/Base/Utils/DeprecationWarner.php
+++ b/eZ/Publish/Core/Base/Utils/DeprecationWarner.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Utils;

--- a/eZ/Publish/Core/Base/Utils/DeprecationWarnerInterface.php
+++ b/eZ/Publish/Core/Base/Utils/DeprecationWarnerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Base\Utils;

--- a/eZ/Publish/Core/Event/BookmarkService.php
+++ b/eZ/Publish/Core/Event/BookmarkService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/ContentService.php
+++ b/eZ/Publish/Core/Event/ContentService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/ContentTypeService.php
+++ b/eZ/Publish/Core/Event/ContentTypeService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/FieldTypeService.php
+++ b/eZ/Publish/Core/Event/FieldTypeService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/LanguageService.php
+++ b/eZ/Publish/Core/Event/LanguageService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/LocationService.php
+++ b/eZ/Publish/Core/Event/LocationService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/NotificationService.php
+++ b/eZ/Publish/Core/Event/NotificationService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/ObjectStateService.php
+++ b/eZ/Publish/Core/Event/ObjectStateService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/Repository.php
+++ b/eZ/Publish/Core/Event/Repository.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/RoleService.php
+++ b/eZ/Publish/Core/Event/RoleService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/SearchService.php
+++ b/eZ/Publish/Core/Event/SearchService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/SectionService.php
+++ b/eZ/Publish/Core/Event/SectionService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/Tests/AbstractServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/AbstractServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/BookmarkServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/BookmarkServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/ContentServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/ContentTypeServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/LanguageServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/LanguageServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/LocationServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/NotificationServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/NotificationServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/ObjectStateServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/RoleServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/RoleServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/SectionServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/SectionServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/TrashServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/TrashServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/URLAliasServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/URLServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/URLServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/URLWildcardServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/URLWildcardServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/UserPreferenceServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/UserPreferenceServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/Event/Tests/UserServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Event\Tests;

--- a/eZ/Publish/Core/Event/TranslationService.php
+++ b/eZ/Publish/Core/Event/TranslationService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/TrashService.php
+++ b/eZ/Publish/Core/Event/TrashService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/URLAliasService.php
+++ b/eZ/Publish/Core/Event/URLAliasService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/URLService.php
+++ b/eZ/Publish/Core/Event/URLService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/URLWildcardService.php
+++ b/eZ/Publish/Core/Event/URLWildcardService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/UserPreferenceService.php
+++ b/eZ/Publish/Core/Event/UserPreferenceService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Event/UserService.php
+++ b/eZ/Publish/Core/Event/UserService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/Author/Author.php
+++ b/eZ/Publish/Core/FieldType/Author/Author.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Author;

--- a/eZ/Publish/Core/FieldType/Author/AuthorCollection.php
+++ b/eZ/Publish/Core/FieldType/Author/AuthorCollection.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Author;

--- a/eZ/Publish/Core/FieldType/Author/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Author/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Author;

--- a/eZ/Publish/Core/FieldType/Author/Type.php
+++ b/eZ/Publish/Core/FieldType/Author/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Author;

--- a/eZ/Publish/Core/FieldType/Author/Value.php
+++ b/eZ/Publish/Core/FieldType/Author/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Author;

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\BinaryBase;

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage;

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/DoctrineStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway;

--- a/eZ/Publish/Core/FieldType/BinaryBase/PathGenerator/LegacyPathGenerator.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/PathGenerator/LegacyPathGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\BinaryBase\PathGenerator;

--- a/eZ/Publish/Core/FieldType/BinaryBase/Type.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\BinaryBase;

--- a/eZ/Publish/Core/FieldType/BinaryBase/Value.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\BinaryBase;

--- a/eZ/Publish/Core/FieldType/BinaryFile/BinaryFileStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/BinaryFileStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\BinaryFile;

--- a/eZ/Publish/Core/FieldType/BinaryFile/BinaryFileStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/BinaryFileStorage/Gateway/DoctrineStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\BinaryFile\BinaryFileStorage\Gateway;

--- a/eZ/Publish/Core/FieldType/BinaryFile/SearchField.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\BinaryFile;

--- a/eZ/Publish/Core/FieldType/BinaryFile/Type.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\BinaryFile;

--- a/eZ/Publish/Core/FieldType/BinaryFile/Value.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\BinaryFile;

--- a/eZ/Publish/Core/FieldType/Checkbox/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Checkbox/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Checkbox;

--- a/eZ/Publish/Core/FieldType/Checkbox/Type.php
+++ b/eZ/Publish/Core/FieldType/Checkbox/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Checkbox;

--- a/eZ/Publish/Core/FieldType/Checkbox/Value.php
+++ b/eZ/Publish/Core/FieldType/Checkbox/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Checkbox;

--- a/eZ/Publish/Core/FieldType/Country/Exception/InvalidValue.php
+++ b/eZ/Publish/Core/FieldType/Country/Exception/InvalidValue.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Country\Exception;

--- a/eZ/Publish/Core/FieldType/Country/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Country/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Country;

--- a/eZ/Publish/Core/FieldType/Country/Type.php
+++ b/eZ/Publish/Core/FieldType/Country/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Country;

--- a/eZ/Publish/Core/FieldType/Country/Value.php
+++ b/eZ/Publish/Core/FieldType/Country/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Country;

--- a/eZ/Publish/Core/FieldType/Date/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Date/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Date;

--- a/eZ/Publish/Core/FieldType/Date/Type.php
+++ b/eZ/Publish/Core/FieldType/Date/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Date;

--- a/eZ/Publish/Core/FieldType/Date/Value.php
+++ b/eZ/Publish/Core/FieldType/Date/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Date;

--- a/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\DateAndTime;

--- a/eZ/Publish/Core/FieldType/DateAndTime/Type.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\DateAndTime;

--- a/eZ/Publish/Core/FieldType/DateAndTime/Value.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\DateAndTime;

--- a/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\EmailAddress;

--- a/eZ/Publish/Core/FieldType/EmailAddress/Type.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\EmailAddress;

--- a/eZ/Publish/Core/FieldType/EmailAddress/Value.php
+++ b/eZ/Publish/Core/FieldType/EmailAddress/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\EmailAddress;

--- a/eZ/Publish/Core/FieldType/FieldSettings.php
+++ b/eZ/Publish/Core/FieldType/FieldSettings.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType;

--- a/eZ/Publish/Core/FieldType/FieldType.php
+++ b/eZ/Publish/Core/FieldType/FieldType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType;

--- a/eZ/Publish/Core/FieldType/FieldTypeRegistry.php
+++ b/eZ/Publish/Core/FieldType/FieldTypeRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType;

--- a/eZ/Publish/Core/FieldType/Float/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Float/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Float;

--- a/eZ/Publish/Core/FieldType/Float/Type.php
+++ b/eZ/Publish/Core/FieldType/Float/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Float;

--- a/eZ/Publish/Core/FieldType/Float/Value.php
+++ b/eZ/Publish/Core/FieldType/Float/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Float;

--- a/eZ/Publish/Core/FieldType/GatewayBasedStorage.php
+++ b/eZ/Publish/Core/FieldType/GatewayBasedStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType;

--- a/eZ/Publish/Core/FieldType/Handler.php
+++ b/eZ/Publish/Core/FieldType/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType;

--- a/eZ/Publish/Core/FieldType/ISBN/SearchField.php
+++ b/eZ/Publish/Core/FieldType/ISBN/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\ISBN;

--- a/eZ/Publish/Core/FieldType/ISBN/Type.php
+++ b/eZ/Publish/Core/FieldType/ISBN/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\ISBN;

--- a/eZ/Publish/Core/FieldType/ISBN/Value.php
+++ b/eZ/Publish/Core/FieldType/ISBN/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\ISBN;

--- a/eZ/Publish/Core/FieldType/Image/AliasCleanerInterface.php
+++ b/eZ/Publish/Core/FieldType/Image/AliasCleanerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Image;

--- a/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
+++ b/eZ/Publish/Core/FieldType/Image/IO/Legacy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Image\IO;

--- a/eZ/Publish/Core/FieldType/Image/IO/OptionsProvider.php
+++ b/eZ/Publish/Core/FieldType/Image/IO/OptionsProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Image\IO;

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Image;

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Image\ImageStorage;

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway/DoctrineStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Image\ImageStorage\Gateway;

--- a/eZ/Publish/Core/FieldType/Image/ImageThumbnailProxyStrategy.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageThumbnailProxyStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/Image/NullAliasCleaner.php
+++ b/eZ/Publish/Core/FieldType/Image/NullAliasCleaner.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/Image/PathGenerator.php
+++ b/eZ/Publish/Core/FieldType/Image/PathGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Image;

--- a/eZ/Publish/Core/FieldType/Image/PathGenerator/LegacyPathGenerator.php
+++ b/eZ/Publish/Core/FieldType/Image/PathGenerator/LegacyPathGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Image\PathGenerator;

--- a/eZ/Publish/Core/FieldType/Image/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Image/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Image;

--- a/eZ/Publish/Core/FieldType/Image/Type.php
+++ b/eZ/Publish/Core/FieldType/Image/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Image;

--- a/eZ/Publish/Core/FieldType/Image/Value.php
+++ b/eZ/Publish/Core/FieldType/Image/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Image;

--- a/eZ/Publish/Core/FieldType/ImageAsset/AssetMapper.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/AssetMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/ImageAsset/ImageAssetThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/ImageAssetThumbnailStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/ImageAsset/SearchField.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/ImageAsset/Type.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/ImageAsset/Value.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/Integer/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Integer/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Integer;

--- a/eZ/Publish/Core/FieldType/Integer/Type.php
+++ b/eZ/Publish/Core/FieldType/Integer/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Integer;

--- a/eZ/Publish/Core/FieldType/Integer/Value.php
+++ b/eZ/Publish/Core/FieldType/Integer/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Integer;

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Keyword;

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Keyword\KeywordStorage;

--- a/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Keyword/KeywordStorage/Gateway/DoctrineStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Keyword\KeywordStorage\Gateway;

--- a/eZ/Publish/Core/FieldType/Keyword/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Keyword/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Keyword;

--- a/eZ/Publish/Core/FieldType/Keyword/Type.php
+++ b/eZ/Publish/Core/FieldType/Keyword/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Keyword;

--- a/eZ/Publish/Core/FieldType/Keyword/Value.php
+++ b/eZ/Publish/Core/FieldType/Keyword/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Keyword;

--- a/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\MapLocation;

--- a/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage;

--- a/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway/DoctrineStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\MapLocation\MapLocationStorage\Gateway;

--- a/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\MapLocation;

--- a/eZ/Publish/Core/FieldType/MapLocation/Type.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\MapLocation;

--- a/eZ/Publish/Core/FieldType/MapLocation/Value.php
+++ b/eZ/Publish/Core/FieldType/MapLocation/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\MapLocation;

--- a/eZ/Publish/Core/FieldType/Media/MediaStorage.php
+++ b/eZ/Publish/Core/FieldType/Media/MediaStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Media;

--- a/eZ/Publish/Core/FieldType/Media/MediaStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Media/MediaStorage/Gateway/DoctrineStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Media\MediaStorage\Gateway;

--- a/eZ/Publish/Core/FieldType/Media/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Media/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Media;

--- a/eZ/Publish/Core/FieldType/Media/Type.php
+++ b/eZ/Publish/Core/FieldType/Media/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Media;

--- a/eZ/Publish/Core/FieldType/Media/Value.php
+++ b/eZ/Publish/Core/FieldType/Media/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Media;

--- a/eZ/Publish/Core/FieldType/Null/Type.php
+++ b/eZ/Publish/Core/FieldType/Null/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Null;

--- a/eZ/Publish/Core/FieldType/Null/Value.php
+++ b/eZ/Publish/Core/FieldType/Null/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Null;

--- a/eZ/Publish/Core/FieldType/NullStorage.php
+++ b/eZ/Publish/Core/FieldType/NullStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType;

--- a/eZ/Publish/Core/FieldType/Relation/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Relation/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Relation;

--- a/eZ/Publish/Core/FieldType/Relation/Type.php
+++ b/eZ/Publish/Core/FieldType/Relation/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Relation;

--- a/eZ/Publish/Core/FieldType/Relation/Value.php
+++ b/eZ/Publish/Core/FieldType/Relation/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Relation;

--- a/eZ/Publish/Core/FieldType/RelationList/SearchField.php
+++ b/eZ/Publish/Core/FieldType/RelationList/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\RelationList;

--- a/eZ/Publish/Core/FieldType/RelationList/Type.php
+++ b/eZ/Publish/Core/FieldType/RelationList/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\RelationList;

--- a/eZ/Publish/Core/FieldType/RelationList/Value.php
+++ b/eZ/Publish/Core/FieldType/RelationList/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\RelationList;

--- a/eZ/Publish/Core/FieldType/Selection/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Selection/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Selection;

--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Selection;

--- a/eZ/Publish/Core/FieldType/Selection/Value.php
+++ b/eZ/Publish/Core/FieldType/Selection/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Selection;

--- a/eZ/Publish/Core/FieldType/StorageGateway.php
+++ b/eZ/Publish/Core/FieldType/StorageGateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType;

--- a/eZ/Publish/Core/FieldType/Tests/APIFieldTypeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/APIFieldTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/AuthorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/AuthorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/BinaryBaseTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/BinaryBaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/BinaryFileTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/BinaryFileTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/CheckboxTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/CheckboxTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/CountryTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/CountryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/DateTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/EmailAddressTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/EmailAddressTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/EmailAddressValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/EmailAddressValidatorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/FieldTypeMockTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FieldTypeMockTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/FieldTypeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FieldTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/FileSizeValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FileSizeValidatorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/FloatTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FloatTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/FloatValueValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FloatValueValidatorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/Generic/ValueSerializer/SymfonySerializerAdapterTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Generic/ValueSerializer/SymfonySerializerAdapterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/Tests/ISBNTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ISBNTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/Image/IO/LegacyTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Image/IO/LegacyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests\Image\IO;

--- a/eZ/Publish/Core/FieldType/Tests/Image/PathGenerator/LegacyPathGeneratorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Image/PathGenerator/LegacyPathGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests\Image\PathGenerator;

--- a/eZ/Publish/Core/FieldType/Tests/ImageAsset/AssetMapperTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAsset/AssetMapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/Tests/ImageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/IntegerTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/IntegerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/IntegerValueValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/IntegerValueValidatorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/Integration/BaseCoreFieldTypeIntegrationTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Integration/BaseCoreFieldTypeIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests\Integration;

--- a/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/UserDoctrineStorageGatewayTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/UserDoctrineStorageGatewayTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/UserStorageGatewayTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Integration/User/UserStorage/UserStorageGatewayTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests\Integration\User\UserStorage;

--- a/eZ/Publish/Core/FieldType/Tests/KeywordTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/KeywordTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/MapLocationTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/MapLocationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/MediaTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/MediaTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/RelationListTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RelationListTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/RelationTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RelationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/StringLengthValidatorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/StringLengthValidatorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/TextBlockTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextBlockTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/TimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TimeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests\Url\Gateway;

--- a/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/UrlStorageTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests\Url;

--- a/eZ/Publish/Core/FieldType/Tests/UrlTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/UrlTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/Tests/UserTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/UserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Tests;

--- a/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\TextBlock;

--- a/eZ/Publish/Core/FieldType/TextBlock/Type.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\TextBlock;

--- a/eZ/Publish/Core/FieldType/TextBlock/Value.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\TextBlock;

--- a/eZ/Publish/Core/FieldType/TextLine/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextLine/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\TextLine;

--- a/eZ/Publish/Core/FieldType/TextLine/Type.php
+++ b/eZ/Publish/Core/FieldType/TextLine/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\TextLine;

--- a/eZ/Publish/Core/FieldType/TextLine/Value.php
+++ b/eZ/Publish/Core/FieldType/TextLine/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\TextLine;

--- a/eZ/Publish/Core/FieldType/Time/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Time/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Time;

--- a/eZ/Publish/Core/FieldType/Time/Type.php
+++ b/eZ/Publish/Core/FieldType/Time/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Time;

--- a/eZ/Publish/Core/FieldType/Time/Value.php
+++ b/eZ/Publish/Core/FieldType/Time/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Time;

--- a/eZ/Publish/Core/FieldType/Unindexed.php
+++ b/eZ/Publish/Core/FieldType/Unindexed.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType;

--- a/eZ/Publish/Core/FieldType/Url/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Url/SearchField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Url;

--- a/eZ/Publish/Core/FieldType/Url/Type.php
+++ b/eZ/Publish/Core/FieldType/Url/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Url;

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Url;

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Url\UrlStorage;

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;

--- a/eZ/Publish/Core/FieldType/Url/Value.php
+++ b/eZ/Publish/Core/FieldType/Url/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Url;

--- a/eZ/Publish/Core/FieldType/User/Type.php
+++ b/eZ/Publish/Core/FieldType/User/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\User;

--- a/eZ/Publish/Core/FieldType/User/UserStorage.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\User;

--- a/eZ/Publish/Core/FieldType/User/UserStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\User\UserStorage;

--- a/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/User/UserStorage/Gateway/DoctrineStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\User\UserStorage\Gateway;

--- a/eZ/Publish/Core/FieldType/User/Value.php
+++ b/eZ/Publish/Core/FieldType/User/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\User;

--- a/eZ/Publish/Core/FieldType/ValidationError.php
+++ b/eZ/Publish/Core/FieldType/ValidationError.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType;

--- a/eZ/Publish/Core/FieldType/Validator.php
+++ b/eZ/Publish/Core/FieldType/Validator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType;

--- a/eZ/Publish/Core/FieldType/Validator/EmailAddressValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/EmailAddressValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Validator;

--- a/eZ/Publish/Core/FieldType/Validator/FileExtensionBlackListValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/FileExtensionBlackListValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Validator;

--- a/eZ/Publish/Core/FieldType/Validator/FileSizeValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/FileSizeValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Validator;

--- a/eZ/Publish/Core/FieldType/Validator/FloatValueValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/FloatValueValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Validator;

--- a/eZ/Publish/Core/FieldType/Validator/ImageValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/ImageValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Validator;

--- a/eZ/Publish/Core/FieldType/Validator/IntegerValueValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/IntegerValueValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Validator;

--- a/eZ/Publish/Core/FieldType/Validator/StringLengthValidator.php
+++ b/eZ/Publish/Core/FieldType/Validator/StringLengthValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType\Validator;

--- a/eZ/Publish/Core/FieldType/Value.php
+++ b/eZ/Publish/Core/FieldType/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\FieldType;

--- a/eZ/Publish/Core/FieldType/ValueSerializer/SymfonySerializerAdapter.php
+++ b/eZ/Publish/Core/FieldType/ValueSerializer/SymfonySerializerAdapter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Helper/ContentInfoLocationLoader.php
+++ b/eZ/Publish/Core/Helper/ContentInfoLocationLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper;

--- a/eZ/Publish/Core/Helper/ContentInfoLocationLoader/SudoMainLocationLoader.php
+++ b/eZ/Publish/Core/Helper/ContentInfoLocationLoader/SudoMainLocationLoader.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper\ContentInfoLocationLoader;

--- a/eZ/Publish/Core/Helper/ContentPreviewHelper.php
+++ b/eZ/Publish/Core/Helper/ContentPreviewHelper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper;

--- a/eZ/Publish/Core/Helper/FieldHelper.php
+++ b/eZ/Publish/Core/Helper/FieldHelper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper;

--- a/eZ/Publish/Core/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsList.php
+++ b/eZ/Publish/Core/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper\FieldsGroups;

--- a/eZ/Publish/Core/Helper/FieldsGroups/FieldsGroupsList.php
+++ b/eZ/Publish/Core/Helper/FieldsGroups/FieldsGroupsList.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper\FieldsGroups;

--- a/eZ/Publish/Core/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactory.php
+++ b/eZ/Publish/Core/Helper/FieldsGroups/RepositoryConfigFieldsGroupsListFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper\FieldsGroups;

--- a/eZ/Publish/Core/Helper/PreviewLocationProvider.php
+++ b/eZ/Publish/Core/Helper/PreviewLocationProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper;

--- a/eZ/Publish/Core/Helper/Tests/ContentInfoLocationLoader/SudoMainLocationLoaderTest.php
+++ b/eZ/Publish/Core/Helper/Tests/ContentInfoLocationLoader/SudoMainLocationLoaderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper\Tests\ContentInfoLocationLoader;

--- a/eZ/Publish/Core/Helper/Tests/ContentPreviewHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/ContentPreviewHelperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper\Tests;

--- a/eZ/Publish/Core/Helper/Tests/FieldHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/FieldHelperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper\Tests;

--- a/eZ/Publish/Core/Helper/Tests/FieldsGroups/ArrayTranslatorFieldsGroupsListTest.php
+++ b/eZ/Publish/Core/Helper/Tests/FieldsGroups/ArrayTranslatorFieldsGroupsListTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper\Tests\FieldsGroups;

--- a/eZ/Publish/Core/Helper/Tests/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
+++ b/eZ/Publish/Core/Helper/Tests/FieldsGroups/RepositoryConfigFieldsGroupsListFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper\Tests\FieldsGroups;

--- a/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
+++ b/eZ/Publish/Core/Helper/Tests/PreviewLocationProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper\Tests;

--- a/eZ/Publish/Core/Helper/Tests/TranslationHelperTest.php
+++ b/eZ/Publish/Core/Helper/Tests/TranslationHelperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper\Tests;

--- a/eZ/Publish/Core/Helper/TranslationHelper.php
+++ b/eZ/Publish/Core/Helper/TranslationHelper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Helper;

--- a/eZ/Publish/Core/IO/Adapter/LocalAdapter.php
+++ b/eZ/Publish/Core/IO/Adapter/LocalAdapter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/IO/ConfigScopeChangeAwareIOService.php
+++ b/eZ/Publish/Core/IO/ConfigScopeChangeAwareIOService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/IO/Exception/BinaryFileNotFoundException.php
+++ b/eZ/Publish/Core/IO/Exception/BinaryFileNotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Exception;

--- a/eZ/Publish/Core/IO/Exception/IOException.php
+++ b/eZ/Publish/Core/IO/Exception/IOException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Exception;

--- a/eZ/Publish/Core/IO/Exception/InvalidBinaryAbsolutePathException.php
+++ b/eZ/Publish/Core/IO/Exception/InvalidBinaryAbsolutePathException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Exception;

--- a/eZ/Publish/Core/IO/Exception/InvalidBinaryFileIdException.php
+++ b/eZ/Publish/Core/IO/Exception/InvalidBinaryFileIdException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Exception;

--- a/eZ/Publish/Core/IO/Exception/InvalidBinaryPrefixException.php
+++ b/eZ/Publish/Core/IO/Exception/InvalidBinaryPrefixException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Exception;

--- a/eZ/Publish/Core/IO/IOBinarydataHandler.php
+++ b/eZ/Publish/Core/IO/IOBinarydataHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO;

--- a/eZ/Publish/Core/IO/IOBinarydataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOBinarydataHandler/Flysystem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\IOBinarydataHandler;

--- a/eZ/Publish/Core/IO/IOBinarydataHandler/SiteAccessDependentBinaryDataHandler.php
+++ b/eZ/Publish/Core/IO/IOBinarydataHandler/SiteAccessDependentBinaryDataHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\IOBinarydataHandler;

--- a/eZ/Publish/Core/IO/IOBinarydataHandler/SiteAccessDependentMetadataHandler.php
+++ b/eZ/Publish/Core/IO/IOBinarydataHandler/SiteAccessDependentMetadataHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\IOBinarydataHandler;

--- a/eZ/Publish/Core/IO/IOConfigProvider.php
+++ b/eZ/Publish/Core/IO/IOConfigProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/IO/IOMetadataHandler.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO;

--- a/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\IOMetadataHandler;

--- a/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\IOMetadataHandler;

--- a/eZ/Publish/Core/IO/IOService.php
+++ b/eZ/Publish/Core/IO/IOService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO;

--- a/eZ/Publish/Core/IO/IOServiceInterface.php
+++ b/eZ/Publish/Core/IO/IOServiceInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO;

--- a/eZ/Publish/Core/IO/MetadataHandler.php
+++ b/eZ/Publish/Core/IO/MetadataHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO;

--- a/eZ/Publish/Core/IO/MetadataHandler/ImageSize.php
+++ b/eZ/Publish/Core/IO/MetadataHandler/ImageSize.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\MetadataHandler;

--- a/eZ/Publish/Core/IO/MimeTypeDetector/FileInfo.php
+++ b/eZ/Publish/Core/IO/MimeTypeDetector/FileInfo.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\MimeTypeDetector;

--- a/eZ/Publish/Core/IO/Tests/ConfigScopeChangeAwareIOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/ConfigScopeChangeAwareIOServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/IO/Tests/IOBinarydataHandler/FlysystemTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOBinarydataHandler/FlysystemTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Tests\IOBinarydataHandler;

--- a/eZ/Publish/Core/IO/Tests/IOMetadataHandler/FlysystemTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOMetadataHandler/FlysystemTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Tests\IOMetadataHandler;

--- a/eZ/Publish/Core/IO/Tests/IOMetadataHandler/LegacyDFSClusterTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOMetadataHandler/LegacyDFSClusterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Tests\IOMetadataHandler;

--- a/eZ/Publish/Core/IO/Tests/IOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/IOServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Tests;

--- a/eZ/Publish/Core/IO/Tests/MetadataHandler/ImageSizeTest.php
+++ b/eZ/Publish/Core/IO/Tests/MetadataHandler/ImageSizeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Tests\MetadataHandler;

--- a/eZ/Publish/Core/IO/Tests/MimeTypeDetector/FileInfoTest.php
+++ b/eZ/Publish/Core/IO/Tests/MimeTypeDetector/FileInfoTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Tests\MimeTypeDetector;

--- a/eZ/Publish/Core/IO/Tests/TolerantIOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/TolerantIOServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Tests;

--- a/eZ/Publish/Core/IO/Tests/UrlDecorator/AbsolutePrefixTest.php
+++ b/eZ/Publish/Core/IO/Tests/UrlDecorator/AbsolutePrefixTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/IO/Tests/UrlDecorator/PrefixTest.php
+++ b/eZ/Publish/Core/IO/Tests/UrlDecorator/PrefixTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/IO/Tests/UrlRedecoratorTest.php
+++ b/eZ/Publish/Core/IO/Tests/UrlRedecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Tests;

--- a/eZ/Publish/Core/IO/TolerantIOService.php
+++ b/eZ/Publish/Core/IO/TolerantIOService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO;

--- a/eZ/Publish/Core/IO/UrlDecorator.php
+++ b/eZ/Publish/Core/IO/UrlDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO;

--- a/eZ/Publish/Core/IO/UrlDecorator/AbsolutePrefix.php
+++ b/eZ/Publish/Core/IO/UrlDecorator/AbsolutePrefix.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/IO/UrlDecorator/Prefix.php
+++ b/eZ/Publish/Core/IO/UrlDecorator/Prefix.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/IO/UrlRedecorator.php
+++ b/eZ/Publish/Core/IO/UrlRedecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO;

--- a/eZ/Publish/Core/IO/UrlRedecoratorInterface.php
+++ b/eZ/Publish/Core/IO/UrlRedecoratorInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO;

--- a/eZ/Publish/Core/IO/Values/BinaryFile.php
+++ b/eZ/Publish/Core/IO/Values/BinaryFile.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Values;

--- a/eZ/Publish/Core/IO/Values/BinaryFileCreateStruct.php
+++ b/eZ/Publish/Core/IO/Values/BinaryFileCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Values;

--- a/eZ/Publish/Core/IO/Values/MissingBinaryFile.php
+++ b/eZ/Publish/Core/IO/Values/MissingBinaryFile.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\IO\Values;

--- a/eZ/Publish/Core/Limitation/AbstractPersistenceLimitationType.php
+++ b/eZ/Publish/Core/Limitation/AbstractPersistenceLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/BlockingLimitationType.php
+++ b/eZ/Publish/Core/Limitation/BlockingLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/ContentTypeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ContentTypeLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/LanguageLimitation/ContentTranslationEvaluator.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitation/ContentTranslationEvaluator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Limitation/LanguageLimitation/NewDraftEvaluator.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitation/NewDraftEvaluator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Limitation/LanguageLimitation/VersionPublishingEvaluator.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitation/VersionPublishingEvaluator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Limitation/LanguageLimitation/VersionTargetEvaluator.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitation/VersionTargetEvaluator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Limitation/LanguageLimitation/VersionTranslationUpdateEvaluator.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitation/VersionTranslationUpdateEvaluator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Limitation/LanguageLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Limitation/LocationLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LocationLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/NewObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/NewObjectStateLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/NewSectionLimitationType.php
+++ b/eZ/Publish/Core/Limitation/NewSectionLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/OwnerLimitationType.php
+++ b/eZ/Publish/Core/Limitation/OwnerLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/ParentContentTypeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ParentContentTypeLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/ParentDepthLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ParentDepthLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/ParentOwnerLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ParentOwnerLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/ParentUserGroupLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ParentUserGroupLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/SectionLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SectionLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/SiteAccessLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SiteAccessLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/StatusLimitationType.php
+++ b/eZ/Publish/Core/Limitation/StatusLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/Limitation/TargetOnlyLimitationType.php
+++ b/eZ/Publish/Core/Limitation/TargetOnlyLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Limitation/Tests/Base.php
+++ b/eZ/Publish/Core/Limitation/Tests/Base.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation\Tests;

--- a/eZ/Publish/Core/Limitation/Tests/BlockingLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/BlockingLimitationTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation\Tests;

--- a/eZ/Publish/Core/Limitation/Tests/ContentTypeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ContentTypeLimitationTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation\Tests;

--- a/eZ/Publish/Core/Limitation/Tests/LocationLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/LocationLimitationTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation\Tests;

--- a/eZ/Publish/Core/Limitation/Tests/NewObjectStateLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/NewObjectStateLimitationTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation\Tests;

--- a/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ObjectStateLimitationTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation\Tests;

--- a/eZ/Publish/Core/Limitation/Tests/ParentContentTypeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ParentContentTypeLimitationTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation\Tests;

--- a/eZ/Publish/Core/Limitation/Tests/ParentDepthLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/ParentDepthLimitationTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation\Tests;

--- a/eZ/Publish/Core/Limitation/Tests/SectionLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SectionLimitationTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation\Tests;

--- a/eZ/Publish/Core/Limitation/Tests/SiteAccessLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SiteAccessLimitationTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation\Tests;

--- a/eZ/Publish/Core/Limitation/Tests/StatusLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/StatusLimitationTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation\Tests;

--- a/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
+++ b/eZ/Publish/Core/Limitation/Tests/SubtreeLimitationTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation\Tests;

--- a/eZ/Publish/Core/Limitation/UserGroupLimitationType.php
+++ b/eZ/Publish/Core/Limitation/UserGroupLimitationType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Limitation;

--- a/eZ/Publish/Core/MVC/ConfigResolverInterface.php
+++ b/eZ/Publish/Core/MVC/ConfigResolverInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC;

--- a/eZ/Publish/Core/MVC/Exception/HiddenLocationException.php
+++ b/eZ/Publish/Core/MVC/Exception/HiddenLocationException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Exception;

--- a/eZ/Publish/Core/MVC/Exception/InvalidSiteAccessException.php
+++ b/eZ/Publish/Core/MVC/Exception/InvalidSiteAccessException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Exception;

--- a/eZ/Publish/Core/MVC/Exception/NoViewTemplateException.php
+++ b/eZ/Publish/Core/MVC/Exception/NoViewTemplateException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Exception;

--- a/eZ/Publish/Core/MVC/Exception/ParameterNotFoundException.php
+++ b/eZ/Publish/Core/MVC/Exception/ParameterNotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Exception;

--- a/eZ/Publish/Core/MVC/Exception/SourceImageNotFoundException.php
+++ b/eZ/Publish/Core/MVC/Exception/SourceImageNotFoundException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Exception;

--- a/eZ/Publish/Core/MVC/RepositoryAware.php
+++ b/eZ/Publish/Core/MVC/RepositoryAware.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC;

--- a/eZ/Publish/Core/MVC/RepositoryAwareInterface.php
+++ b/eZ/Publish/Core/MVC/RepositoryAwareInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC;

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/AbstractPropertyWhitelistNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/AbstractPropertyWhitelistNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/CompoundMatcherNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/CompoundMatcherNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Component\Serializer;

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/HostElementNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/HostElementNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/HostTextNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/HostTextNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/MapNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/MapNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/RegexHostNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/RegexHostNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/RegexNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/RegexNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/RegexURINormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/RegexURINormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SerializerTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/SimplifiedRequestNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Component\Serializer;

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/URIElementNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/URIElementNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/URITextNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/URITextNormalizer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/CompoundMatcherNormalizerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/CompoundMatcherNormalizerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/HostElementNormalizerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/HostElementNormalizerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/HostTextNormalizerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/HostTextNormalizerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/MapNormalizerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/MapNormalizerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/RegexHostNormalizerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/RegexHostNormalizerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/RegexNormalizerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/RegexNormalizerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/RegexURINormalizerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/RegexURINormalizerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/SimplifiedRequestNormalizerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/SimplifiedRequestNormalizerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Component\Tests\Serializer;

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/Stubs/CompoundStub.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/Stubs/CompoundStub.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/Stubs/MatcherStub.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/Stubs/MatcherStub.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/Stubs/RegexMatcher.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/Stubs/RegexMatcher.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/Stubs/SerializerStub.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/Stubs/SerializerStub.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Component\Tests\Serializer\Stubs;

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/URIElementNormalizerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/URIElementNormalizerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/URITextNormalizerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/URITextNormalizerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/ConfigDumperInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/ConfigDumperInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony;

--- a/eZ/Publish/Core/MVC/Symfony/Configuration/VersatileScopeInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Configuration/VersatileScopeInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Configuration;

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadRedirectionController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadRedirectionController.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/QueryController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/QueryController.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/ViewController.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Content;

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Controller.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Controller.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller;

--- a/eZ/Publish/Core/MVC/Symfony/Controller/QueryRenderController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/QueryRenderController.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Controller/SecurityController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/SecurityController.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller;

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Tests\Controller\Content;

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/ControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/ControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Controller\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/QueryRenderControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/QueryRenderControllerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Event/APIContentExceptionEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/APIContentExceptionEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event;

--- a/eZ/Publish/Core/MVC/Symfony/Event/ConsoleInitEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/ConsoleInitEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event;

--- a/eZ/Publish/Core/MVC/Symfony/Event/ContentCacheClearEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/ContentCacheClearEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event;

--- a/eZ/Publish/Core/MVC/Symfony/Event/InteractiveLoginEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/InteractiveLoginEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Event/PostSiteAccessMatchEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/PostSiteAccessMatchEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event;

--- a/eZ/Publish/Core/MVC/Symfony/Event/PreContentViewEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/PreContentViewEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event;

--- a/eZ/Publish/Core/MVC/Symfony/Event/ResolveRenderOptionsEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/ResolveRenderOptionsEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Event/RouteReferenceGenerationEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/RouteReferenceGenerationEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event;

--- a/eZ/Publish/Core/MVC/Symfony/Event/ScopeChangeEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/ScopeChangeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event;

--- a/eZ/Publish/Core/MVC/Symfony/Event/Tests/ContentCacheClearEventTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/Tests/ContentCacheClearEventTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Event/Tests/InteractiveLoginEventTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/Tests/InteractiveLoginEventTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Event/Tests/RouteReferenceGenerationEventTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/Tests/RouteReferenceGenerationEventTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Event/Tests/ScopeChangeEventTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Event/Tests/ScopeChangeEventTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Event\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/ContentViewTwigVariablesSubscriber.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/ContentViewTwigVariablesSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/LanguageSwitchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/LanguageSwitchListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\EventListener;

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\EventListener;

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/ContentViewTwigVariablesSubscriberTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/ContentViewTwigVariablesSubscriberTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/LanguageSwitchListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/LanguageSwitchListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\EventListener\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\EventListener\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/ExpressionLanguage/ExpressionLanguage.php
+++ b/eZ/Publish/Core/MVC/Symfony/ExpressionLanguage/ExpressionLanguage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/ExpressionLanguage/TwigVariableProviderExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/ExpressionLanguage/TwigVariableProviderExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/BinaryBase/ContentDownloadUrlGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/BinaryBase/ContentDownloadUrlGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\BinaryBase;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/ImageAsset/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/ImageAsset/ParameterProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Relation/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Relation/ParameterProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\Relation;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/RelationList/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/RelationList/ParameterProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\RelationList;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/ImageAsset/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/ImageAsset/ParameterProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/Relation/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/Relation/ParameterProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\Relation;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RelationList/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/RelationList/ParameterProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\RelationList;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/User/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/User/ParameterProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/View/ParameterProvider/LocaleParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/View/ParameterProvider/LocaleParameterProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\View\ParameterProvider;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/View/ParameterProviderRegistryTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/View/ParameterProviderRegistryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\Tests\View;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/User/ParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/User/ParameterProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/View/ParameterProvider/LocaleParameterProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/View/ParameterProvider/LocaleParameterProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\View\ParameterProvider;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/View/ParameterProviderInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/View/ParameterProviderInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\View;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/View/ParameterProviderRegistry.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/View/ParameterProviderRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\View;

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/View/ParameterProviderRegistryInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/View/ParameterProviderRegistryInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\View;

--- a/eZ/Publish/Core/MVC/Symfony/Locale/LocaleConverter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Locale/LocaleConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Locale;

--- a/eZ/Publish/Core/MVC/Symfony/Locale/LocaleConverterInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Locale/LocaleConverterInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Locale;

--- a/eZ/Publish/Core/MVC/Symfony/Locale/Tests/LocaleConverterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Locale/Tests/LocaleConverterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Locale\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Locale/Tests/UserLanguagePreferenceProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Locale/Tests/UserLanguagePreferenceProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Locale/UserLanguagePreferenceProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Locale/UserLanguagePreferenceProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Locale/UserLanguagePreferenceProviderInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Locale/UserLanguagePreferenceProviderInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/MVCEvents.php
+++ b/eZ/Publish/Core/MVC/Symfony/MVCEvents.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ClassNameMatcherFactory.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ClassNameMatcherFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ConfigurableMatcherFactoryInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ConfigurableMatcherFactoryInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Depth.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Depth.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Content.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Content.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/ContentType.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/ContentType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/ContentTypeGroup.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/ContentTypeGroup.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Location.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Location.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/LocationRemote.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/LocationRemote.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/ParentContentType.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/ParentContentType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/ParentLocation.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/ParentLocation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Remote.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Remote.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Section.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/Section.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Identifier/ContentType.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Identifier/ContentType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Identifier;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Identifier/ParentContentType.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Identifier/ParentContentType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Identifier;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Identifier/Section.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Identifier/Section.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased\Identifier;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/MatcherInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/MatcherInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/MultipleValued.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/MultipleValued.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/UrlAlias.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/UrlAlias.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\ContentBased;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/DynamicallyConfiguredMatcherFactoryDecorator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/DynamicallyConfiguredMatcherFactoryDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/MatcherFactoryInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/MatcherFactoryInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/AbstractMatcherFactoryTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/AbstractMatcherFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/BaseTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/BaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/DepthTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/DepthTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTypeGroupTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTypeGroupTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ContentTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/LocationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/LocationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ParentContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ParentContentTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ParentLocationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/ParentLocationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/RemoteTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/RemoteTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/SectionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Id/SectionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Id;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/ContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/ContentTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Identifier;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/ParentContentTypeTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/ParentContentTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased\Identifier;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/SectionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/Identifier/SectionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/MultipleValuedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/MultipleValuedTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/UrlAliasTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/UrlAliasTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests\ContentBased;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBasedMatcherFactoryTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBasedMatcherFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/DynamicallyConfiguredMatcherFactoryDecoratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/Tests/DynamicallyConfiguredMatcherFactoryDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ViewMatcherInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ViewMatcherInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/RequestStackAware.php
+++ b/eZ/Publish/Core/MVC/Symfony/RequestStackAware.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/ChainRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/ChainRouter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/RouteReferenceGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/RouteReferenceGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Generator;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/RouteReferenceGeneratorInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/RouteReferenceGeneratorInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Generator;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Generator;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/RouteReference.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/RouteReference.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/SimplifiedRequest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/SimplifiedRequest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/GeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/GeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/RouteReferenceGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/RouteReferenceGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/RouteReferenceTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/RouteReferenceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/SimplifiedRequestTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/SimplifiedRequestTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasRouterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasRouterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/UrlAliasRouter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing;

--- a/eZ/Publish/Core/MVC/Symfony/Routing/UrlWildcardRouter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/UrlWildcardRouter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Routing;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/AnonymousAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/AnonymousAuthenticationProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Authentication;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/AuthenticatorInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/AuthenticatorInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Authentication;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/DefaultAuthenticationSuccessHandler.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/DefaultAuthenticationSuccessHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Authentication;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RememberMeRepositoryAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RememberMeRepositoryAuthenticationProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Authentication;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Authentication;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authorization/Attribute.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authorization/Attribute.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Authorization;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authorization/Voter/CoreVoter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authorization/Voter/CoreVoter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Authorization\Voter;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authorization/Voter/ValueObjectVoter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authorization/Voter/ValueObjectVoter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Authorization\Voter;

--- a/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/EventListener/SecurityListener.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\EventListener;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Exception/UnauthorizedSiteAccessException.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Exception/UnauthorizedSiteAccessException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Exception;

--- a/eZ/Publish/Core/MVC/Symfony/Security/HttpUtils.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/HttpUtils.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security;

--- a/eZ/Publish/Core/MVC/Symfony/Security/InteractiveLoginToken.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/InteractiveLoginToken.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security;

--- a/eZ/Publish/Core/MVC/Symfony/Security/ReferenceUserInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/ReferenceUserInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/AnonymousAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/AnonymousAuthenticationProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/DefaultAuthenticationSuccessHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RememberMeRepositoryAuthenticationProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RepositoryAuthenticationProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Authentication/RepositoryAuthenticationProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Authentication;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/EventListener/SecurityListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/EventListener/SecurityListenerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\EventListener;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/HttpUtilsTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/HttpUtilsTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/InteractiveLoginTokenTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/InteractiveLoginTokenTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/EmailProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/EmailProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/UsernameProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/User/UsernameProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserCheckerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserCheckerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserWrappedTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Voter/CoreVoterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Voter/CoreVoterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Voter;

--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/Voter/ValueObjectVoterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/Voter/ValueObjectVoterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\Tests\Voter;

--- a/eZ/Publish/Core/MVC/Symfony/Security/User.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Security/User/APIUserProviderInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User/APIUserProviderInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security\User;

--- a/eZ/Publish/Core/MVC/Symfony/Security/User/BaseProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User/BaseProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Security/User/EmailProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User/EmailProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Security/User/UsernameProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/User/UsernameProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserChecker.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserChecker.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security;

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserWrapped.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Security;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound/LogicalAnd.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound/LogicalAnd.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound/LogicalOr.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound/LogicalOr.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Compound;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/CompoundInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/CompoundInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/HostElement.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/HostElement.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/HostText.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/HostText.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/Host.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/Host.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/Port.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/Port.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Map;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex/Host.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex/Host.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Regex;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex/URI.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex/URI.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher\Regex;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIElement.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIText.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/URIText.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Matcher;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/MatcherBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/MatcherBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/MatcherBuilderInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/MatcherBuilderInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Provider/ChainSiteAccessProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Provider/ChainSiteAccessProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Provider/StaticSiteAccessProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Provider/StaticSiteAccessProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Router.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Router.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessAware.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessAware.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessProviderInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessProviderInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessRouterInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessRouterInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessService.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessServiceInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/SiteAccessServiceInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundAndTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundAndTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\Compound;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundOrTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Compound/CompoundOrTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests\Compound;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/MatcherSerializationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/MatcherSerializationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Provider/ChainSiteAccessProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/Provider/ChainSiteAccessProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterBaseTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterBaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostElementTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostElementTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostPortURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostPortURITest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostRegexTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostRegexTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostTextTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostTextTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterMapURITest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterPortHostURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterPortHostURITest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterSpecialPortsTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterSpecialPortsTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElementTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElementTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIRegexTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIRegexTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURITextTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURITextTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/SiteAccessServiceTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/SiteAccessServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/SiteAccessSetting.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/SiteAccessSetting.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/URILexer.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/URILexer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/VersatileMatcher.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/VersatileMatcher.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\SiteAccess;

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccessGroup.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccessGroup.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Exception/InvalidResponseException.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Exception/InvalidResponseException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Exception/MissingFieldBlockException.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Exception/MissingFieldBlockException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Exception;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/FieldBlockRendererInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/FieldBlockRendererInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/GlobalHelper.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/GlobalHelper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderContentStrategy.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderContentStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderLocationStrategy.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderLocationStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderOptions.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderOptions.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/RenderStrategy.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/RenderStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/BaseRenderStrategyTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/BaseRenderStrategyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/GlobalHelperTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/GlobalHelperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderContentStrategyTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderContentStrategyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderLocationStrategyTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderLocationStrategyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderOptionsTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderOptionsTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderStrategyTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/RenderStrategyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/ContentExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/ContentExtensionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/DataAttributesExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/DataAttributesExtensionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FieldRenderingExtensionIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSizeExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSizeExtensionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/QueryRenderingExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/QueryRenderingExtensionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/RoutingExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/RoutingExtensionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/ResourceProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/ResourceProviderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ContentExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/CoreExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/CoreExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/DataAttributesExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/DataAttributesExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/FieldRenderingExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/FileSizeExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/FileSizeExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ImageExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/ImageExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/QueryRenderingExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/QueryRenderingExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RenderContentExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RenderExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RenderExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RenderLocationExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RenderLocationExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RoutingExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/RoutingExtension.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/FieldBlockRenderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/FieldBlockRenderer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/ResourceProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/ResourceProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/ResourceProviderInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/ResourceProviderInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/Translation/CatalogueMapperFileWriter.php
+++ b/eZ/Publish/Core/MVC/Symfony/Translation/CatalogueMapperFileWriter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Translation;

--- a/eZ/Publish/Core/MVC/Symfony/Translation/ExceptionMessageTemplateFileVisitor.php
+++ b/eZ/Publish/Core/MVC/Symfony/Translation/ExceptionMessageTemplateFileVisitor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Translation;

--- a/eZ/Publish/Core/MVC/Symfony/Translation/FieldTypesTranslationExtractor.php
+++ b/eZ/Publish/Core/MVC/Symfony/Translation/FieldTypesTranslationExtractor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Translation;

--- a/eZ/Publish/Core/MVC/Symfony/Translation/TranslatableExceptionsFileVisitor.php
+++ b/eZ/Publish/Core/MVC/Symfony/Translation/TranslatableExceptionsFileVisitor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Translation;

--- a/eZ/Publish/Core/MVC/Symfony/Translation/ValidationErrorFileVisitor.php
+++ b/eZ/Publish/Core/MVC/Symfony/Translation/ValidationErrorFileVisitor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\Translation;

--- a/eZ/Publish/Core/MVC/Symfony/View/BaseView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/BaseView.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Builder;

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ParametersFilter/RequestAttributes.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ParametersFilter/RequestAttributes.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Builder\ParametersFilter;

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/Registry/ControllerMatch.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/Registry/ControllerMatch.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Builder\Registry;

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ViewBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Builder;

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ViewBuilderRegistry.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ViewBuilderRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Builder;

--- a/eZ/Publish/Core/MVC/Symfony/View/CachableView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/CachableView.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/Configurator.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Configurator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/Configurator/ViewProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Configurator/ViewProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Configurator;

--- a/eZ/Publish/Core/MVC/Symfony/View/ContentValueView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ContentValueView.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/ContentView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ContentView.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/CustomLocationControllerChecker.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/CustomLocationControllerChecker.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/EmbedView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/EmbedView.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/Event/FilterViewBuilderParametersEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Event/FilterViewBuilderParametersEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Event;

--- a/eZ/Publish/Core/MVC/Symfony/View/Event/FilterViewParametersEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Event/FilterViewParametersEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Event;

--- a/eZ/Publish/Core/MVC/Symfony/View/GenericVariableProviderRegistry.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/GenericVariableProviderRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/View/LocationValueView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/LocationValueView.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/LoginFormView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/LoginFormView.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/View/Manager.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Manager.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/CustomParameters.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/CustomParameters.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;

--- a/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/EmbedObjectParameters.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/EmbedObjectParameters.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;

--- a/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/EventDispatcherInjector.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/EventDispatcherInjector.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;

--- a/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/NoLayout.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/NoLayout.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;

--- a/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/ValueObjectsIds.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/ValueObjectsIds.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;

--- a/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/ViewbaseLayout.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ParametersInjector/ViewbaseLayout.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\ParametersInjector;

--- a/eZ/Publish/Core/MVC/Symfony/View/Provider/Configured.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Provider/Configured.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Provider;

--- a/eZ/Publish/Core/MVC/Symfony/View/Provider/Content.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Provider/Content.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Provider;

--- a/eZ/Publish/Core/MVC/Symfony/View/Provider/Location.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Provider/Location.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Provider;

--- a/eZ/Publish/Core/MVC/Symfony/View/Provider/Registry.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Provider/Registry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Provider;

--- a/eZ/Publish/Core/MVC/Symfony/View/QueryView.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/QueryView.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/View/Renderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Renderer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/Renderer/TemplateRenderer.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Renderer/TemplateRenderer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Renderer;

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/AbstractViewTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/AbstractViewTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/ContentViewBuilderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/ContentViewBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ContentViewTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/LoginFormViewTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/LoginFormViewTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Renderer/TemplateRendererTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Renderer/TemplateRendererTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Tests\Renderer;

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/VariableProviderRegistryTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/VariableProviderRegistryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/ViewManagerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View\Tests;

--- a/eZ/Publish/Core/MVC/Symfony/View/VariableProviderRegistry.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/VariableProviderRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/MVC/Symfony/View/View.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/View.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/ViewEvents.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ViewEvents.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/ViewManagerInterface.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ViewManagerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/MVC/Symfony/View/ViewProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/ViewProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\MVC\Symfony\View;

--- a/eZ/Publish/Core/Notification/Renderer/NotificationRenderer.php
+++ b/eZ/Publish/Core/Notification/Renderer/NotificationRenderer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Notification/Renderer/Registry.php
+++ b/eZ/Publish/Core/Notification/Renderer/Registry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Pagination/Pagerfanta/AdapterFactory/SearchHitAdapterFactory.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/AdapterFactory/SearchHitAdapterFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Pagination/Pagerfanta/AdapterFactory/SearchHitAdapterFactoryInterface.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/AdapterFactory/SearchHitAdapterFactoryInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Pagination/Pagerfanta/ContentSearchAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/ContentSearchAdapter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Pagination\Pagerfanta;

--- a/eZ/Publish/Core/Pagination/Pagerfanta/ContentSearchHitAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/ContentSearchHitAdapter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Pagination\Pagerfanta;

--- a/eZ/Publish/Core/Pagination/Pagerfanta/LocationSearchAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/LocationSearchAdapter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Pagination\Pagerfanta;

--- a/eZ/Publish/Core/Pagination/Pagerfanta/LocationSearchHitAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/LocationSearchHitAdapter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Pagination\Pagerfanta;

--- a/eZ/Publish/Core/Pagination/Tests/AdapterFactory/SearchHitAdapterFactoryTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/AdapterFactory/SearchHitAdapterFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Pagination/Tests/ContentSearchAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/ContentSearchAdapterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Pagination\Tests;

--- a/eZ/Publish/Core/Pagination/Tests/ContentSearchHitAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/ContentSearchHitAdapterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Pagination\Tests;

--- a/eZ/Publish/Core/Pagination/Tests/LocationSearchAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/LocationSearchAdapterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Pagination\Tests;

--- a/eZ/Publish/Core/Pagination/Tests/LocationSearchHitAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/LocationSearchHitAdapterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Pagination\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/AbstractHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryPersistenceHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryPersistenceHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/Adapter/TransactionAwareAdapterInterface.php
+++ b/eZ/Publish/Core/Persistence/Cache/Adapter/TransactionAwareAdapterInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/Adapter/TransactionalInMemoryCacheAdapter.php
+++ b/eZ/Publish/Core/Persistence/Cache/Adapter/TransactionalInMemoryCacheAdapter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/BookmarkHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/BookmarkHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/ContentLanguageHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentLanguageHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentTypeHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/Handler.php
+++ b/eZ/Publish/Core/Persistence/Cache/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/InMemory/InMemoryCache.php
+++ b/eZ/Publish/Core/Persistence/Cache/InMemory/InMemoryCache.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/NotificationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/NotificationHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ObjectStateHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/PersistenceLogger.php
+++ b/eZ/Publish/Core/Persistence/Cache/PersistenceLogger.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/SectionHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/SectionHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractCacheHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractCacheHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractInMemoryCacheHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractInMemoryCacheHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/Adapter/InMemoryClearingProxyAdapterTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/Adapter/InMemoryClearingProxyAdapterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/BookmarkHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/BookmarkHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentLanguageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentLanguageHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentTypeHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/InMemory/InMemoryCacheTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/InMemory/InMemoryCacheTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/NotificationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/NotificationHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ObjectStateHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ObjectStateHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/PersistenceHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/PersistenceHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/PersistenceLoggerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/PersistenceLoggerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/SectionHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/SectionHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/TransactionHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/TransactionHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/URLHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/URLHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlWildcardHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlWildcardHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache\Tests;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UserPreferenceHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UserPreferenceHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Cache/TransactionHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TransactionHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/URLHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/URLHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/UrlWildcardHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlWildcardHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/UserHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Cache;

--- a/eZ/Publish/Core/Persistence/Cache/UserPreferenceHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UserPreferenceHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/FieldType.php
+++ b/eZ/Publish/Core/Persistence/FieldType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence;

--- a/eZ/Publish/Core/Persistence/FieldTypeRegistry.php
+++ b/eZ/Publish/Core/Persistence/FieldTypeRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence;

--- a/eZ/Publish/Core/Persistence/Legacy/Bookmark/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Bookmark/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Bookmark/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Bookmark/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Bookmark/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Bookmark/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Bookmark/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Bookmark/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Bookmark/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Bookmark/Mapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/AuthorConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/AuthorConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/BinaryFileConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/BinaryFileConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/CheckboxConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/CheckboxConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/CountryConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/CountryConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateAndTimeConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/DateConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/EmailAddressConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/EmailAddressConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Exception/NotFound.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/Exception/NotFound.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter\Exception;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/FloatConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/FloatConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ISBNConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ISBNConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageAssetConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageAssetConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/IntegerConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/IntegerConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/KeywordConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/KeywordConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/MapLocationConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/MapLocationConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/MediaConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/MediaConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/NullConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/NullConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationListConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/RelationListConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SerializableConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SerializableConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TextBlockConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TextBlockConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TextLineConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TextLineConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TimeConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/TimeConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/UrlConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/UrlConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/UserConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/UserConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/ConverterRegistry.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/ConverterRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase/QueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/DoctrineDatabase/QueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Gateway\DoctrineDatabase;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/CachingHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/CachingHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Language;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Language;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/Mapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Language;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Language/MaskGenerator.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Language/MaskGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Language;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Location;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Location;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Mapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Location;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Location\Trash;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/MultilingualStorageFieldDefinition.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/MultilingualStorageFieldDefinition.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\ObjectState;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/ObjectState/Mapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\ObjectState;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Section/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Section/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Section;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/StorageFieldDefinition.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/StorageFieldDefinition.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/StorageFieldValue.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/StorageFieldValue.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/StorageHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/StorageHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/StorageRegistry.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/StorageRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/AddField.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/AddField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater\Action;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/RemoveField.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/ContentUpdater/Action/RemoveField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type\ContentUpdater\Action;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Mapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/MemoryCachingHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\Type;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Update/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Update/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Update/Handler/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Update/Handler/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/DTO/SwappedLocationProperties.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/DTO/SwappedLocationProperties.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\DTO;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/DTO/UrlAliasForSwappedLocation.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/DTO/UrlAliasForSwappedLocation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias\DTO;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Mapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/SlugConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/SlugConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlAlias;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlWildcard/Mapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Content\UrlWildcard;

--- a/eZ/Publish/Core/Persistence/Legacy/Exception/GroupNotEmpty.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Exception/GroupNotEmpty.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Exception;

--- a/eZ/Publish/Core/Persistence/Legacy/Exception/RemoveLastGroupFromType.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Exception/RemoveLastGroupFromType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Exception;

--- a/eZ/Publish/Core/Persistence/Legacy/Exception/RoleNotFound.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Exception/RoleNotFound.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Exception;

--- a/eZ/Publish/Core/Persistence/Legacy/Exception/StorageNotFound.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Exception/StorageNotFound.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Exception;

--- a/eZ/Publish/Core/Persistence/Legacy/Exception/TypeGroupNotFound.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Exception/TypeGroupNotFound.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Exception;

--- a/eZ/Publish/Core/Persistence/Legacy/Exception/TypeNotFound.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Exception/TypeNotFound.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Exception;

--- a/eZ/Publish/Core/Persistence/Legacy/Exception/TypeStillHasContent.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Exception/TypeStillHasContent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Exception;

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ContentIdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ContentIdQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/DateMetadataQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/DateMetadataQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/LanguageCodeQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/LanguageCodeQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ObjectStateIdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ObjectStateIdQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ObjectStateIdentifierQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ObjectStateIdentifierQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/RemoteIdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/RemoteIdQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Section/IdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Section/IdQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Section/IdentifierQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Section/IdentifierQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/SiblingQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/SiblingQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Type/BaseQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Type/BaseQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Type/GroupIdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Type/GroupIdQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Type/IdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Type/IdQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Type/IdentifierQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Type/IdentifierQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/AncestorQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/AncestorQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BaseLocationCriterionQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/BaseLocationCriterionQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/DepthQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/DepthQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/IdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/IdQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/IsMainLocationQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/IsMainLocationQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/ParentLocationIdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/ParentLocationIdQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/PriorityQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/PriorityQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/RemoteIdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/RemoteIdQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/SubtreeQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/SubtreeQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/VisibilityQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Location/VisibilityQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/LogicalAndQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/LogicalAndQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/LogicalNotQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/LogicalNotQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/LogicalOrQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/LogicalOrQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/MatchAllQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/MatchAllQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/MatchNoneQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/MatchNoneQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/BaseUserCriterionQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/BaseUserCriterionQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/IsUserBasedQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/IsUserBasedQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/IsUserEnabledQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/IsUserEnabledQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/Metadata/GroupQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/Metadata/GroupQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/Metadata/ModifierQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/Metadata/ModifierQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/Metadata/OwnerQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/Metadata/OwnerQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/UserEmailQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/UserEmailQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/UserIdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/UserIdQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/UserLoginQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/User/UserLoginQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionVisitor.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionVisitor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Content/Doctrine/DoctrineGateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Content/Doctrine/DoctrineGateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Content/GatewayDataMapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Content/GatewayDataMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Content/Mapper/DoctrineGatewayDataMapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Content/Mapper/DoctrineGatewayDataMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Location/Doctrine/DoctrineGateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Location/Doctrine/DoctrineGateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Handler/ContentFilteringHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Handler/ContentFilteringHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Handler/LocationFilteringHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Handler/LocationFilteringHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/DateModifiedSortClauseQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/DateModifiedSortClauseQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/DatePublishedSortClauseQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/DatePublishedSortClauseQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/IdSortClauseQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/IdSortClauseQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/NameSortClauseQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/NameSortClauseQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/SectionIdentifierSortClauseQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/SectionIdentifierSortClauseQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/SectionNameSortClauseQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Content/SectionNameSortClauseQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/BaseLocationSortClauseQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/BaseLocationSortClauseQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/DepthQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/DepthQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/IdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/IdQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/PathQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/PathQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/PriorityQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/PriorityQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/VisibilityQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseQueryBuilder/Location/VisibilityQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseVisitor.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/SortClauseVisitor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Notification/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Notification/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Notification/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Notification/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Notification/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Notification/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Notification/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Notification/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Notification/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Notification/Mapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/SharedGateway/DatabasePlatform/FallbackGateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/SharedGateway/DatabasePlatform/FallbackGateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/SharedGateway/DatabasePlatform/SqliteGateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/SharedGateway/DatabasePlatform/SqliteGateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/SharedGateway/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/SharedGateway/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/SharedGateway/GatewayFactory.php
+++ b/eZ/Publish/Core/Persistence/Legacy/SharedGateway/GatewayFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Bookmark/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Bookmark/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Bookmark/HandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Bookmark/HandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Bookmark/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Bookmark/MapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Bookmark/_fixtures/bookmarks.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Bookmark/_fixtures/bookmarks.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 return [

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/AuthorTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/AuthorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/CheckboxTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/CheckboxTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/CountryTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/CountryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateAndTimeTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateAndTimeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/DateTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/ISBNTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/ISBNTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/KeywordTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/KeywordTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/MediaTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/MediaTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationListTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationListTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/RelationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SelectionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SerializableConverterTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/SerializableConverterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/TextBlockTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/TextBlockTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/TextLineTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/TextLineTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/TimeTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/TimeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/UrlTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValue/Converter/UrlTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\FieldValue\Converter;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValueConverterRegistryTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldValueConverterRegistryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Gateway/RandomSortClauseHandlerFactoryTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Gateway/RandomSortClauseHandlerFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/CachingLanguageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/CachingLanguageHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Language;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Language\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/LanguageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/LanguageHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Language;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/MapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Language;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/MaskGeneratorTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Language/MaskGeneratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Language;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LanguageAwareTestCase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LanguageAwareTestCase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LanguageHandlerMock.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LanguageHandlerMock.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Location\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTrashTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTrashTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Location\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/MapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Location;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/TrashHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Location;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/MapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\ObjectState\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/MapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\ObjectState;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/ObjectStateHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ObjectState/ObjectStateHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\ObjectState;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Section/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Section/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Section\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Section/SectionHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Section/SectionHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Section;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageRegistryTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/StorageRegistryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/TreeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/TreeHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentTypeHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/AddFieldTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/AddFieldTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type\ContentUpdater\Action;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/RemoveFieldTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdater/Action/RemoveFieldTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type\ContentUpdater\Action;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdaterTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/ContentUpdaterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/MapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Update/Handler/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Type/Update/Handler/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\Type\Update\Handler;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlAlias\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/SlugConverterTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/SlugConverterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlAlias;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlAlias;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasMapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlAlias/UrlAliasMapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlAlias;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/UrlWildcardHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/UrlWildcardHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/UrlWildcardMapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/UrlWildcard/UrlWildcardMapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\Content\UrlWildcard;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/BaseCriterionVisitorQueryBuilderTestCase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/BaseCriterionVisitorQueryBuilderTestCase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/Content/LanguageCodeQueryBuilderQueryBuilderTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/Content/LanguageCodeQueryBuilderQueryBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/Content/Type/ContentTypeGroupIdQueryBuilderTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/Content/Type/ContentTypeGroupIdQueryBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/Content/Type/ContentTypeQueryBuildersQueryBuilderTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/Content/Type/ContentTypeQueryBuildersQueryBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/Location/AncestorQueryBuilderTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/Location/AncestorQueryBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/Location/LocationIdQueryBuilderTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/Location/LocationIdQueryBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/Location/ParentLocationQueryBuilderTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/Location/ParentLocationQueryBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/LogicalOperatorQueryBuilderQueryBuilderTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Filter/CriterionQueryBuilder/LogicalOperatorQueryBuilderQueryBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/HandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/HandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Notification/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Notification/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Notification/HandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Notification/HandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Notification/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Notification/MapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Notification/_fixtures/notifications.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Notification/_fixtures/notifications.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 return [

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/SharedGateway/GatewayFactoryTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/SharedGateway/GatewayFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/TestCase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/TestCase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/TransactionHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/TransactionHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/HandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/HandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/MapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriteriaConverterTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriteriaConverterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/CriterionHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/CriterionHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/LogicalAndTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/LogicalAndTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/LogicalNotTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/LogicalNotTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/LogicalOrTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/LogicalOrTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/MatchAllTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/MatchAllTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/MatchNoneTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/MatchNoneTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/PatternTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/PatternTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/ValidityTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/ValidityTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/VisibleOnlyTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Query/CriterionHandler/VisibleOnlyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/Role/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/Role/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/Role/LimitationConverterTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/Role/LimitationConverterTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\User\Role;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/UserHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\Tests\User;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/User/_fixtures/roles.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/User/_fixtures/roles.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 return [

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/UserPreference/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/UserPreference/Gateway/DoctrineDatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/UserPreference/HandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/UserPreference/HandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/UserPreference/MapperTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/UserPreference/MapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/UserPreference/_fixtures/user_preferences.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/UserPreference/_fixtures/user_preferences.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 return [

--- a/eZ/Publish/Core/Persistence/Legacy/TransactionHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/TransactionHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Gateway;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Mapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriteriaConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriteriaConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Base.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Base.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/LogicalAnd.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/LogicalAnd.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/LogicalNot.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/LogicalNot.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/LogicalOr.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/LogicalOr.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/MatchAll.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/MatchAll.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/MatchNone.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/MatchNone.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Pattern.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Pattern.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/SectionId.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/SectionId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/SectionIdentifier.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/SectionIdentifier.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Validity.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/Validity.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/VisibleOnly.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Query/CriterionHandler/VisibleOnly.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/User/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\User;

--- a/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Mapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\User;

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/LimitationConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/LimitationConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\User\Role;

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/LimitationHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/LimitationHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\User\Role;

--- a/eZ/Publish/Core/Persistence/Legacy/User/Role/LimitationHandler/ObjectStateHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/User/Role/LimitationHandler/ObjectStateHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Legacy\User\Role\LimitationHandler;

--- a/eZ/Publish/Core/Persistence/Legacy/UserPreference/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/UserPreference/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/UserPreference/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/UserPreference/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/UserPreference/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/UserPreference/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/UserPreference/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/UserPreference/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Legacy/UserPreference/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/UserPreference/Mapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Tests/DatabaseConnectionFactory.php
+++ b/eZ/Publish/Core/Persistence/Tests/DatabaseConnectionFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Persistence/Tests/FieldTypeRegistryTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/FieldTypeRegistryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Tests;

--- a/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorDefinitionBasedParserTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorDefinitionBasedParserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Tests\TransformationProcessor;

--- a/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorDefinitionBasedTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorDefinitionBasedTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Tests\TransformationProcessor;

--- a/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorPcreCompilerTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorPcreCompilerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Tests\TransformationProcessor;

--- a/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorPreprocessedBasedTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/TransformationProcessor/TransformationProcessorPreprocessedBasedTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\Tests\TransformationProcessor;

--- a/eZ/Publish/Core/Persistence/TransformationProcessor.php
+++ b/eZ/Publish/Core/Persistence/TransformationProcessor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence;

--- a/eZ/Publish/Core/Persistence/TransformationProcessor/DefinitionBased.php
+++ b/eZ/Publish/Core/Persistence/TransformationProcessor/DefinitionBased.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\TransformationProcessor;

--- a/eZ/Publish/Core/Persistence/TransformationProcessor/DefinitionBased/Parser.php
+++ b/eZ/Publish/Core/Persistence/TransformationProcessor/DefinitionBased/Parser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\TransformationProcessor\DefinitionBased;

--- a/eZ/Publish/Core/Persistence/TransformationProcessor/PcreCompiler.php
+++ b/eZ/Publish/Core/Persistence/TransformationProcessor/PcreCompiler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\TransformationProcessor;

--- a/eZ/Publish/Core/Persistence/TransformationProcessor/PreprocessedBased.php
+++ b/eZ/Publish/Core/Persistence/TransformationProcessor/PreprocessedBased.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence\TransformationProcessor;

--- a/eZ/Publish/Core/Persistence/Utf8Converter.php
+++ b/eZ/Publish/Core/Persistence/Utf8Converter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Persistence;

--- a/eZ/Publish/Core/Query/QueryFactory.php
+++ b/eZ/Publish/Core/Query/QueryFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Query/QueryFactoryInterface.php
+++ b/eZ/Publish/Core/Query/QueryFactoryInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Query;

--- a/eZ/Publish/Core/Query/Tests/QueryFactoryTest.php
+++ b/eZ/Publish/Core/Query/Tests/QueryFactoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/ArrayQueryTypeRegistry.php
+++ b/eZ/Publish/Core/QueryType/ArrayQueryTypeRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\QueryType;

--- a/eZ/Publish/Core/QueryType/BuiltIn/AbstractLocationQueryType.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/AbstractLocationQueryType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/AbstractQueryType.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/AbstractQueryType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/AncestorsQueryType.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/AncestorsQueryType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/ChildrenQueryType.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/ChildrenQueryType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/GeoLocationQueryType.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/GeoLocationQueryType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/RelatedToContentQueryType.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/RelatedToContentQueryType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SiblingsQueryType.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SiblingsQueryType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortClausesFactory.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortClausesFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortClausesFactoryInterface.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortClausesFactoryInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Exception/SyntaxErrorException.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Exception/SyntaxErrorException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Exception/UnsupportedSortClauseException.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Exception/UnsupportedSortClauseException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParser/DefaultSortClauseParser.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParser/DefaultSortClauseParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParser/FieldSortClauseParser.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParser/FieldSortClauseParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParser/MapDistanceSortClauseParser.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParser/MapDistanceSortClauseParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParser/RandomSortClauseParser.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParser/RandomSortClauseParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParserDispatcher.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParserDispatcher.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParserInterface.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortClauseParserInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortSpecLexer.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortSpecLexer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortSpecLexerInterface.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortSpecLexerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortSpecParser.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortSpecParser.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortSpecParserInterface.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/SortSpecParserInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortClauseParser/DefaultSortClauseParserTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortClauseParser/DefaultSortClauseParserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortClauseParser/FieldSortClauseParserTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortClauseParser/FieldSortClauseParserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortClauseParser/MapDistanceSortClauseParserTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortClauseParser/MapDistanceSortClauseParserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortClauseParser/RandomSortClauseParserTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortClauseParser/RandomSortClauseParserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortClauseParserDispatcherTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortClauseParserDispatcherTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortSpecLexerStub.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortSpecLexerStub.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortSpecLexerTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortSpecLexerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortSpecParserTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Tests/SortSpecParserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Token.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SortSpec/Token.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/SubtreeQueryType.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/SubtreeQueryType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/Tests/AbstractQueryTypeTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/Tests/AbstractQueryTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/Tests/AncestorsQueryTypeTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/Tests/AncestorsQueryTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/Tests/ChildrenQueryTypeTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/Tests/ChildrenQueryTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/Tests/GeoLocationQueryTypeTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/Tests/GeoLocationQueryTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/Tests/RelatedToContentQueryTypeTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/Tests/RelatedToContentQueryTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/Tests/SiblingsQueryTypeTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/Tests/SiblingsQueryTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/BuiltIn/Tests/SubtreeQueryTest.php
+++ b/eZ/Publish/Core/QueryType/BuiltIn/Tests/SubtreeQueryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/QueryType/ContentViewQueryTypeMapper.php
+++ b/eZ/Publish/Core/QueryType/ContentViewQueryTypeMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\QueryType;

--- a/eZ/Publish/Core/QueryType/OptionsResolverBasedQueryType.php
+++ b/eZ/Publish/Core/QueryType/OptionsResolverBasedQueryType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\QueryType;

--- a/eZ/Publish/Core/QueryType/QueryParameterContentViewQueryTypeMapper.php
+++ b/eZ/Publish/Core/QueryType/QueryParameterContentViewQueryTypeMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\QueryType;

--- a/eZ/Publish/Core/QueryType/QueryType.php
+++ b/eZ/Publish/Core/QueryType/QueryType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\QueryType;

--- a/eZ/Publish/Core/QueryType/QueryTypeRegistry.php
+++ b/eZ/Publish/Core/QueryType/QueryTypeRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\QueryType;

--- a/eZ/Publish/Core/Repository/BookmarkService.php
+++ b/eZ/Publish/Core/Repository/BookmarkService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/EventSubscriber/DeleteUserSubscriber.php
+++ b/eZ/Publish/Core/Repository/EventSubscriber/DeleteUserSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/FieldTypeService.php
+++ b/eZ/Publish/Core/Repository/FieldTypeService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Helper/NameSchemaService.php
+++ b/eZ/Publish/Core/Repository/Helper/NameSchemaService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Helper;

--- a/eZ/Publish/Core/Repository/Helper/RelationProcessor.php
+++ b/eZ/Publish/Core/Repository/Helper/RelationProcessor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Helper;

--- a/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Helper/RoleDomainMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Helper;

--- a/eZ/Publish/Core/Repository/LanguageService.php
+++ b/eZ/Publish/Core/Repository/LanguageService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository;

--- a/eZ/Publish/Core/Repository/LocationResolver/LocationResolver.php
+++ b/eZ/Publish/Core/Repository/LocationResolver/LocationResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/LocationResolver/PermissionAwareLocationResolver.php
+++ b/eZ/Publish/Core/Repository/LocationResolver/PermissionAwareLocationResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Mapper;

--- a/eZ/Publish/Core/Repository/Mapper/ContentMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Mapper/ContentTypeDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentTypeDomainMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Mapper/ProxyAwareDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ProxyAwareDomainMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Mapper/RoleDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/RoleDomainMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Mapper;

--- a/eZ/Publish/Core/Repository/NotificationService.php
+++ b/eZ/Publish/Core/Repository/NotificationService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/ObjectStateService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository;

--- a/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
+++ b/eZ/Publish/Core/Repository/Permission/CachedPermissionService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Permission/LimitationService.php
+++ b/eZ/Publish/Core/Repository/Permission/LimitationService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Permission/PermissionCriterionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionCriterionResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
+++ b/eZ/Publish/Core/Repository/PermissionsCriterionHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository;

--- a/eZ/Publish/Core/Repository/ProxyFactory/ProxyDomainMapper.php
+++ b/eZ/Publish/Core/Repository/ProxyFactory/ProxyDomainMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/ProxyFactory/ProxyDomainMapperFactory.php
+++ b/eZ/Publish/Core/Repository/ProxyFactory/ProxyDomainMapperFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/ProxyFactory/ProxyDomainMapperFactoryInterface.php
+++ b/eZ/Publish/Core/Repository/ProxyFactory/ProxyDomainMapperFactoryInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\ProxyFactory;

--- a/eZ/Publish/Core/Repository/ProxyFactory/ProxyDomainMapperInterface.php
+++ b/eZ/Publish/Core/Repository/ProxyFactory/ProxyDomainMapperInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/ProxyFactory/ProxyGenerator.php
+++ b/eZ/Publish/Core/Repository/ProxyFactory/ProxyGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/ProxyFactory/ProxyGeneratorInterface.php
+++ b/eZ/Publish/Core/Repository/ProxyFactory/ProxyGeneratorInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/RoleService.php
+++ b/eZ/Publish/Core/Repository/RoleService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository;

--- a/eZ/Publish/Core/Repository/SearchService.php
+++ b/eZ/Publish/Core/Repository/SearchService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SectionService.php
+++ b/eZ/Publish/Core/Repository/SectionService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Config/IOConfigResolver.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Config/IOConfigResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Language/AbstractLanguageResolver.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Language/AbstractLanguageResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Language/LanguageResolver.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Language/LanguageResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Language;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/LanguageService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/LanguageService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/NotificationService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/NotificationService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ObjectStateService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Repository.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Repository.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/SearchService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/SearchService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/SectionService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/SectionService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/AbstractServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/AbstractServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Tests;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Tests;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentTypeServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Tests;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/Language/LanguageResolverTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/Language/LanguageResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LanguageServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LanguageServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Tests;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LocationServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Tests;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ObjectStateServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ObjectStateServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Tests;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/SearchServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/SearchServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Tests;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/TrashServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/TrashServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Tests;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/UrlAliasServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/UrlAliasServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Tests;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/UserServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/UserServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\SiteAccessAware\Tests;

--- a/eZ/Publish/Core/Repository/SiteAccessAware/TrashService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/TrashService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/URLAliasService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/URLAliasService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/UserService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/UserService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/Field/ContentFieldStrategy.php
+++ b/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/Field/ContentFieldStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/FirstMatchingFieldStrategy.php
+++ b/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/FirstMatchingFieldStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/StaticStrategy.php
+++ b/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/StaticStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/ThumbnailChainStrategy.php
+++ b/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/ThumbnailChainStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Strategy/ContentValidator/ContentValidatorStrategy.php
+++ b/eZ/Publish/Core/Repository/Strategy/ContentValidator/ContentValidatorStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/ContentThumbnail/ContentFieldStrategyTest.php
+++ b/eZ/Publish/Core/Repository/Tests/ContentThumbnail/ContentFieldStrategyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/ContentThumbnail/StaticStrategyTest.php
+++ b/eZ/Publish/Core/Repository/Tests/ContentThumbnail/StaticStrategyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/ContentThumbnail/ThumbnailChainStrategyTest.php
+++ b/eZ/Publish/Core/Repository/Tests/ContentThumbnail/ThumbnailChainStrategyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/ContentValidator/ContentValidatorStrategyTest.php
+++ b/eZ/Publish/Core/Repository/Tests/ContentValidator/ContentValidatorStrategyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\ContentValidator;

--- a/eZ/Publish/Core/Repository/Tests/Helper/FieldTypeRegistryTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Helper/FieldTypeRegistryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Helper;

--- a/eZ/Publish/Core/Repository/Tests/LocationResolver/PermissionAwareLocationResolverTest.php
+++ b/eZ/Publish/Core/Repository/Tests/LocationResolver/PermissionAwareLocationResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/Permission/CachedPermissionServiceTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Permission/CachedPermissionServiceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/Permission/PermissionCriterionResolverTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Permission/PermissionCriterionResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Permission;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/Base.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/BookmarkTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/BookmarkTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/NameSchemaTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/NameSchemaTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/PermissionsCriterionHandlerTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RelationProcessorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RepositoryTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RepositoryTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/RoleTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/RoleTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/SearchTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlAliasTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlAliasTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlWildcardTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UrlWildcardTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UserPasswordValidatorTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UserPasswordValidatorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UserPreferenceTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UserPreferenceTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/UserTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/UserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ValueStub.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ValueStub.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Service\Mock;

--- a/eZ/Publish/Core/Repository/Tests/Values/Content/ContentInfoTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/Content/ContentInfoTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values\Content;

--- a/eZ/Publish/Core/Repository/Tests/Values/Content/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/Content/ContentTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values\Content;

--- a/eZ/Publish/Core/Repository/Tests/Values/Content/LocationTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/Content/LocationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values\Content;

--- a/eZ/Publish/Core/Repository/Tests/Values/Content/TrashItemTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/Content/TrashItemTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values\Content;

--- a/eZ/Publish/Core/Repository/Tests/Values/Content/VersionInfoTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/Content/VersionInfoTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values\Content;

--- a/eZ/Publish/Core/Repository/Tests/Values/ContentType/ContentTypeDraftTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ContentType/ContentTypeDraftTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values\ContentType;

--- a/eZ/Publish/Core/Repository/Tests/Values/ContentType/ContentTypeTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ContentType/ContentTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/Values/ContentType/FieldDefinitionCollectionTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ContentType/FieldDefinitionCollectionTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Tests/Values/MultiLanguageTestTrait.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/MultiLanguageTestTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values;

--- a/eZ/Publish/Core/Repository/Tests/Values/ObjectState/ObjectStateGroupTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ObjectState/ObjectStateGroupTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values\ObjectState;

--- a/eZ/Publish/Core/Repository/Tests/Values/ObjectState/ObjectStateTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/ObjectState/ObjectStateTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values\ObjectState;

--- a/eZ/Publish/Core/Repository/Tests/Values/User/PolicyTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/User/PolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values\User;

--- a/eZ/Publish/Core/Repository/Tests/Values/User/RoleTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/User/RoleTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values\User;

--- a/eZ/Publish/Core/Repository/Tests/Values/User/UserGroupTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/User/UserGroupTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values\User;

--- a/eZ/Publish/Core/Repository/Tests/Values/User/UserTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Values/User/UserTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Tests\Values\User;

--- a/eZ/Publish/Core/Repository/TrashService.php
+++ b/eZ/Publish/Core/Repository/TrashService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/URLAliasService.php
+++ b/eZ/Publish/Core/Repository/URLAliasService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/URLService.php
+++ b/eZ/Publish/Core/Repository/URLService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/URLWildcardService.php
+++ b/eZ/Publish/Core/Repository/URLWildcardService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/User/Exception/UnsupportedPasswordHashType.php
+++ b/eZ/Publish/Core/Repository/User/Exception/UnsupportedPasswordHashType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/User/PasswordHashService.php
+++ b/eZ/Publish/Core/Repository/User/PasswordHashService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/User/PasswordHashServiceInterface.php
+++ b/eZ/Publish/Core/Repository/User/PasswordHashServiceInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/User/PasswordValidator.php
+++ b/eZ/Publish/Core/Repository/User/PasswordValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/User/PasswordValidatorInterface.php
+++ b/eZ/Publish/Core/Repository/User/PasswordValidatorInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/UserPreferenceService.php
+++ b/eZ/Publish/Core/Repository/UserPreferenceService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Validator/ContentCreateStructValidator.php
+++ b/eZ/Publish/Core/Repository/Validator/ContentCreateStructValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Validator/ContentUpdateStructValidator.php
+++ b/eZ/Publish/Core/Repository/Validator/ContentUpdateStructValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Validator/UserPasswordValidator.php
+++ b/eZ/Publish/Core/Repository/Validator/UserPasswordValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Validator/VersionValidator.php
+++ b/eZ/Publish/Core/Repository/Validator/VersionValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/Content/Content.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Content.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/Content/ContentCreateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/Content/ContentCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/Content/ContentUpdateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/Content/ContentUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/Content/Location.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Location.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/Content/Query/Criterion/PermissionSubtree.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Query/Criterion/PermissionSubtree.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Values\Content\Query\Criterion;

--- a/eZ/Publish/Core/Repository/Values/Content/Relation.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Relation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/Content/TrashItem.php
+++ b/eZ/Publish/Core/Repository/Values/Content/TrashItem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/Content/VersionInfo.php
+++ b/eZ/Publish/Core/Repository/Values/Content/VersionInfo.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Values\Content;

--- a/eZ/Publish/Core/Repository/Values/ContentType/ContentType.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/ContentType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Values\ContentType;

--- a/eZ/Publish/Core/Repository/Values/ContentType/ContentTypeCreateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/ContentTypeCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Values\ContentType;

--- a/eZ/Publish/Core/Repository/Values/ContentType/ContentTypeDraft.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/ContentTypeDraft.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Values\ContentType;

--- a/eZ/Publish/Core/Repository/Values/ContentType/ContentTypeGroup.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/ContentTypeGroup.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Values\ContentType;

--- a/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinition.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinition.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinitionCollection.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/FieldDefinitionCollection.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/ContentType/FieldType.php
+++ b/eZ/Publish/Core/Repository/Values/ContentType/FieldType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/MultiLanguageDescriptionTrait.php
+++ b/eZ/Publish/Core/Repository/Values/MultiLanguageDescriptionTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Values;

--- a/eZ/Publish/Core/Repository/Values/MultiLanguageNameTrait.php
+++ b/eZ/Publish/Core/Repository/Values/MultiLanguageNameTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Values;

--- a/eZ/Publish/Core/Repository/Values/MultiLanguageTrait.php
+++ b/eZ/Publish/Core/Repository/Values/MultiLanguageTrait.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Values;

--- a/eZ/Publish/Core/Repository/Values/ObjectState/ObjectState.php
+++ b/eZ/Publish/Core/Repository/Values/ObjectState/ObjectState.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/ObjectState/ObjectStateGroup.php
+++ b/eZ/Publish/Core/Repository/Values/ObjectState/ObjectStateGroup.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Values\ObjectState;

--- a/eZ/Publish/Core/Repository/Values/User/Policy.php
+++ b/eZ/Publish/Core/Repository/Values/User/Policy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/User/PolicyCreateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/User/PolicyCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/User/PolicyDraft.php
+++ b/eZ/Publish/Core/Repository/Values/User/PolicyDraft.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/User/PolicyUpdateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/User/PolicyUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Values\User;

--- a/eZ/Publish/Core/Repository/Values/User/Role.php
+++ b/eZ/Publish/Core/Repository/Values/User/Role.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Repository\Values\User;

--- a/eZ/Publish/Core/Repository/Values/User/RoleCopyStruct.php
+++ b/eZ/Publish/Core/Repository/Values/User/RoleCopyStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/User/RoleCreateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/User/RoleCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/User/RoleDraft.php
+++ b/eZ/Publish/Core/Repository/Values/User/RoleDraft.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/User/User.php
+++ b/eZ/Publish/Core/Repository/Values/User/User.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/User/UserCreateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/User/UserGroup.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserGroup.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/User/UserGroupCreateStruct.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserGroupCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/User/UserGroupRoleAssignment.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserGroupRoleAssignment.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/User/UserReference.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserReference.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Repository/Values/User/UserRoleAssignment.php
+++ b/eZ/Publish/Core/Repository/Values/User/UserRoleAssignment.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Common/BackgroundIndexer.php
+++ b/eZ/Publish/Core/Search/Common/BackgroundIndexer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common;

--- a/eZ/Publish/Core/Search/Common/BackgroundIndexer/NullIndexer.php
+++ b/eZ/Publish/Core/Search/Common/BackgroundIndexer/NullIndexer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\BackgroundIndexer;

--- a/eZ/Publish/Core/Search/Common/EventSubscriber/AbstractSearchEventSubscriber.php
+++ b/eZ/Publish/Core/Search/Common/EventSubscriber/AbstractSearchEventSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\EventSubscriber;

--- a/eZ/Publish/Core/Search/Common/EventSubscriber/ContentEventSubscriber.php
+++ b/eZ/Publish/Core/Search/Common/EventSubscriber/ContentEventSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\EventSubscriber;

--- a/eZ/Publish/Core/Search/Common/EventSubscriber/LocationEventSubscriber.php
+++ b/eZ/Publish/Core/Search/Common/EventSubscriber/LocationEventSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\EventSubscriber;

--- a/eZ/Publish/Core/Search/Common/EventSubscriber/ObjectStateEventSubscriber.php
+++ b/eZ/Publish/Core/Search/Common/EventSubscriber/ObjectStateEventSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\EventSubscriber;

--- a/eZ/Publish/Core/Search/Common/EventSubscriber/SectionEventSubscriber.php
+++ b/eZ/Publish/Core/Search/Common/EventSubscriber/SectionEventSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\EventSubscriber;

--- a/eZ/Publish/Core/Search/Common/EventSubscriber/TrashEventSubscriber.php
+++ b/eZ/Publish/Core/Search/Common/EventSubscriber/TrashEventSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\EventSubscriber;

--- a/eZ/Publish/Core/Search/Common/EventSubscriber/UserEventSubscriber.php
+++ b/eZ/Publish/Core/Search/Common/EventSubscriber/UserEventSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\EventSubscriber;

--- a/eZ/Publish/Core/Search/Common/FieldNameGenerator.php
+++ b/eZ/Publish/Core/Search/Common/FieldNameGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common;

--- a/eZ/Publish/Core/Search/Common/FieldNameResolver.php
+++ b/eZ/Publish/Core/Search/Common/FieldNameResolver.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common;

--- a/eZ/Publish/Core/Search/Common/FieldRegistry.php
+++ b/eZ/Publish/Core/Search/Common/FieldRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/Aggregate.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/Aggregate.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/BooleanMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/BooleanMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/DateMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/DateMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/DocumentMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/DocumentMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/FloatMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/FloatMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/GeoLocationMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/GeoLocationMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/IdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/IdentifierMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/IntegerMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/IntegerMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleBooleanMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleBooleanMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleIdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleIdentifierMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleIntegerMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleIntegerMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleRemoteIdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleRemoteIdentifierMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleStringMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleStringMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/PriceMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/PriceMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/RemoteIdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/RemoteIdentifierMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/StringMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/StringMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common\FieldValueMapper;

--- a/eZ/Publish/Core/Search/Common/IncrementalIndexer.php
+++ b/eZ/Publish/Core/Search/Common/IncrementalIndexer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common;

--- a/eZ/Publish/Core/Search/Common/Indexer.php
+++ b/eZ/Publish/Core/Search/Common/Indexer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Common;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriteriaConverter.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriteriaConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/CompositeCriterion.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/CompositeCriterion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeGroupId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeGroupId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ContentTypeIdentifier.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/DateMetadata.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/DateMetadata.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/Field.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/Field.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldBase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldBase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldEmpty.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldEmpty.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldRelation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Converter.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Converter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Collection.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Collection.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Composite.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Composite.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Keyword.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Keyword.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Simple.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/Handler/Simple.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue\Handler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/HandlerRegistry.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FieldValue/HandlerRegistry.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler\FieldValue;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/FullText.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/IsUserBased.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/IsUserBased.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/IsUserEnabled.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/IsUserEnabled.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LanguageCode.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LanguageCode.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalAnd.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalAnd.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalNot.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalNot.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalOr.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/LogicalOr.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MapLocationDistance.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MapLocationDistance.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchAll.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchAll.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchNone.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/MatchNone.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ObjectStateId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ObjectStateId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ObjectStateIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/ObjectStateIdentifier.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/RemoteId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/RemoteId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/SectionIdentifier.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserEmail.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserEmail.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserLogin.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserLogin.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserMetadata.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/CriterionHandler/UserMetadata.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseConverter.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseConverter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/AbstractRandom.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/AbstractRandom.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/ContentId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/ContentId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/ContentName.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/ContentName.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/DateModified.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/DateModified.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/DatePublished.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/DatePublished.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Factory/RandomSortClauseHandlerFactory.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Factory/RandomSortClauseHandlerFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Field.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Field.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/MapLocationDistance.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/MapLocationDistance.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Random/MySqlRandom.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Random/MySqlRandom.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Random/PgSqlRandom.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Random/PgSqlRandom.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Random/SqlLiteRandom.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Random/SqlLiteRandom.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/SectionIdentifier.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/SectionIdentifier.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/SectionName.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/SectionName.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Trash/ContentTypeName.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Trash/ContentTypeName.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Trash/DateTrashed.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Trash/DateTrashed.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Trash/UserLogin.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Common/Gateway/SortClauseHandler/Trash/UserLogin.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Legacy/Content/FullTextData.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FullTextData.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content;

--- a/eZ/Publish/Core/Search/Legacy/Content/FullTextValue.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/FullTextValue.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content;

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content;

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Ancestor.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Ancestor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationRemoteId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/LocationRemoteId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/ParentLocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/ParentLocationId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/PermissionSubtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/PermissionSubtree.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Subtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Subtree.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Visibility.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/CriterionHandler/Visibility.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway;

--- a/eZ/Publish/Core/Search/Legacy/Content/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Gateway;

--- a/eZ/Publish/Core/Search/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content;

--- a/eZ/Publish/Core/Search/Legacy/Content/Indexer.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Indexer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Ancestor.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Ancestor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Depth.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Depth.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/IsMainLocation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/IsMainLocation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Priority.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Location/Priority.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler\Location;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationRemoteId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/LocationRemoteId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/ParentLocationId.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/ParentLocationId.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Subtree.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Subtree.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Visibility.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/CriterionHandler/Visibility.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\CriterionHandler;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Depth.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Depth.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Id.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Id.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/IsMainLocation.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/IsMainLocation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Path.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Path.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Priority.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Priority.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location;

--- a/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Visibility.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Location/Gateway/SortClauseHandler/Location/Visibility.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Location\Gateway\SortClauseHandler\Location;

--- a/eZ/Publish/Core/Search/Legacy/Content/Mapper/FullTextMapper.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/Mapper/FullTextMapper.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\Mapper;

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\WordIndexer;

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Gateway/DoctrineDatabase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Gateway;

--- a/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Repository/SearchIndex.php
+++ b/eZ/Publish/Core/Search/Legacy/Content/WordIndexer/Repository/SearchIndex.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Content\WordIndexer\Repository;

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/AbstractTestCase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentSortTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerContentTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationSortTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
+++ b/eZ/Publish/Core/Search/Legacy/Tests/Content/HandlerLocationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Legacy\Tests\Content;

--- a/eZ/Publish/Core/Search/Tests/Common/FieldValueMapper/RemoteIdentifierMapperTest.php
+++ b/eZ/Publish/Core/Search/Tests/Common/FieldValueMapper/RemoteIdentifierMapperTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Tests/Common/LocationEventSubscriber/LocationEventSubscriberTest.php
+++ b/eZ/Publish/Core/Search/Tests/Common/LocationEventSubscriber/LocationEventSubscriberTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
+++ b/eZ/Publish/Core/Search/Tests/FieldNameResolverTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Tests;

--- a/eZ/Publish/Core/Search/Tests/TestCase.php
+++ b/eZ/Publish/Core/Search/Tests/TestCase.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\Core\Search\Tests;

--- a/eZ/Publish/Core/settings/containerBuilder.php
+++ b/eZ/Publish/Core/settings/containerBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 use eZ\Publish\API\Repository\Tests\Container\Compiler\SetAllServicesPublicPass;

--- a/eZ/Publish/SPI/Exception/InvalidArgumentException.php
+++ b/eZ/Publish/SPI/Exception/InvalidArgumentException.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Exception/InvalidArgumentType.php
+++ b/eZ/Publish/SPI/Exception/InvalidArgumentType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/FieldType/BinaryBase/PathGenerator.php
+++ b/eZ/Publish/SPI/FieldType/BinaryBase/PathGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\FieldType\BinaryBase;

--- a/eZ/Publish/SPI/FieldType/Comparable.php
+++ b/eZ/Publish/SPI/FieldType/Comparable.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/FieldType/FieldStorage.php
+++ b/eZ/Publish/SPI/FieldType/FieldStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\FieldType;

--- a/eZ/Publish/SPI/FieldType/FieldType.php
+++ b/eZ/Publish/SPI/FieldType/FieldType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\FieldType;

--- a/eZ/Publish/SPI/FieldType/GatewayBasedStorage.php
+++ b/eZ/Publish/SPI/FieldType/GatewayBasedStorage.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\FieldType;

--- a/eZ/Publish/SPI/FieldType/Generic/Tests/GenericTest.php
+++ b/eZ/Publish/SPI/FieldType/Generic/Tests/GenericTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/FieldType/Generic/Tests/Stubs/Type.php
+++ b/eZ/Publish/SPI/FieldType/Generic/Tests/Stubs/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/FieldType/Generic/Tests/Stubs/Value.php
+++ b/eZ/Publish/SPI/FieldType/Generic/Tests/Stubs/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/FieldType/Generic/Type.php
+++ b/eZ/Publish/SPI/FieldType/Generic/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/FieldType/Generic/ValidationError/ConstraintViolationAdapter.php
+++ b/eZ/Publish/SPI/FieldType/Generic/ValidationError/ConstraintViolationAdapter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/FieldType/Indexable.php
+++ b/eZ/Publish/SPI/FieldType/Indexable.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\FieldType;

--- a/eZ/Publish/SPI/FieldType/StorageGateway.php
+++ b/eZ/Publish/SPI/FieldType/StorageGateway.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\FieldType;

--- a/eZ/Publish/SPI/FieldType/Tests/FieldTypeTest.php
+++ b/eZ/Publish/SPI/FieldType/Tests/FieldTypeTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\FieldType\Tests;

--- a/eZ/Publish/SPI/FieldType/ValidationError.php
+++ b/eZ/Publish/SPI/FieldType/ValidationError.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\FieldType;

--- a/eZ/Publish/SPI/FieldType/ValidationError/AbstractValidationError.php
+++ b/eZ/Publish/SPI/FieldType/ValidationError/AbstractValidationError.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/FieldType/ValidationError/NonConfigurableValidationError.php
+++ b/eZ/Publish/SPI/FieldType/ValidationError/NonConfigurableValidationError.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/FieldType/ValidationError/UnknownValidatorValidationError.php
+++ b/eZ/Publish/SPI/FieldType/ValidationError/UnknownValidatorValidationError.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/FieldType/Value.php
+++ b/eZ/Publish/SPI/FieldType/Value.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\FieldType;

--- a/eZ/Publish/SPI/FieldType/ValueSerializerInterface.php
+++ b/eZ/Publish/SPI/FieldType/ValueSerializerInterface.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/HashGenerator.php
+++ b/eZ/Publish/SPI/HashGenerator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI;

--- a/eZ/Publish/SPI/IO/BinaryFile.php
+++ b/eZ/Publish/SPI/IO/BinaryFile.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\IO;

--- a/eZ/Publish/SPI/IO/BinaryFileCreateStruct.php
+++ b/eZ/Publish/SPI/IO/BinaryFileCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\IO;

--- a/eZ/Publish/SPI/IO/MimeTypeDetector.php
+++ b/eZ/Publish/SPI/IO/MimeTypeDetector.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\IO;

--- a/eZ/Publish/SPI/Limitation/Target.php
+++ b/eZ/Publish/SPI/Limitation/Target.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Limitation/Target/Builder/VersionBuilder.php
+++ b/eZ/Publish/SPI/Limitation/Target/Builder/VersionBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Limitation/Target/Version.php
+++ b/eZ/Publish/SPI/Limitation/Target/Version.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Limitation/TargetAwareType.php
+++ b/eZ/Publish/SPI/Limitation/TargetAwareType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Limitation/Type.php
+++ b/eZ/Publish/SPI/Limitation/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Limitation;

--- a/eZ/Publish/SPI/MVC/EventSubscriber/ConfigScopeChangeSubscriber.php
+++ b/eZ/Publish/SPI/MVC/EventSubscriber/ConfigScopeChangeSubscriber.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/MVC/Templating/BaseRenderStrategy.php
+++ b/eZ/Publish/SPI/MVC/Templating/BaseRenderStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/MVC/Templating/RenderStrategy.php
+++ b/eZ/Publish/SPI/MVC/Templating/RenderStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/MVC/View/VariableProvider.php
+++ b/eZ/Publish/SPI/MVC/View/VariableProvider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Options/MutableOptionsBag.php
+++ b/eZ/Publish/SPI/Options/MutableOptionsBag.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Options/OptionsBag.php
+++ b/eZ/Publish/SPI/Options/OptionsBag.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Bookmark/Bookmark.php
+++ b/eZ/Publish/SPI/Persistence/Bookmark/Bookmark.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Bookmark/CreateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Bookmark/CreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Bookmark/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Bookmark/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Content.php
+++ b/eZ/Publish/SPI/Persistence/Content.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence;

--- a/eZ/Publish/SPI/Persistence/Content/ContentInfo.php
+++ b/eZ/Publish/SPI/Persistence/Content/ContentInfo.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/ContentItem.php
+++ b/eZ/Publish/SPI/Persistence/Content/ContentItem.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Content/CreateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/CreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/Field.php
+++ b/eZ/Publish/SPI/Persistence/Content/Field.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/FieldTypeConstraints.php
+++ b/eZ/Publish/SPI/Persistence/Content/FieldTypeConstraints.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/FieldValue.php
+++ b/eZ/Publish/SPI/Persistence/Content/FieldValue.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/Language.php
+++ b/eZ/Publish/SPI/Persistence/Content/Language.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/Language/CreateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/Language/CreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Language;

--- a/eZ/Publish/SPI/Persistence/Content/Language/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Language/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Language;

--- a/eZ/Publish/SPI/Persistence/Content/LoadStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/LoadStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/Location.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/Location/CreateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/CreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Location;

--- a/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Location;

--- a/eZ/Publish/SPI/Persistence/Content/Location/Trash/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Trash/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Location\Trash;

--- a/eZ/Publish/SPI/Persistence/Content/Location/Trash/TrashResult.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Trash/TrashResult.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Location\Trash;

--- a/eZ/Publish/SPI/Persistence/Content/Location/Trashed.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Trashed.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Location;

--- a/eZ/Publish/SPI/Persistence/Content/Location/UpdateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/UpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Location;

--- a/eZ/Publish/SPI/Persistence/Content/LocationWithContentInfo.php
+++ b/eZ/Publish/SPI/Persistence/Content/LocationWithContentInfo.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Content/MetadataUpdateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/MetadataUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/ObjectState.php
+++ b/eZ/Publish/SPI/Persistence/Content/ObjectState.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/ObjectState/Group.php
+++ b/eZ/Publish/SPI/Persistence/Content/ObjectState/Group.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\ObjectState;

--- a/eZ/Publish/SPI/Persistence/Content/ObjectState/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/ObjectState/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\ObjectState;

--- a/eZ/Publish/SPI/Persistence/Content/ObjectState/InputStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/ObjectState/InputStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\ObjectState;

--- a/eZ/Publish/SPI/Persistence/Content/Relation.php
+++ b/eZ/Publish/SPI/Persistence/Content/Relation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/Relation/CreateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/Relation/CreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Relation;

--- a/eZ/Publish/SPI/Persistence/Content/Section.php
+++ b/eZ/Publish/SPI/Persistence/Content/Section.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/Section/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Section/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Section;

--- a/eZ/Publish/SPI/Persistence/Content/Type.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/Type/CreateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/CreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Type;

--- a/eZ/Publish/SPI/Persistence/Content/Type/DeleteByParamsStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/DeleteByParamsStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Type;

--- a/eZ/Publish/SPI/Persistence/Content/Type/FieldDefinition.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/FieldDefinition.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Type;

--- a/eZ/Publish/SPI/Persistence/Content/Type/Group.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Group.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Type;

--- a/eZ/Publish/SPI/Persistence/Content/Type/Group/CreateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Group/CreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Type\Group;

--- a/eZ/Publish/SPI/Persistence/Content/Type/Group/UpdateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Group/UpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Type\Group;

--- a/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Type;

--- a/eZ/Publish/SPI/Persistence/Content/Type/UpdateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/Type/UpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\Type;

--- a/eZ/Publish/SPI/Persistence/Content/UpdateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Content/UpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/UrlAlias.php
+++ b/eZ/Publish/SPI/Persistence/Content/UrlAlias.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/UrlAlias/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\UrlAlias;

--- a/eZ/Publish/SPI/Persistence/Content/UrlWildcard.php
+++ b/eZ/Publish/SPI/Persistence/Content/UrlWildcard.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/Content/UrlWildcard/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/UrlWildcard/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content\UrlWildcard;

--- a/eZ/Publish/SPI/Persistence/Content/VersionInfo.php
+++ b/eZ/Publish/SPI/Persistence/Content/VersionInfo.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\Content;

--- a/eZ/Publish/SPI/Persistence/FieldType.php
+++ b/eZ/Publish/SPI/Persistence/FieldType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence;

--- a/eZ/Publish/SPI/Persistence/FieldType/IsEmptyValue.php
+++ b/eZ/Publish/SPI/Persistence/FieldType/IsEmptyValue.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\FieldType;

--- a/eZ/Publish/SPI/Persistence/Filter/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Filter/Content/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Filter/Content/LazyContentItemListIterator.php
+++ b/eZ/Publish/SPI/Persistence/Filter/Content/LazyContentItemListIterator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Filter/CriterionVisitor.php
+++ b/eZ/Publish/SPI/Persistence/Filter/CriterionVisitor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Filter/Doctrine/FilteringQueryBuilder.php
+++ b/eZ/Publish/SPI/Persistence/Filter/Doctrine/FilteringQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Filter/LazyListIterator.php
+++ b/eZ/Publish/SPI/Persistence/Filter/LazyListIterator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Filter/Location/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Filter/Location/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Filter/Location/LazyLocationListIterator.php
+++ b/eZ/Publish/SPI/Persistence/Filter/Location/LazyLocationListIterator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Filter/SortClauseVisitor.php
+++ b/eZ/Publish/SPI/Persistence/Filter/SortClauseVisitor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Notification/CreateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Notification/CreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Notification/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Notification/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Notification/Notification.php
+++ b/eZ/Publish/SPI/Persistence/Notification/Notification.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/Notification/UpdateStruct.php
+++ b/eZ/Publish/SPI/Persistence/Notification/UpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/TransactionHandler.php
+++ b/eZ/Publish/SPI/Persistence/TransactionHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence;

--- a/eZ/Publish/SPI/Persistence/URL/Handler.php
+++ b/eZ/Publish/SPI/Persistence/URL/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\URL;

--- a/eZ/Publish/SPI/Persistence/URL/URL.php
+++ b/eZ/Publish/SPI/Persistence/URL/URL.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\URL;

--- a/eZ/Publish/SPI/Persistence/URL/URLUpdateStruct.php
+++ b/eZ/Publish/SPI/Persistence/URL/URLUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\URL;

--- a/eZ/Publish/SPI/Persistence/User.php
+++ b/eZ/Publish/SPI/Persistence/User.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence;

--- a/eZ/Publish/SPI/Persistence/User/Handler.php
+++ b/eZ/Publish/SPI/Persistence/User/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\User;

--- a/eZ/Publish/SPI/Persistence/User/Policy.php
+++ b/eZ/Publish/SPI/Persistence/User/Policy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\User;

--- a/eZ/Publish/SPI/Persistence/User/Role.php
+++ b/eZ/Publish/SPI/Persistence/User/Role.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\User;

--- a/eZ/Publish/SPI/Persistence/User/RoleAssignment.php
+++ b/eZ/Publish/SPI/Persistence/User/RoleAssignment.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\User;

--- a/eZ/Publish/SPI/Persistence/User/RoleCopyStruct.php
+++ b/eZ/Publish/SPI/Persistence/User/RoleCopyStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/User/RoleCreateStruct.php
+++ b/eZ/Publish/SPI/Persistence/User/RoleCreateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\User;

--- a/eZ/Publish/SPI/Persistence/User/RoleUpdateStruct.php
+++ b/eZ/Publish/SPI/Persistence/User/RoleUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\User;

--- a/eZ/Publish/SPI/Persistence/User/UserTokenUpdateStruct.php
+++ b/eZ/Publish/SPI/Persistence/User/UserTokenUpdateStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence\User;

--- a/eZ/Publish/SPI/Persistence/UserPreference/Handler.php
+++ b/eZ/Publish/SPI/Persistence/UserPreference/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/UserPreference/UserPreference.php
+++ b/eZ/Publish/SPI/Persistence/UserPreference/UserPreference.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/UserPreference/UserPreferenceSetStruct.php
+++ b/eZ/Publish/SPI/Persistence/UserPreference/UserPreferenceSetStruct.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Persistence/ValueObject.php
+++ b/eZ/Publish/SPI/Persistence/ValueObject.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Persistence;

--- a/eZ/Publish/SPI/Repository/Decorator/BookmarkServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/BookmarkServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/ContentServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/ContentServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/ContentTypeServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/ContentTypeServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/FieldTypeServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/FieldTypeServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/LanguageServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/LanguageServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/NotificationServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/NotificationServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/ObjectStateServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/ObjectStateServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/RoleServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/RoleServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 /**

--- a/eZ/Publish/SPI/Repository/Decorator/SearchServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/SearchServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/SectionServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/SectionServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 /**

--- a/eZ/Publish/SPI/Repository/Decorator/TranslationServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/TranslationServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/TrashServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/TrashServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/URLAliasServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/URLAliasServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/URLServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/URLServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/URLWildcardServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/URLWildcardServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/UserPreferenceServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/UserPreferenceServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Decorator/UserServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/UserServiceDecorator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 /**

--- a/eZ/Publish/SPI/Repository/Event/AfterEvent.php
+++ b/eZ/Publish/SPI/Repository/Event/AfterEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Event/BeforeEvent.php
+++ b/eZ/Publish/SPI/Repository/Event/BeforeEvent.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/Field/FieldTypeBasedThumbnailStrategy.php
+++ b/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/Field/FieldTypeBasedThumbnailStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/Field/ThumbnailStrategy.php
+++ b/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/Field/ThumbnailStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/ThumbnailStrategy.php
+++ b/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/ThumbnailStrategy.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/BookmarkServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/BookmarkServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/ContentServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/ContentServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/ContentTypeServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/ContentTypeServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/FieldTypeServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/FieldTypeServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/LanguageServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/LanguageServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/LocationServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/LocationServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/NotificationServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/NotificationServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/ObjectStateServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/ObjectStateServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/RoleServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/RoleServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/SearchServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/SearchServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/SectionServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/SectionServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/TranslationServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/TranslationServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/TrashServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/TrashServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/URLAliasServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/URLAliasServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/URLServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/URLServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/URLWildcardServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/URLWildcardServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/UserPreferenceServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/UserPreferenceServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/UserServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/UserServiceDecoratorTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Validator/ContentValidator.php
+++ b/eZ/Publish/SPI/Repository/Validator/ContentValidator.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Values/Filter/CriterionQueryBuilder.php
+++ b/eZ/Publish/SPI/Repository/Values/Filter/CriterionQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Values/Filter/FilteringCriterion.php
+++ b/eZ/Publish/SPI/Repository/Values/Filter/FilteringCriterion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Values/Filter/FilteringSortClause.php
+++ b/eZ/Publish/SPI/Repository/Values/Filter/FilteringSortClause.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Values/Filter/SortClauseQueryBuilder.php
+++ b/eZ/Publish/SPI/Repository/Values/Filter/SortClauseQueryBuilder.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Values/MultiLanguageDescription.php
+++ b/eZ/Publish/SPI/Repository/Values/MultiLanguageDescription.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Repository\Values;

--- a/eZ/Publish/SPI/Repository/Values/MultiLanguageName.php
+++ b/eZ/Publish/SPI/Repository/Values/MultiLanguageName.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Repository\Values;

--- a/eZ/Publish/SPI/Repository/Values/Trash/Query/Criterion.php
+++ b/eZ/Publish/SPI/Repository/Values/Trash/Query/Criterion.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Repository/Values/Trash/Query/SortClause.php
+++ b/eZ/Publish/SPI/Repository/Values/Trash/Query/SortClause.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Search/Capable.php
+++ b/eZ/Publish/SPI/Search/Capable.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Search/ContentTranslationHandler.php
+++ b/eZ/Publish/SPI/Search/ContentTranslationHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Search/Document.php
+++ b/eZ/Publish/SPI/Search/Document.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search;

--- a/eZ/Publish/SPI/Search/Field.php
+++ b/eZ/Publish/SPI/Search/Field.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search;

--- a/eZ/Publish/SPI/Search/FieldType.php
+++ b/eZ/Publish/SPI/Search/FieldType.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search;

--- a/eZ/Publish/SPI/Search/FieldType/BooleanField.php
+++ b/eZ/Publish/SPI/Search/FieldType/BooleanField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/CustomField.php
+++ b/eZ/Publish/SPI/Search/FieldType/CustomField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/DateField.php
+++ b/eZ/Publish/SPI/Search/FieldType/DateField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/DocumentField.php
+++ b/eZ/Publish/SPI/Search/FieldType/DocumentField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/FloatField.php
+++ b/eZ/Publish/SPI/Search/FieldType/FloatField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/FullTextField.php
+++ b/eZ/Publish/SPI/Search/FieldType/FullTextField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/GeoLocationField.php
+++ b/eZ/Publish/SPI/Search/FieldType/GeoLocationField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/IdentifierField.php
+++ b/eZ/Publish/SPI/Search/FieldType/IdentifierField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/IntegerField.php
+++ b/eZ/Publish/SPI/Search/FieldType/IntegerField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/MultipleBooleanField.php
+++ b/eZ/Publish/SPI/Search/FieldType/MultipleBooleanField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/MultipleIdentifierField.php
+++ b/eZ/Publish/SPI/Search/FieldType/MultipleIdentifierField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/MultipleIntegerField.php
+++ b/eZ/Publish/SPI/Search/FieldType/MultipleIntegerField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/MultipleRemoteIdentifierField.php
+++ b/eZ/Publish/SPI/Search/FieldType/MultipleRemoteIdentifierField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/MultipleStringField.php
+++ b/eZ/Publish/SPI/Search/FieldType/MultipleStringField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/PriceField.php
+++ b/eZ/Publish/SPI/Search/FieldType/PriceField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/RemoteIdentifierField.php
+++ b/eZ/Publish/SPI/Search/FieldType/RemoteIdentifierField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/StringField.php
+++ b/eZ/Publish/SPI/Search/FieldType/StringField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/FieldType/TextField.php
+++ b/eZ/Publish/SPI/Search/FieldType/TextField.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search\FieldType;

--- a/eZ/Publish/SPI/Search/Handler.php
+++ b/eZ/Publish/SPI/Search/Handler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Search;

--- a/eZ/Publish/SPI/Search/VersatileHandler.php
+++ b/eZ/Publish/SPI/Search/VersatileHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/SiteAccess/ConfigProcessor.php
+++ b/eZ/Publish/SPI/SiteAccess/ConfigProcessor.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Specification/Content/ContentContainerSpecification.php
+++ b/eZ/Publish/SPI/Specification/Content/ContentContainerSpecification.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Specification/Content/ContentSpecification.php
+++ b/eZ/Publish/SPI/Specification/Content/ContentSpecification.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Specification/Content/ContentTypeSpecification.php
+++ b/eZ/Publish/SPI/Specification/Content/ContentTypeSpecification.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Specification/Tests/Content/ContentContainerSpecificationTest.php
+++ b/eZ/Publish/SPI/Specification/Tests/Content/ContentContainerSpecificationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Specification/Tests/Content/ContentTypeSpecificationTest.php
+++ b/eZ/Publish/SPI/Specification/Tests/Content/ContentTypeSpecificationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Tests/FieldType/AuthorIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/AuthorIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BaseIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/BinaryFileIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/CheckboxIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/CheckboxIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/CountryIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/CountryIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/DateAndTimeIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/DateAndTimeIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/DateIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/DateIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/EmailAddressIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/EmailAddressIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/FileBaseIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/FloatIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/FloatIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/ISBNIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ISBNIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/ImageAssetIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageAssetIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/IntegerIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/IntegerIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/KeywordIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/KeywordIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/MapLocationIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/MapLocationIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/MediaIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/RelationIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RelationIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/RelationListIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/RelationListIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/SelectionIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/TextBlockIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/TextBlockIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/TextLineIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/TextLineIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/TimeIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/TimeIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/UrlIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/UrlIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/FieldType/UserIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/UserIntegrationTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Tests\FieldType;

--- a/eZ/Publish/SPI/Tests/Limitation/Target/Builder/VersionBuilderTest.php
+++ b/eZ/Publish/SPI/Tests/Limitation/Target/Builder/VersionBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Tests/Persistence/BaseInMemoryCachedFileFixture.php
+++ b/eZ/Publish/SPI/Tests/Persistence/BaseInMemoryCachedFileFixture.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Tests/Persistence/FileFixtureFactory.php
+++ b/eZ/Publish/SPI/Tests/Persistence/FileFixtureFactory.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Tests/Persistence/Filter/Doctrine/FilteringQueryBuilderTest.php
+++ b/eZ/Publish/SPI/Tests/Persistence/Filter/Doctrine/FilteringQueryBuilderTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Tests/Persistence/Fixture.php
+++ b/eZ/Publish/SPI/Tests/Persistence/Fixture.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Tests/Persistence/FixtureImporter.php
+++ b/eZ/Publish/SPI/Tests/Persistence/FixtureImporter.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Tests/Persistence/PhpArrayFileFixture.php
+++ b/eZ/Publish/SPI/Tests/Persistence/PhpArrayFileFixture.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Tests/Persistence/YamlFixture.php
+++ b/eZ/Publish/SPI/Tests/Persistence/YamlFixture.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/Tests/Variation/InMemoryVariationHandler.php
+++ b/eZ/Publish/SPI/Tests/Variation/InMemoryVariationHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 declare(strict_types=1);

--- a/eZ/Publish/SPI/User/Identity.php
+++ b/eZ/Publish/SPI/User/Identity.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\User;

--- a/eZ/Publish/SPI/User/IdentityAware.php
+++ b/eZ/Publish/SPI/User/IdentityAware.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\User;

--- a/eZ/Publish/SPI/Variation/Values/ImageVariation.php
+++ b/eZ/Publish/SPI/Variation/Values/ImageVariation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Variation\Values;

--- a/eZ/Publish/SPI/Variation/Values/Variation.php
+++ b/eZ/Publish/SPI/Variation/Values/Variation.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Variation\Values;

--- a/eZ/Publish/SPI/Variation/VariationHandler.php
+++ b/eZ/Publish/SPI/Variation/VariationHandler.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Variation;

--- a/eZ/Publish/SPI/Variation/VariationPurger.php
+++ b/eZ/Publish/SPI/Variation/VariationPurger.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @copyright Copyright (C) eZ Systems AS. All rights reserved.
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
 namespace eZ\Publish\SPI\Variation;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.2`+
| **BC breaks**                          | no
| **Doc needed**                       | no

Since 3.2 our copyright header should state "Ibexa AS" instead of "eZ Systems AS".
Bumped Ibexa Code Style package to v0.2 to fix that.
We can bump it to 0.4 but maybe as a follow-up because the diff is too big already.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution ~manually~ on Travis (should be enough)
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
