### PR TITLE
Added the location parameter to ez_render_field

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/full.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/full.html.twig
@@ -3,6 +3,6 @@
     <h2>{{ ez_content_name(content) }}</h2>
     {% for field in content.fieldsByLanguage(language|default(null)) %}
         <h3>{{ field.fieldDefIdentifier }}</h3>
-        {{ ez_render_field(content, field.fieldDefIdentifier) }}
+        {{ ez_render_field(content, field.fieldDefIdentifier, {location: location|default(null)}) }}
     {% endfor %}
 {% endblock %}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [https://jira.ez.no/browse/EZP-31659](https://jira.ez.no/browse/EZP-31659)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | yes

Adds the location as a parameter to `ez_render_field()` in the default view template. Required by the query fieldtype's handling of locations (https://github.com/ezsystems/ezplatform-query-fieldtype/pull/38).

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
