### PR TITLE
EZP-32255: Get rid of default DSF configuration (moved to Core)

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -1,11 +1,3 @@
-parameters:
-    ibexa.platform.io.nfs.adapter.config:
-        root: './'
-        path: '$var_dir$/$storage_dir$/'
-        writeFlags: ~
-        linkHandling: ~
-        permissions: [ ]
-
 services:
     ezpublish.core.io.command.migrate_files:
         class: eZ\Bundle\EzPublishIOBundle\Command\MigrateFilesCommand


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32255
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | maybe
| **Doc needed**                       | no

Due to how are configurations loaded with Flex, we have to move configuration to where it is overwritten (EzPlatformCoreBundle).

### Requires: https://github.com/ezsystems/ezplatform-core/pull/29

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
