### PR TITLE
IBX-143: Fixed merge-up of reindex command changes

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -9,7 +9,6 @@ namespace eZ\Bundle\EzPublishCoreBundle\Command;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use function count;
 use const DIRECTORY_SEPARATOR;
-use Doctrine\DBAL\Connection;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
 use eZ\Publish\Core\Search\Common\Indexer;
 use eZ\Publish\Core\Search\Common\IncrementalIndexer;
@@ -58,7 +57,6 @@ class ReindexCommand extends Command implements BackwardCompatibleCommand
 
     public function __construct(
         $searchIndexer,
-        Connection $connection,
         Handler $locationHandler,
         IndexerGateway $gateway,
         LoggerInterface $logger,

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml
@@ -43,4 +43,4 @@ services:
             $projectDir: '%kernel.project_dir%'
             $isDebug: '%kernel.debug%'
         tags:
-            - { name: console.command, command: ezplatform:reindex }
+            - { name: console.command }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -343,20 +343,6 @@ services:
         tags:
             - { name: console.command }
 
-    ezplatform.core.command.reindex:
-        class: eZ\Bundle\EzPublishCoreBundle\Command\ReindexCommand
-        arguments:
-            $searchIndexer: '@ezpublish.spi.search.indexer'
-            $connection: '@ezpublish.api.storage_engine.legacy.connection'
-            $locationHandler: '@ezpublish.spi.persistence.location_handler'
-            $logger: '@logger'
-            $siteaccess: '@ezpublish.siteaccess'
-            $env: '%kernel.environment%'
-            $projectDir: '%kernel.project_dir%'
-            $isDebug: '%kernel.debug%'
-        tags:
-            - { name: console.command }
-
     ibexa.doctrine.orm.entity_manager:
         class: Doctrine\ORM\EntityManager
         lazy: true


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-143](https://issues.ibexa.co/browse/IBX-143)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no
| **Tests pass**              | yes, failure is unrelated

This PR aligns a merge up of ezsystems/ezpublish-kernel#3094 changes with master.
All commands are defined in `eZ/Bundle/EzPublishCoreBundle/Resources/config/commands.yml`, so the old definition was removed from `eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml`. 

Moreover the command can't be lazy as it seems not compatible with `BackwardCompatibleCommand` feature (making both `ibexa:reindex` and `ezplatform:reindex` available, with the latter one triggering deprecation warning).

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage (ezsystems/ezpublish-kernel#3094).
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).