### PR TITLE
[Composer] Added missing dependency on symfony/templating

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,6 +53,7 @@
         "twig/extra-bundle": "^3.0",
         "friendsofsymfony/jsrouting-bundle": "^2.5",
         "psr/event-dispatcher": "^1.0",
+        "symfony/templating": "^5.1",
         "composer/package-versions-deprecated": "^1.11"
     },
     "require-dev": {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.2`+
| **Doc needed**                       | no

Our MVC Controller still relies on the deprecated `symfony/templating`, however we didn't have it in our dependencies. Looks like it was installed as a peer dependency of Liip Imagine Bundle, so the issue wasn't discovered. With the today's release of Liip Imagine Bundle 2.5.0 that dependency is gone, so we need to (and should prior to that anyway) require it explicitly. 

Both test and production code (a bit implicitly) rely on that, so putting it in the `require` section.

Observed CI failure [ezplatform-kernel/builds/216658855](https://travis-ci.com/github/ezsystems/ezplatform-kernel/builds/216658855)

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/php-dev-team`).
