### PR TITLE
IBX-85: Fixed Content cache containing invalid "uri" for file field types

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Automatic Changelog Generator for tag
+
+on:  
+  push:
+    tags:
+      - 'v*'
+      - '!v*-alpha*'
+      - '!v*-beta*'
+      - '!v*-rc*'
+
+jobs:  
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Set Environment
+        run: |
+          echo "BUILD_TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+
+      - name: Get previous release tag based on type
+        id: prevrelease
+        uses: ibexa/version-logic-action@master
+        with:
+          currentTag: ${{ env.BUILD_TAG }}
+
+      - name: Generate changelog
+        id: changelog
+        uses: ibexa/changelog-generator-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          currentTag: ${{ env.BUILD_TAG }}
+          previousTag: ${{ steps.prevrelease.outputs.previousTag }}
+
+      - name: Print the changelog
+        run: echo "${{ steps.changelog.outputs.changelog }}"
+
+      - name: Create Release
+        id: create_release
+        uses: zendesk/action-create-release@v1
+        with:
+          tag_name: ${{ env.BUILD_TAG }}
+          body: |
+            ${{ steps.changelog.outputs.changelog }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\FieldType\BinaryBase;
 
+use eZ\Publish\SPI\FieldType\BinaryBase\RouteAwarePathGenerator;
 use eZ\Publish\SPI\FieldType\GatewayBasedStorage;
 use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\SPI\FieldType\BinaryBase\PathGenerator;
@@ -32,7 +33,7 @@ class BinaryBaseStorage extends GatewayBasedStorage
     /** @var \eZ\Publish\SPI\IO\MimeTypeDetector */
     protected $mimeTypeDetector;
 
-    /** @var PathGenerator */
+    /** @var \eZ\Publish\SPI\FieldType\BinaryBase\PathGenerator */
     protected $downloadUrlGenerator;
 
     /** @var \eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage\Gateway */
@@ -59,7 +60,7 @@ class BinaryBaseStorage extends GatewayBasedStorage
     }
 
     /**
-     * @param PathGenerator $downloadUrlGenerator
+     * @param \eZ\Publish\SPI\FieldType\BinaryBase\PathGenerator $downloadUrlGenerator
      */
     public function setDownloadUrlGenerator(PathGenerator $downloadUrlGenerator)
     {
@@ -146,9 +147,21 @@ class BinaryBaseStorage extends GatewayBasedStorage
         if ($field->value->externalData !== null) {
             $binaryFile = $this->ioService->loadBinaryFile($field->value->externalData['id']);
             $field->value->externalData['fileSize'] = $binaryFile->size;
-            $field->value->externalData['uri'] = isset($this->downloadUrlGenerator) ?
-                $this->downloadUrlGenerator->getStoragePathForField($field, $versionInfo) :
-                $binaryFile->uri;
+
+            $uri = $binaryFile->uri;
+            if (isset($this->downloadUrlGenerator)) {
+                $uri = $this->downloadUrlGenerator->getStoragePathForField($field, $versionInfo);
+
+                if ($this->downloadUrlGenerator instanceof RouteAwarePathGenerator) {
+                    $field->value->externalData['route'] = $this->downloadUrlGenerator->getRoute($field, $versionInfo);
+                    $field->value->externalData['route_parameters'] = $this->downloadUrlGenerator->getParameters(
+                        $field,
+                        $versionInfo
+                    );
+                }
+            }
+
+            $field->value->externalData['uri'] = $uri;
         }
     }
 

--- a/eZ/Publish/Core/FieldType/BinaryBase/Type.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/Type.php
@@ -8,8 +8,10 @@ namespace eZ\Publish\Core\FieldType\BinaryBase;
 
 use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
+use eZ\Publish\Core\FieldType\Media\Value;
 use eZ\Publish\Core\FieldType\ValidationError;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\SPI\FieldType\BinaryBase\RouteAwarePathGenerator;
 use eZ\Publish\SPI\FieldType\Value as SPIValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue as PersistenceValue;
 use eZ\Publish\Core\FieldType\Value as BaseValue;
@@ -20,7 +22,7 @@ use eZ\Publish\Core\FieldType\Value as BaseValue;
 abstract class Type extends FieldType
 {
     /**
-     * @see eZ\Publish\Core\FieldType::$validatorConfigurationSchema
+     * @see \eZ\Publish\Core\FieldType\FieldType::$validatorConfigurationSchema
      */
     protected $validatorConfigurationSchema = [
         'FileSizeValidator' => [
@@ -34,12 +36,16 @@ abstract class Type extends FieldType
     /** @var \eZ\Publish\Core\FieldType\Validator[] */
     private $validators;
 
+    /** @var \eZ\Publish\SPI\FieldType\BinaryBase\RouteAwarePathGenerator|null */
+    protected $routeAwarePathGenerator;
+
     /**
      * @param \eZ\Publish\Core\FieldType\Validator[] $validators
      */
-    public function __construct(array $validators)
+    public function __construct(array $validators, ?RouteAwarePathGenerator $routeAwarePathGenerator = null)
     {
         $this->validators = $validators;
+        $this->routeAwarePathGenerator = $routeAwarePathGenerator;
     }
 
     /**
@@ -50,6 +56,20 @@ abstract class Type extends FieldType
      * @return Value
      */
     abstract protected function createValue(array $inputValue);
+
+    final protected function regenerateUri(array $inputValue): array
+    {
+        if (isset($this->routeAwarePathGenerator, $inputValue['route'])) {
+            $inputValue['uri'] = $this->routeAwarePathGenerator->generate(
+                $inputValue['route'],
+                $inputValue['route_parameters'] ?? []
+            );
+        }
+
+        unset($inputValue['route'], $inputValue['route_parameters']);
+
+        return $inputValue;
+    }
 
     /**
      * @param \eZ\Publish\Core\FieldType\BinaryBase\Value|\eZ\Publish\SPI\FieldType\Value $value
@@ -245,27 +265,23 @@ abstract class Type extends FieldType
     {
         // Restored data comes in $data, since it has already been processed
         // there might be more data in the persistence value than needed here
-        $result = $this->fromHash(
-            [
-                'id' => (isset($fieldValue->externalData['id'])
-                    ? $fieldValue->externalData['id']
-                    : null),
-                'fileName' => (isset($fieldValue->externalData['fileName'])
-                    ? $fieldValue->externalData['fileName']
-                    : null),
-                'fileSize' => (isset($fieldValue->externalData['fileSize'])
-                    ? $fieldValue->externalData['fileSize']
-                    : null),
-                'mimeType' => (isset($fieldValue->externalData['mimeType'])
-                    ? $fieldValue->externalData['mimeType']
-                    : null),
-                'uri' => (isset($fieldValue->externalData['uri'])
-                    ? $fieldValue->externalData['uri']
-                    : null),
-            ]
-        );
+        $hash = [
+            'id' => $fieldValue->externalData['id'] ?? null,
+            'fileName' => $fieldValue->externalData['fileName'] ?? null,
+            'fileSize' => $fieldValue->externalData['fileSize'] ?? null,
+            'mimeType' => $fieldValue->externalData['mimeType'] ?? null,
+            'uri' => $fieldValue->externalData['uri'] ?? null,
+        ];
 
-        return $result;
+        if (isset($fieldValue->externalData['route'])) {
+            $hash['route'] = $fieldValue->externalData['route'];
+        }
+
+        if (isset($fieldValue->externalData['route_parameters'])) {
+            $hash['route_parameters'] = $fieldValue->externalData['route_parameters'];
+        }
+
+        return $this->fromHash($hash);
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/BinaryFile/Type.php
+++ b/eZ/Publish/Core/FieldType/BinaryFile/Type.php
@@ -44,10 +44,12 @@ class Type extends BinaryBaseType
      *
      * @param array $inputValue
      *
-     * @return Value
+     * @return \eZ\Publish\Core\FieldType\BinaryFile\Value
      */
     protected function createValue(array $inputValue)
     {
+        $inputValue = $this->regenerateUri($inputValue);
+
         return new Value($inputValue);
     }
 

--- a/eZ/Publish/Core/FieldType/Media/Type.php
+++ b/eZ/Publish/Core/FieldType/Media/Type.php
@@ -120,10 +120,12 @@ class Type extends BaseType
      *
      * @param array $inputValue
      *
-     * @return Value
+     * @return \eZ\Publish\Core\FieldType\Media\Value
      */
     protected function createValue(array $inputValue)
     {
+        $inputValue = $this->regenerateUri($inputValue);
+
         return new Value($inputValue);
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/BinaryFileTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/BinaryFileTest.php
@@ -9,11 +9,15 @@ namespace eZ\Publish\Core\FieldType\Tests;
 use eZ\Publish\Core\FieldType\BinaryFile\Type as BinaryFileType;
 use eZ\Publish\Core\FieldType\BinaryFile\Value as BinaryFileValue;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
+use eZ\Publish\Core\FieldType\FieldType;
 use eZ\Publish\Core\FieldType\ValidationError;
+use eZ\Publish\SPI\FieldType\BinaryBase\RouteAwarePathGenerator;
 
 /**
  * @group fieldType
  * @group ezbinaryfile
+ *
+ * @covers \eZ\Publish\Core\FieldType\BinaryFile\Type
  */
 class BinaryFileTest extends BinaryBaseTest
 {
@@ -26,11 +30,14 @@ class BinaryFileTest extends BinaryBaseTest
      * NOT take care for test case wide caching of the field type, just return
      * a new instance from this method!
      *
-     * @return FieldType
+     * @return \eZ\Publish\Core\FieldType\FieldType
      */
-    protected function createFieldTypeUnderTest()
+    protected function createFieldTypeUnderTest(): FieldType
     {
-        $fieldType = new BinaryFileType([$this->getBlackListValidatorMock()]);
+        $fieldType = new BinaryFileType(
+            [$this->getBlackListValidatorMock()],
+            $this->getRouteAwarePathGenerator()
+        );
         $fieldType->setTransformationProcessor($this->getTransformationProcessorMock());
 
         return $fieldType;
@@ -445,6 +452,55 @@ class BinaryFileTest extends BinaryBaseTest
                     ]
                 ),
             ],
+            [
+                [
+                    'id' => __FILE__,
+                    'fileName' => 'sindelfingen.jpg',
+                    'fileSize' => 2342,
+                    'downloadCount' => 0,
+                    'mimeType' => 'image/jpeg',
+                    'uri' => 'some_uri_acquired_from_SPI',
+                    'route' => 'some_route',
+                ],
+                new BinaryFileValue(
+                    [
+                        'id' => null,
+                        'inputUri' => __FILE__,
+                        'path' => __FILE__,
+                        'fileName' => 'sindelfingen.jpg',
+                        'fileSize' => 2342,
+                        'downloadCount' => 0,
+                        'mimeType' => 'image/jpeg',
+                        'uri' => '__GENERATED_URI__',
+                    ]
+                ),
+            ],
+            [
+                [
+                    'id' => __FILE__,
+                    'fileName' => 'sindelfingen.jpg',
+                    'fileSize' => 2342,
+                    'downloadCount' => 0,
+                    'mimeType' => 'image/jpeg',
+                    'uri' => 'some_uri_acquired_from_SPI',
+                    'route' => 'some_route',
+                    'route_parameters' => [
+                        'any_param' => true,
+                    ],
+                ],
+                new BinaryFileValue(
+                    [
+                        'id' => null,
+                        'inputUri' => __FILE__,
+                        'path' => __FILE__,
+                        'fileName' => 'sindelfingen.jpg',
+                        'fileSize' => 2342,
+                        'downloadCount' => 0,
+                        'mimeType' => 'image/jpeg',
+                        'uri' => '__GENERATED_URI_WITH_PARAMS__',
+                    ]
+                ),
+            ],
             // @todo: Provide upload struct (via REST)!
         ];
     }
@@ -575,5 +631,20 @@ class BinaryFileTest extends BinaryBaseTest
                 ],
             ],
         ];
+    }
+
+    private function getRouteAwarePathGenerator(): RouteAwarePathGenerator
+    {
+        $mock = $this->createMock(RouteAwarePathGenerator::class);
+        $mock->method('generate')
+            ->willReturnCallback(static function (string $route, array $routeParameters = []): string {
+                if ($routeParameters) {
+                    return '__GENERATED_URI_WITH_PARAMS__';
+                }
+
+                return '__GENERATED_URI__';
+            });
+
+        return $mock;
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/BinaryBase/ContentDownloadUrlGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/BinaryBase/ContentDownloadUrlGenerator.php
@@ -7,14 +7,18 @@
 namespace eZ\Publish\Core\MVC\Symfony\FieldType\BinaryBase;
 
 use eZ\Publish\SPI\FieldType\BinaryBase\PathGenerator;
+use eZ\Publish\SPI\FieldType\BinaryBase\RouteAwarePathGenerator;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use Symfony\Component\Routing\RouterInterface;
 
-class ContentDownloadUrlGenerator extends PathGenerator
+class ContentDownloadUrlGenerator extends PathGenerator implements RouteAwarePathGenerator
 {
     /** @var \Symfony\Component\Routing\RouterInterface */
     private $router;
+
+    /** @var string */
+    private $route = 'ez_content_download_field_id';
 
     public function __construct(RouterInterface $router)
     {
@@ -23,13 +27,25 @@ class ContentDownloadUrlGenerator extends PathGenerator
 
     public function getStoragePathForField(Field $field, VersionInfo $versionInfo)
     {
-        return $this->router->generate(
-            'ez_content_download_field_id',
-            [
-                'contentId' => $versionInfo->contentInfo->id,
-                'fieldId' => $field->id,
-                'version' => $versionInfo->versionNo,
-            ]
-        );
+        return $this->generate($this->route, $this->getParameters($field, $versionInfo));
+    }
+
+    public function generate(string $route, ?array $parameters = []): string
+    {
+        return $this->router->generate($route, $parameters ?? []);
+    }
+
+    public function getRoute(Field $field, VersionInfo $versionInfo): string
+    {
+        return $this->route;
+    }
+
+    public function getParameters(Field $field, VersionInfo $versionInfo): array
+    {
+        return [
+            'contentId' => $versionInfo->contentInfo->id,
+            'fieldId' => $field->id,
+            'version' => $versionInfo->versionNo,
+        ];
     }
 }

--- a/eZ/Publish/Core/settings/fieldtypes.yml
+++ b/eZ/Publish/Core/settings/fieldtypes.yml
@@ -266,6 +266,7 @@ services:
         class: eZ\Publish\Core\FieldType\BinaryFile\Type
         arguments:
             - ['@ezpublish.fieldType.validator.black_list']
+            - "@?ezpublish.fieldType.ezbinarybase.download_url_generator"
         parent: ezpublish.fieldType
         tags:
             - {name: ezplatform.field_type, alias: ezbinaryfile}
@@ -345,6 +346,7 @@ services:
         class: eZ\Publish\Core\FieldType\Media\Type
         arguments:
             - ['@ezpublish.fieldType.validator.black_list']
+            - "@?ezpublish.fieldType.ezbinarybase.download_url_generator"
         parent: ezpublish.fieldType
         tags:
             - {name: ezplatform.field_type, alias: ezmedia}

--- a/eZ/Publish/SPI/FieldType/BinaryBase/PathGenerator.php
+++ b/eZ/Publish/SPI/FieldType/BinaryBase/PathGenerator.php
@@ -9,7 +9,10 @@ namespace eZ\Publish\SPI\FieldType\BinaryBase;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 use eZ\Publish\SPI\Persistence\Content\Field;
 
-abstract class PathGenerator
+/**
+ * @deprecated use \eZ\Publish\SPI\FieldType\BinaryBase\PathGeneratorInterface instead.
+ */
+abstract class PathGenerator implements PathGeneratorInterface
 {
     abstract public function getStoragePathForField(Field $field, VersionInfo $versionInfo);
 }

--- a/eZ/Publish/SPI/FieldType/BinaryBase/PathGeneratorInterface.php
+++ b/eZ/Publish/SPI/FieldType/BinaryBase/PathGeneratorInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\FieldType\BinaryBase;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+
+interface PathGeneratorInterface
+{
+    public function getStoragePathForField(Field $field, VersionInfo $versionInfo);
+}

--- a/eZ/Publish/SPI/FieldType/BinaryBase/RouteAwarePathGenerator.php
+++ b/eZ/Publish/SPI/FieldType/BinaryBase/RouteAwarePathGenerator.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\SPI\FieldType\BinaryBase;
+
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+
+/**
+ * A variant of PathGenerator that uses Symfony routes for generating URIs.
+ */
+interface RouteAwarePathGenerator extends PathGeneratorInterface
+{
+    public function getRoute(Field $field, VersionInfo $versionInfo): string;
+
+    public function getParameters(Field $field, VersionInfo $versionInfo): array;
+
+    public function generate(string $route, array $parameters = []): string;
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-85](https://issues.ibexa.co/browse/IBX-85)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.3` & `2.5`
| **BC breaks**                          | no
| **Doc needed**                       | no

Merge up for https://github.com/ezsystems/ezpublish-kernel/pull/3096

> This fixes the issue of Content sharing field with Site-Access aware/reliant external data.
> 
> The root of the issue is that "uri" for `BinaryFileField` is calculated right after it is acquired from the database, in SPI persistence layer. This causes cache to contain this calculated "uri" value in all SiteAccess' that share the same cache key.
> 
> Solution involves:
> 1. Extending the `eZ\Publish\Core\MVC\Symfony\FieldType\BinaryBase\ContentDownloadUrlGenerator` with additional methods that would allow recovering of the route and parameters used for the "uri" calculation. A new `eZ\Publish\SPI\FieldType\BinaryBase\RouteAwarePathGenerator` is introduced to mark their presence.
> 2. Making `eZ\Publish\Core\FieldType\BinaryBase\BinaryBaseStorage::getFieldData`, which is called internally by `eZ\Publish\Core\Persistence\Legacy\Content\Handler::load`, add "route" and "route_parameters" to external data (if `RouteAwarePathGenerator` is used). They are stored into cache alongside the calculated "uri" for BC compatibility.
> 3. Have classes descending from `eZ\Publish\Core\FieldType\BinaryBase\Type` use newly introduced `regenerateUri` method that recalculates the "uri" from cached "route" and "route_parameters", if they are present.
> 
> ## How to reproduce the issue
> 1. Add a new Media File
> ![image](https://user-images.githubusercontent.com/3183926/113995663-bcf95b80-9856-11eb-8401-cb34d75a551a.png)
> 
> 2. Either manually clear cache and visit admin file content page, or trigger any admin edit actions that result in cache being regenerated.
> 
> 3. Observe the URI generated for `content.fields` in template.
> (`vendor/ezsystems/ezplatform-admin-ui/src/bundle/Resources/views/themes/admin/content/location_view.html.twig`)
> ![image](https://user-images.githubusercontent.com/3183926/114001879-a6560300-985c-11eb-89cd-c2d8260eb2d3.png)
> ![image](https://user-images.githubusercontent.com/3183926/114000359-385d0c00-985b-11eb-9e84-3c08eb599bef.png)
> 
> 4. Visit the content location. Observe that the URL in template for `content.fields` is the same as the one visible in admin. That's the bug. (`eZ/Bundle/EzPublishCoreBundle/Resources/views/default/content/full.html.twig`)
> ![image](https://user-images.githubusercontent.com/3183926/114001990-bff74a80-985c-11eb-920c-dd505a550df5.png)
> ![image](https://user-images.githubusercontent.com/3183926/114000478-54f94400-985b-11eb-9771-a26d2aff2d19.png)
> 
> ## Note
> Our content field templates do regenerate the URI during rendering (`eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig`).
> ![image](https://user-images.githubusercontent.com/3183926/114001706-76a6fb00-985c-11eb-974e-36815d9dffb7.png)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
