### PR TITLE
EZP-31795: Added VersionInfo to getThumbnail method in order to utilise builtin caching mechanism

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\FieldType\Image;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field\FieldTypeBasedThumbnailStrategy;
 use eZ\Publish\SPI\Variation\VariationHandler;
 
@@ -40,10 +41,14 @@ class ImageThumbnailStrategy implements FieldTypeBasedThumbnailStrategy
         return $this->fieldTypeIdentifier;
     }
 
-    public function getThumbnail(Field $field): ?Thumbnail
+    public function getThumbnail(Field $field, ?APIVersionInfo $versionInfo = null): ?Thumbnail
     {
         /** @var \eZ\Publish\SPI\Variation\Values\ImageVariation $variation */
-        $variation = $this->variationHandler->getVariation($field, new VersionInfo(), $this->variationName);
+        $variation = $this->variationHandler->getVariation(
+            $field,
+            $versionInfo ?? new VersionInfo(),
+            $this->variationName
+        );
 
         return new Thumbnail([
             'resource' => $variation->uri,

--- a/eZ/Publish/Core/FieldType/ImageAsset/ImageAssetThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/ImageAsset/ImageAssetThumbnailStrategy.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field\FieldTypeBasedThumbnailStrategy;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy as ContentThumbnailStrategy;
 
@@ -41,17 +42,22 @@ class ImageAssetThumbnailStrategy implements FieldTypeBasedThumbnailStrategy
         return $this->fieldTypeIdentifier;
     }
 
-    public function getThumbnail(Field $field): ?Thumbnail
+    public function getThumbnail(Field $field, ?VersionInfo $versionInfo = null): ?Thumbnail
     {
         try {
-            $content = $this->contentService->loadContent((int) $field->value->destinationContentId);
+            $content = $this->contentService->loadContent(
+                (int) $field->value->destinationContentId,
+                null,
+                $versionInfo ? $versionInfo->versionNo : null
+            );
         } catch (NotFoundException $e) {
             return null;
         }
 
         return $this->thumbnailStrategy->getThumbnail(
             $content->getContentType(),
-            $content->getFields()
+            $content->getFields(),
+            $content->versionInfo
         );
     }
 }

--- a/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
@@ -118,6 +118,7 @@ class ContentDomainMapper extends ProxyAwareDomainMapper
         $internalFields = $this->buildDomainFields($spiContent->fields, $contentType, $prioritizedLanguages, $fieldAlwaysAvailableLanguage);
 
         $versionInfo = $this->buildVersionInfoDomainObject($spiContent->versionInfo, $prioritizedLanguages);
+
         return new Content(
             [
                 'thumbnail' => $this->thumbnailStrategy->getThumbnail($contentType, $internalFields, $versionInfo),

--- a/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
@@ -117,11 +117,12 @@ class ContentDomainMapper extends ProxyAwareDomainMapper
 
         $internalFields = $this->buildDomainFields($spiContent->fields, $contentType, $prioritizedLanguages, $fieldAlwaysAvailableLanguage);
 
+        $versionInfo = $this->buildVersionInfoDomainObject($spiContent->versionInfo, $prioritizedLanguages);
         return new Content(
             [
-                'thumbnail' => $this->thumbnailStrategy->getThumbnail($contentType, $internalFields),
+                'thumbnail' => $this->thumbnailStrategy->getThumbnail($contentType, $internalFields, $versionInfo),
                 'internalFields' => $internalFields,
-                'versionInfo' => $this->buildVersionInfoDomainObject($spiContent->versionInfo, $prioritizedLanguages),
+                'versionInfo' => $versionInfo,
                 'contentType' => $contentType,
                 'prioritizedFieldLanguageCode' => $prioritizedFieldLanguageCode,
             ]

--- a/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/Field/ContentFieldStrategy.php
+++ b/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/Field/ContentFieldStrategy.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\Core\Repository\Strategy\ContentThumbnail\Field;
 
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field\FieldTypeBasedThumbnailStrategy;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field\ThumbnailStrategy;
@@ -35,7 +36,7 @@ final class ContentFieldStrategy implements ThumbnailStrategy
     /**
      * @throws \eZ\Publish\Core\Base\Exceptions\NotFoundException
      */
-    public function getThumbnail(Field $field): ?Thumbnail
+    public function getThumbnail(Field $field, ?VersionInfo $versionInfo = null): ?Thumbnail
     {
         if (!$this->hasStrategy($field->fieldTypeIdentifier)) {
             throw new NotFoundException('Field\ThumbnailStrategy', $field->fieldTypeIdentifier);
@@ -45,7 +46,7 @@ final class ContentFieldStrategy implements ThumbnailStrategy
 
         /** @var FieldTypeBasedThumbnailStrategy $fieldStrategy */
         foreach ($fieldStrategies as $fieldStrategy) {
-            $thumbnail = $fieldStrategy->getThumbnail($field);
+            $thumbnail = $fieldStrategy->getThumbnail($field, $versionInfo);
 
             if ($thumbnail !== null) {
                 return $thumbnail;

--- a/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/FirstMatchingFieldStrategy.php
+++ b/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/FirstMatchingFieldStrategy.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\Repository\Strategy\ContentThumbnail;
 use eZ\Publish\API\Repository\FieldTypeService;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field\ThumbnailStrategy as ContentFieldThumbnailStrategy;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy;
@@ -31,7 +32,7 @@ final class FirstMatchingFieldStrategy implements ThumbnailStrategy
         $this->fieldTypeService = $fieldTypeService;
     }
 
-    public function getThumbnail(ContentType $contentType, array $fields): ?Thumbnail
+    public function getThumbnail(ContentType $contentType, array $fields, ?VersionInfo $versionInfo = null): ?Thumbnail
     {
         $fieldDefinitions = $contentType->getFieldDefinitions();
 
@@ -49,7 +50,7 @@ final class FirstMatchingFieldStrategy implements ThumbnailStrategy
                 && $this->contentFieldStrategy->hasStrategy($field->fieldTypeIdentifier)
                 && !$fieldType->isEmptyValue($field->value)
             ) {
-                return $this->contentFieldStrategy->getThumbnail($field);
+                return $this->contentFieldStrategy->getThumbnail($field, $versionInfo);
             }
         }
 

--- a/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/StaticStrategy.php
+++ b/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/StaticStrategy.php
@@ -11,6 +11,7 @@ namespace eZ\Publish\Core\Repository\Strategy\ContentThumbnail;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 
 final class StaticStrategy implements ThumbnailStrategy
 {
@@ -22,7 +23,7 @@ final class StaticStrategy implements ThumbnailStrategy
         $this->staticThumbnail = $staticThumbnail;
     }
 
-    public function getThumbnail(ContentType $contentType, array $fields): Thumbnail
+    public function getThumbnail(ContentType $contentType, array $fields, ?VersionInfo $versionInfo = null): Thumbnail
     {
         return new Thumbnail([
             'resource' => $this->staticThumbnail,

--- a/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/ThumbnailChainStrategy.php
+++ b/eZ/Publish/Core/Repository/Strategy/ContentThumbnail/ThumbnailChainStrategy.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\Repository\Strategy\ContentThumbnail;
 
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\ThumbnailStrategy;
 
@@ -25,10 +26,10 @@ final class ThumbnailChainStrategy implements ThumbnailStrategy
         $this->strategies = $strategies;
     }
 
-    public function getThumbnail(ContentType $contentType, array $fields): ?Thumbnail
+    public function getThumbnail(ContentType $contentType, array $fields, ?VersionInfo $versionInfo = null): ?Thumbnail
     {
         foreach ($this->strategies as $strategy) {
-            $thumbnail = $strategy->getThumbnail($contentType, $fields);
+            $thumbnail = $strategy->getThumbnail($contentType, $fields, $versionInfo);
 
             if ($thumbnail !== null) {
                 return $thumbnail;

--- a/eZ/Publish/Core/Repository/Tests/ContentThumbnail/ContentFieldStrategyTest.php
+++ b/eZ/Publish/Core/Repository/Tests/ContentThumbnail/ContentFieldStrategyTest.php
@@ -12,6 +12,7 @@ use ArrayIterator;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Strategy\ContentThumbnail\Field\ContentFieldStrategy;
 use eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field\FieldTypeBasedThumbnailStrategy;
 use PHPUnit\Framework\TestCase;
@@ -34,7 +35,7 @@ class ContentFieldStrategyTest extends TestCase
                 return $this->fieldTypeIdentifier;
             }
 
-            public function getThumbnail(Field $field): ?Thumbnail
+            public function getThumbnail(Field $field, ?VersionInfo $versionInfo = null): ?Thumbnail
             {
                 return new Thumbnail([
                     'resource' => $field->value,

--- a/eZ/Publish/Core/settings/tests/integration_legacy.yml
+++ b/eZ/Publish/Core/settings/tests/integration_legacy.yml
@@ -54,3 +54,5 @@ services:
     eZ\Publish\API\Repository\SettingService:
         public: true
         alias: eZ\Publish\Core\Event\SettingService
+
+    ezpublish.image_alias.imagine.cache.alias_generator_decorator: '@eZ\Publish\SPI\Tests\Variation\InMemoryVariationHandler'

--- a/eZ/Publish/Core/settings/thumbnails.yml
+++ b/eZ/Publish/Core/settings/thumbnails.yml
@@ -7,7 +7,7 @@ services:
     eZ\Publish\Core\FieldType\Image\ImageThumbnailStrategy:
         arguments:
             $fieldTypeIdentifier: 'ezimage'
-            $variationHandler: '@eZ\Publish\SPI\Variation\VariationHandler'
+            $variationHandler: '@ezpublish.image_alias.imagine.cache.alias_generator_decorator'
             $variationName: 'medium'
         tags:
             - { name: ezplatform.spi.field.thumbnail_strategy, priority: 0 }

--- a/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/Field/ThumbnailStrategy.php
+++ b/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/Field/ThumbnailStrategy.php
@@ -10,8 +10,9 @@ namespace eZ\Publish\SPI\Repository\Strategy\ContentThumbnail\Field;
 
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 
 interface ThumbnailStrategy
 {
-    public function getThumbnail(Field $field): ?Thumbnail;
+    public function getThumbnail(Field $field, ?VersionInfo $versionInfo = null): ?Thumbnail;
 }

--- a/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/ThumbnailStrategy.php
+++ b/eZ/Publish/SPI/Repository/Strategy/ContentThumbnail/ThumbnailStrategy.php
@@ -9,9 +9,10 @@ declare(strict_types=1);
 namespace eZ\Publish\SPI\Repository\Strategy\ContentThumbnail;
 
 use eZ\Publish\API\Repository\Values\Content\Thumbnail;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\API\Repository\Values\ContentType\ContentType;
 
 interface ThumbnailStrategy
 {
-    public function getThumbnail(ContentType $contentType, array $fields): ?Thumbnail;
+    public function getThumbnail(ContentType $contentType, array $fields, ?VersionInfo $versionInfo = null): ?Thumbnail;
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-31795
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | yes
| **Doc needed**                       | yes

https://github.com/ezsystems/ezplatform-admin-ui/pull/1690
https://github.com/ezsystems/ezplatform-connector-dam/pull/29

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/php-dev-team`).
