### PR TITLE
Fixed cast to int destinationContentId in ImageAsset/AliasGenerator

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/ImageAsset/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/ImageAsset/AliasGenerator.php
@@ -53,7 +53,7 @@ class AliasGenerator implements VariationHandler
     {
         if ($this->supportsValue($field->value)) {
             $destinationContent = $this->contentService->loadContent(
-                $field->value->destinationContentId
+                (int)$field->value->destinationContentId
             );
 
             return $this->innerAliasGenerator->getVariation(


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.3.X` 
| **BC breaks**                          |no
| **Doc needed**                       |no

This PR provides fix for ImageAsset/AliasGenerator::getVariation. Argument contentId in ContentService::loadContent expects to be int but string given when try to get content for imageasset 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
