### PR TITLE
EZP-32284: Made `type` parameter optional in InstallPlatformCommand

### DIFF
--- a/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Command/InstallPlatformCommand.php
@@ -65,8 +65,9 @@ final class InstallPlatformCommand extends Command implements BackwardCompatible
         $this->setAliases($this->getDeprecatedAliases());
         $this->addArgument(
             'type',
-            InputArgument::REQUIRED,
-            'The type of install. Available options: ' . implode(', ', array_keys($this->installers))
+            InputArgument::OPTIONAL,
+            'The type of install. Available options: ' . implode(', ', array_keys($this->installers)),
+            'ibexa-oss'
         );
         $this->addOption(
             'skip-indexing',

--- a/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Resources/config/services.yml
@@ -14,7 +14,8 @@ services:
         autowire: true
         parent: EzSystems\PlatformInstallerBundle\Installer\DbBasedInstaller
         tags:
-            - {name: ezplatform.installer, type: clean}
+            - { name: ezplatform.installer, type: clean } # left for BC, should be removed in Ibexa 4.0
+            - { name: ezplatform.installer, type: ibexa-oss }
 
     EzSystems\PlatformInstallerBundle\Command\InstallPlatformCommand:
         arguments:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32284
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | yes

For some reason `ibexa:install` command always requires to pass `type` explicitly. It becomes a huge issue with number of products we now offer. This PR mades `type` argument optional and will use `ibexa-oss` installer by default. This is only a part of full solution as for enterprise editions the installer will automatically select relevant installation type based on installed product. That to be provided via separate package.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
