### PR TITLE
EZP-32281: IndexRequestListener requires redirect

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/IndexRequestListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/IndexRequestListener.php
@@ -49,7 +49,7 @@ class IndexRequestListener implements EventSubscriberInterface
             if ($indexPage !== null) {
                 $indexPage = '/' . ltrim($indexPage, '/');
                 $request->attributes->set('semanticPathinfo', $indexPage);
-                $request->attributes->set('needsForward', true);
+                $request->attributes->set('needsRedirect', true);
             }
         }
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/IndexRequestListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/IndexRequestListenerTest.php
@@ -77,7 +77,7 @@ class IndexRequestListenerTest extends TestCase
         $this->request->attributes->set('semanticPathinfo', $requestPath);
         $this->indexRequestEventListener->onKernelRequestIndex($this->event);
         $this->assertEquals($expectedIndexPath, $this->request->attributes->get('semanticPathinfo'));
-        $this->assertTrue($this->request->attributes->get('needsForward'));
+        $this->assertTrue($this->request->attributes->get('needsRedirect'));
     }
 
     public function indexPageProvider()
@@ -97,6 +97,6 @@ class IndexRequestListenerTest extends TestCase
     {
         $this->request->attributes->set('semanticPathinfo', '/anyContent');
         $this->indexRequestEventListener->onKernelRequestIndex($this->event);
-        $this->assertFalse($this->request->attributes->has('needsForward'));
+        $this->assertFalse($this->request->attributes->has('needsRedirect'));
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32281
| **Type**                                   | bug
| **Target eZ Platform version** | v3.1
| **BC breaks**                          | no
| **Doc needed**                       | no

`IndexRequestListener` originally had `needsForward` set to `true` which later on resulted in `needsCaseRedirect` in `UrlAliasRouter` returning `false` as both paths were the same which finally resulted in redirect not being fired. That shouldn't be the case and the redirect should occur at an earlier stage without the unnecessary forward.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
