### PR TITLE
Fix EZP-32349: do not leave stale data in ezcontentclass_attribute_ml

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Type/Gateway/DoctrineDatabase.php
@@ -1091,25 +1091,6 @@ final class DoctrineDatabase extends Gateway
 
     public function deleteFieldDefinitionsForType(int $typeId, int $status): void
     {
-        $query = $this->connection->createQueryBuilder();
-        $expr = $query->expr();
-        $query
-            ->delete(self::FIELD_DEFINITION_TABLE)
-            ->where(
-                $query->expr()->eq(
-                    'contentclass_id',
-                    $query->createPositionalParameter($typeId, ParameterType::INTEGER)
-                )
-            )
-            ->andWhere(
-                $expr->eq(
-                    'version',
-                    $query->createPositionalParameter($status, ParameterType::INTEGER)
-                )
-            );
-
-        $query->execute();
-
         $subQuery = $this->connection->createQueryBuilder();
         $subQuery
             ->select('f_def.id as ezcontentclass_attribute_id')
@@ -1129,6 +1110,25 @@ final class DoctrineDatabase extends Gateway
             ->setParameter('status', $status, ParameterType::INTEGER);
 
         $deleteQuery->execute();
+
+        $query = $this->connection->createQueryBuilder();
+        $expr = $query->expr();
+        $query
+            ->delete(self::FIELD_DEFINITION_TABLE)
+            ->where(
+                $query->expr()->eq(
+                    'contentclass_id',
+                    $query->createPositionalParameter($typeId, ParameterType::INTEGER)
+                )
+            )
+            ->andWhere(
+                $expr->eq(
+                    'version',
+                    $query->createPositionalParameter($status, ParameterType::INTEGER)
+                )
+            );
+
+        $query->execute();
     }
 
     public function delete(int $typeId, int $status): void


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-32349
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.0` to `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs). <= no. Which branch is 3.x ?
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`). <= no, as this is reshuffling of existing code
- [ ] Asked for a review (ping `@ezsystems/php-dev-team`) <= is that supposed to be a slack username or what ?
