### PR TITLE
IBX-340: Allowed URL Gateway queries to not perform count operations

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseURLServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseURLServiceTest.php
@@ -22,7 +22,7 @@ abstract class BaseURLServiceTest extends BaseTest
 {
     private const URL_CONTENT_TYPE_IDENTIFIER = 'link_ct';
 
-    protected function doTestFindUrls(URLQuery $query, array $expectedUrls, $expectedTotalCount = null, $ignoreOrder = true)
+    protected function doTestFindUrls(URLQuery $query, array $expectedUrls, ?int $expectedTotalCount, bool $ignoreOrder = true)
     {
         $repository = $this->getRepository();
 
@@ -30,12 +30,8 @@ abstract class BaseURLServiceTest extends BaseTest
         $searchResult = $repository->getURLService()->findUrls($query);
         /* END: Use Case */
 
-        if ($expectedTotalCount === null) {
-            $expectedTotalCount = count($expectedUrls);
-        }
-
         $this->assertInstanceOf(SearchResult::class, $searchResult);
-        $this->assertEquals($expectedTotalCount, $searchResult->totalCount);
+        $this->assertSame($expectedTotalCount, $searchResult->totalCount);
         $this->assertSearchResultItems($searchResult, $expectedUrls, $ignoreOrder);
     }
 

--- a/eZ/Publish/API/Repository/Tests/URLServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLServiceTest.php
@@ -23,6 +23,8 @@ use eZ\Publish\API\Repository\Values\URL\UsageSearchResult;
  */
 class URLServiceTest extends BaseURLServiceTest
 {
+    private const TOTAL_URLS_COUNT = 20;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -194,7 +196,44 @@ class URLServiceTest extends BaseURLServiceTest
         $query = new URLQuery();
         $query->filter = new Criterion\MatchAll();
 
-        $this->doTestFindUrls($query, $expectedUrls);
+        $this->doTestFindUrls($query, $expectedUrls, count($expectedUrls));
+    }
+
+    /**
+     * Test for URLService::findUrls() method.
+     *
+     * @see \eZ\Publish\Core\Repository\URLService::findUrls()
+     */
+    public function testFindUrlsWithoutCounting()
+    {
+        $expectedUrls = [
+            'http://www.apache.org/',
+            'http://calendar.google.com/calendar/render',
+            'http://www.dropbox.com/',
+            '/content/view/sitemap/2',
+            'http://support.google.com/chrome/answer/95647?hl=es',
+            'http://www.nazwa.pl/',
+            'http://www.facebook.com/sharer.php',
+            'http://www.wikipedia.org/',
+            'http://www.google.de/',
+            'http://www.google.com/',
+            'http://www.nginx.com/',
+            '/content/view/tagcloud/2',
+            'http://www.youtube.com/',
+            'http://vimeo.com/',
+            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'http://twitter.com/',
+            'http://www.google.com/analytics/',
+            'http://www.facebook.com/',
+            'http://www.discuz.net/forum.php',
+            'http://instagram.com/',
+        ];
+
+        $query = new URLQuery();
+        $query->filter = new Criterion\MatchAll();
+        $query->performCount = false;
+
+        $this->doTestFindUrls($query, $expectedUrls, null);
     }
 
     /**
@@ -208,7 +247,7 @@ class URLServiceTest extends BaseURLServiceTest
         $query = new URLQuery();
         $query->filter = new Criterion\MatchNone();
 
-        $this->doTestFindUrls($query, []);
+        $this->doTestFindUrls($query, [], 0);
     }
 
     /**
@@ -230,7 +269,7 @@ class URLServiceTest extends BaseURLServiceTest
         $query = new URLQuery();
         $query->filter = new Criterion\Pattern('google');
 
-        $this->doTestFindUrls($query, $expectedUrls);
+        $this->doTestFindUrls($query, $expectedUrls, count($expectedUrls));
     }
 
     /**
@@ -266,7 +305,7 @@ class URLServiceTest extends BaseURLServiceTest
         $query = new URLQuery();
         $query->filter = new Criterion\Validity(true);
 
-        $this->doTestFindUrls($query, $expectedUrls);
+        $this->doTestFindUrls($query, $expectedUrls, count($expectedUrls));
     }
 
     /**
@@ -286,7 +325,7 @@ class URLServiceTest extends BaseURLServiceTest
         $query = new URLQuery();
         $query->filter = new Criterion\SectionId([3]);
 
-        $this->doTestFindUrls($query, $expectedUrls);
+        $this->doTestFindUrls($query, $expectedUrls, count($expectedUrls));
     }
 
     /**
@@ -309,7 +348,7 @@ class URLServiceTest extends BaseURLServiceTest
             new Criterion\Validity(true),
         ]);
 
-        $this->doTestFindUrls($query, $expectedUrls);
+        $this->doTestFindUrls($query, $expectedUrls, count($expectedUrls));
     }
 
     /**
@@ -329,7 +368,7 @@ class URLServiceTest extends BaseURLServiceTest
         $query = new URLQuery();
         $query->filter = new Criterion\SectionIdentifier(['media']);
 
-        $this->doTestFindUrls($query, $expectedUrls);
+        $this->doTestFindUrls($query, $expectedUrls, count($expectedUrls));
     }
 
     /**
@@ -354,7 +393,7 @@ class URLServiceTest extends BaseURLServiceTest
             new Criterion\Validity(true),
         ]);
 
-        $this->doTestFindUrls($query, $expectedUrls);
+        $this->doTestFindUrls($query, $expectedUrls, count($expectedUrls));
     }
 
     /**
@@ -379,7 +418,7 @@ class URLServiceTest extends BaseURLServiceTest
             new Criterion\SectionId([2]),
         ]);
 
-        $this->doTestFindUrls($query, $expectedUrls);
+        $this->doTestFindUrls($query, $expectedUrls, count($expectedUrls));
     }
 
     /**
@@ -397,7 +436,7 @@ class URLServiceTest extends BaseURLServiceTest
         $query = new URLQuery();
         $query->filter = new Criterion\Validity(false);
 
-        $this->doTestFindUrls($query, $expectedUrls);
+        $this->doTestFindUrls($query, $expectedUrls, count($expectedUrls));
     }
 
     /**
@@ -433,7 +472,7 @@ class URLServiceTest extends BaseURLServiceTest
         $query = new URLQuery();
         $query->filter = new Criterion\VisibleOnly();
 
-        $this->doTestFindUrls($query, $expectedUrls);
+        $this->doTestFindUrls($query, $expectedUrls, count($expectedUrls));
     }
 
     /**
@@ -464,8 +503,6 @@ class URLServiceTest extends BaseURLServiceTest
      */
     public function testFindUrlsWithInvalidOffsetThrowsInvalidArgumentException()
     {
-        $this->expectException(\eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue::class);
-
         $query = new URLQuery();
         $query->filter = new Criterion\MatchAll();
         $query->offset = 'invalid!';
@@ -474,7 +511,8 @@ class URLServiceTest extends BaseURLServiceTest
 
         /* BEGIN: Use Case */
         $urlService = $repository->getURLService();
-        // This call will fail with a InvalidArgumentException
+
+        $this->expectException(\eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue::class);
         $urlService->findUrls($query);
         /* END: Use Case */
     }
@@ -486,8 +524,6 @@ class URLServiceTest extends BaseURLServiceTest
      */
     public function testFindUrlsWithInvalidLimitThrowsInvalidArgumentException()
     {
-        $this->expectException(\eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue::class);
-
         $query = new URLQuery();
         $query->filter = new Criterion\MatchAll();
         $query->limit = 'invalid!';
@@ -496,7 +532,8 @@ class URLServiceTest extends BaseURLServiceTest
 
         /* BEGIN: Use Case */
         $urlService = $repository->getURLService();
-        // This call will fail with a InvalidArgumentException
+
+        $this->expectException(\eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue::class);
         $urlService->findUrls($query);
         /* END: Use Case */
     }
@@ -527,7 +564,7 @@ class URLServiceTest extends BaseURLServiceTest
         $query->offset = 10;
         $query->sortClauses = [new SortClause\Id()];
 
-        $this->doTestFindUrls($query, $expectedUrls, 20);
+        $this->doTestFindUrls($query, $expectedUrls, self::TOTAL_URLS_COUNT);
     }
 
     /**
@@ -550,7 +587,7 @@ class URLServiceTest extends BaseURLServiceTest
         $query->limit = 3;
         $query->sortClauses = [new SortClause\Id()];
 
-        $this->doTestFindUrls($query, $expectedUrls, 20);
+        $this->doTestFindUrls($query, $expectedUrls, self::TOTAL_URLS_COUNT);
     }
 
     /**
@@ -565,7 +602,7 @@ class URLServiceTest extends BaseURLServiceTest
         $query->filter = new Criterion\MatchAll();
         $query->limit = 0;
 
-        $this->doTestFindUrls($query, [], 20);
+        $this->doTestFindUrls($query, [], self::TOTAL_URLS_COUNT);
     }
 
     /**
@@ -581,7 +618,7 @@ class URLServiceTest extends BaseURLServiceTest
         $query->filter = new Criterion\MatchAll();
         $query->sortClauses = [$sortClause];
 
-        $this->doTestFindUrls($query, $expectedUrls, null, false);
+        $this->doTestFindUrls($query, $expectedUrls, count($expectedUrls), false);
     }
 
     public function dataProviderForFindUrlsWithSorting()
@@ -751,16 +788,14 @@ class URLServiceTest extends BaseURLServiceTest
      */
     public function testLoadByIdThrowsNotFoundException()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
-
         $repository = $this->getRepository();
 
         $nonExistentUrlId = $this->generateId('url', self::DB_INT_MAX);
         /* BEGIN: Use Case */
         $urlService = $repository->getURLService();
 
-        // This call will fail with a NotFoundException
-        $url = $urlService->loadById($nonExistentUrlId);
+        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
+        $urlService->loadById($nonExistentUrlId);
         /* END: Use Case */
     }
 
@@ -800,16 +835,14 @@ class URLServiceTest extends BaseURLServiceTest
      */
     public function testLoadByUrlThrowsNotFoundException()
     {
-        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
-
         $repository = $this->getRepository();
 
         $nonExistentUrl = 'https://laravel.com/';
         /* BEGIN: Use Case */
         $urlService = $repository->getURLService();
 
-        // This call will fail with a NotFoundException
-        $url = $urlService->loadByUrl($nonExistentUrl);
+        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
+        $urlService->loadByUrl($nonExistentUrl);
         /* END: Use Case */
     }
 

--- a/eZ/Publish/API/Repository/Tests/URLServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLServiceTest.php
@@ -32,109 +32,109 @@ class URLServiceTest extends BaseURLServiceTest
         $urls = [
             [
                 'name' => 'Twitter',
-                'url' => 'http://twitter.com/',
+                'url' => 'https://twitter.com/',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'Facebook',
-                'url' => 'http://www.facebook.com/',
+                'url' => 'https://www.facebook.com/',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'Google',
-                'url' => 'http://www.google.com/',
+                'url' => 'https://www.google.com/',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'Vimeo',
-                'url' => 'http://vimeo.com/',
+                'url' => 'https://vimeo.com/',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'Facebook Sharer',
-                'url' => 'http://www.facebook.com/sharer.php',
+                'url' => 'https://www.facebook.com/sharer.php',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'Youtube',
-                'url' => 'http://www.youtube.com/',
+                'url' => 'https://www.youtube.com/',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'Googel support',
-                'url' => 'http://support.google.com/chrome/answer/95647?hl=es',
+                'url' => 'https://support.google.com/chrome/answer/95647?hl=es',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'Instagram',
-                'url' => 'http://instagram.com/',
+                'url' => 'https://instagram.com/',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'Discuz',
-                'url' => 'http://www.discuz.net/forum.php',
+                'url' => 'https://www.discuz.net/forum.php',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'Google calendar',
-                'url' => 'http://calendar.google.com/calendar/render',
+                'url' => 'https://calendar.google.com/calendar/render',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'Wikipedia',
-                'url' => 'http://www.wikipedia.org/',
+                'url' => 'https://www.wikipedia.org/',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'Google Analytics',
-                'url' => 'http://www.google.com/analytics/',
+                'url' => 'https://www.google.com/analytics/',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'nazwa.pl',
-                'url' => 'http://www.nazwa.pl/',
+                'url' => 'https://www.nazwa.pl/',
                 'published' => true,
                 'sectionId' => 1,
             ],
             [
                 'name' => 'Apache',
-                'url' => 'http://www.apache.org/',
+                'url' => 'https://www.apache.org/',
                 'published' => true,
                 'sectionId' => 2,
             ],
             [
                 'name' => 'Nginx',
-                'url' => 'http://www.nginx.com/',
+                'url' => 'https://www.nginx.com/',
                 'published' => true,
                 'sectionId' => 2,
             ],
             [
                 'name' => 'Microsoft.com',
-                'url' => 'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+                'url' => 'https://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
                 'published' => true,
                 'sectionId' => 3,
             ],
             [
                 'name' => 'Dropbox',
-                'url' => 'http://www.dropbox.com/',
+                'url' => 'https://www.dropbox.com/',
                 'published' => false,
                 'sectionId' => 3,
             ],
             [
                 'name' => 'Google [DE]',
-                'url' => 'http://www.google.de/',
+                'url' => 'https://www.google.de/',
                 'published' => true,
                 'sectionId' => 3,
             ],
@@ -171,26 +171,26 @@ class URLServiceTest extends BaseURLServiceTest
     public function testFindUrls()
     {
         $expectedUrls = [
-            'http://www.apache.org/',
-            'http://calendar.google.com/calendar/render',
-            'http://www.dropbox.com/',
+            'https://www.apache.org/',
+            'https://calendar.google.com/calendar/render',
+            'https://www.dropbox.com/',
             '/content/view/sitemap/2',
-            'http://support.google.com/chrome/answer/95647?hl=es',
-            'http://www.nazwa.pl/',
-            'http://www.facebook.com/sharer.php',
-            'http://www.wikipedia.org/',
-            'http://www.google.de/',
-            'http://www.google.com/',
-            'http://www.nginx.com/',
+            'https://support.google.com/chrome/answer/95647?hl=es',
+            'https://www.nazwa.pl/',
+            'https://www.facebook.com/sharer.php',
+            'https://www.wikipedia.org/',
+            'https://www.google.de/',
+            'https://www.google.com/',
+            'https://www.nginx.com/',
             '/content/view/tagcloud/2',
-            'http://www.youtube.com/',
-            'http://vimeo.com/',
-            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
-            'http://twitter.com/',
-            'http://www.google.com/analytics/',
-            'http://www.facebook.com/',
-            'http://www.discuz.net/forum.php',
-            'http://instagram.com/',
+            'https://www.youtube.com/',
+            'https://vimeo.com/',
+            'https://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'https://twitter.com/',
+            'https://www.google.com/analytics/',
+            'https://www.facebook.com/',
+            'https://www.discuz.net/forum.php',
+            'https://instagram.com/',
         ];
 
         $query = new URLQuery();
@@ -207,26 +207,26 @@ class URLServiceTest extends BaseURLServiceTest
     public function testFindUrlsWithoutCounting()
     {
         $expectedUrls = [
-            'http://www.apache.org/',
-            'http://calendar.google.com/calendar/render',
-            'http://www.dropbox.com/',
+            'https://www.apache.org/',
+            'https://calendar.google.com/calendar/render',
+            'https://www.dropbox.com/',
             '/content/view/sitemap/2',
-            'http://support.google.com/chrome/answer/95647?hl=es',
-            'http://www.nazwa.pl/',
-            'http://www.facebook.com/sharer.php',
-            'http://www.wikipedia.org/',
-            'http://www.google.de/',
-            'http://www.google.com/',
-            'http://www.nginx.com/',
+            'https://support.google.com/chrome/answer/95647?hl=es',
+            'https://www.nazwa.pl/',
+            'https://www.facebook.com/sharer.php',
+            'https://www.wikipedia.org/',
+            'https://www.google.de/',
+            'https://www.google.com/',
+            'https://www.nginx.com/',
             '/content/view/tagcloud/2',
-            'http://www.youtube.com/',
-            'http://vimeo.com/',
-            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
-            'http://twitter.com/',
-            'http://www.google.com/analytics/',
-            'http://www.facebook.com/',
-            'http://www.discuz.net/forum.php',
-            'http://instagram.com/',
+            'https://www.youtube.com/',
+            'https://vimeo.com/',
+            'https://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'https://twitter.com/',
+            'https://www.google.com/analytics/',
+            'https://www.facebook.com/',
+            'https://www.discuz.net/forum.php',
+            'https://instagram.com/',
         ];
 
         $query = new URLQuery();
@@ -259,11 +259,11 @@ class URLServiceTest extends BaseURLServiceTest
     public function testFindUrlsUsingPatternCriterion()
     {
         $expectedUrls = [
-            'http://www.google.de/',
-            'http://www.google.com/',
-            'http://support.google.com/chrome/answer/95647?hl=es',
-            'http://calendar.google.com/calendar/render',
-            'http://www.google.com/analytics/',
+            'https://www.google.de/',
+            'https://www.google.com/',
+            'https://support.google.com/chrome/answer/95647?hl=es',
+            'https://calendar.google.com/calendar/render',
+            'https://www.google.com/analytics/',
         ];
 
         $query = new URLQuery();
@@ -281,25 +281,25 @@ class URLServiceTest extends BaseURLServiceTest
     public function testFindUrlsUsingValidityCriterionValid()
     {
         $expectedUrls = [
-            'http://www.google.com/',
+            'https://www.google.com/',
             '/content/view/sitemap/2',
-            'http://support.google.com/chrome/answer/95647?hl=es',
-            'http://www.google.de/',
-            'http://www.nginx.com/',
-            'http://www.google.com/analytics/',
-            'http://www.discuz.net/forum.php',
-            'http://www.wikipedia.org/',
-            'http://www.facebook.com/sharer.php',
-            'http://twitter.com/',
-            'http://www.nazwa.pl/',
-            'http://instagram.com/',
-            'http://www.apache.org/',
-            'http://www.dropbox.com/',
-            'http://www.facebook.com/',
-            'http://www.youtube.com/',
-            'http://calendar.google.com/calendar/render',
-            'http://vimeo.com/',
-            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'https://support.google.com/chrome/answer/95647?hl=es',
+            'https://www.google.de/',
+            'https://www.nginx.com/',
+            'https://www.google.com/analytics/',
+            'https://www.discuz.net/forum.php',
+            'https://www.wikipedia.org/',
+            'https://www.facebook.com/sharer.php',
+            'https://twitter.com/',
+            'https://www.nazwa.pl/',
+            'https://instagram.com/',
+            'https://www.apache.org/',
+            'https://www.dropbox.com/',
+            'https://www.facebook.com/',
+            'https://www.youtube.com/',
+            'https://calendar.google.com/calendar/render',
+            'https://vimeo.com/',
+            'https://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
         ];
 
         $query = new URLQuery();
@@ -317,9 +317,9 @@ class URLServiceTest extends BaseURLServiceTest
     public function testFindUrlsUsingSectionIdCriterion(): void
     {
         $expectedUrls = [
-            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
-            'http://www.dropbox.com/',
-            'http://www.google.de/',
+            'https://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'https://www.dropbox.com/',
+            'https://www.google.de/',
         ];
 
         $query = new URLQuery();
@@ -337,9 +337,9 @@ class URLServiceTest extends BaseURLServiceTest
     public function testFindUrlsUsingSectionIdAndValidityCriterionValid(): void
     {
         $expectedUrls = [
-            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
-            'http://www.dropbox.com/',
-            'http://www.google.de/',
+            'https://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'https://www.dropbox.com/',
+            'https://www.google.de/',
         ];
 
         $query = new URLQuery();
@@ -360,9 +360,9 @@ class URLServiceTest extends BaseURLServiceTest
     public function testFindUrlsUsingSectionIdentifierCriterion(): void
     {
         $expectedUrls = [
-            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
-            'http://www.dropbox.com/',
-            'http://www.google.de/',
+            'https://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'https://www.dropbox.com/',
+            'https://www.google.de/',
         ];
 
         $query = new URLQuery();
@@ -380,11 +380,11 @@ class URLServiceTest extends BaseURLServiceTest
     public function testFindUrlsUsingSectionIdentifierAndValidityCriterionValid(): void
     {
         $expectedUrls = [
-            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
-            'http://www.dropbox.com/',
-            'http://www.google.de/',
-            'http://www.apache.org/',
-            'http://www.nginx.com/',
+            'https://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'https://www.dropbox.com/',
+            'https://www.google.de/',
+            'https://www.apache.org/',
+            'https://www.nginx.com/',
         ];
 
         $query = new URLQuery();
@@ -405,11 +405,11 @@ class URLServiceTest extends BaseURLServiceTest
     public function testFindUrlsUsingSectionIdentifierOrSectionIdCriterion(): void
     {
         $expectedUrls = [
-            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
-            'http://www.dropbox.com/',
-            'http://www.google.de/',
-            'http://www.apache.org/',
-            'http://www.nginx.com/',
+            'https://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'https://www.dropbox.com/',
+            'https://www.google.de/',
+            'https://www.apache.org/',
+            'https://www.nginx.com/',
         ];
 
         $query = new URLQuery();
@@ -448,24 +448,24 @@ class URLServiceTest extends BaseURLServiceTest
     public function testFindUrlsUsingVisibleOnlyCriterion()
     {
         $expectedUrls = [
-            'http://vimeo.com/',
-            'http://calendar.google.com/calendar/render',
-            'http://www.facebook.com/',
-            'http://www.google.com/',
-            'http://www.google.com/analytics/',
-            'http://www.facebook.com/sharer.php',
-            'http://www.apache.org/',
-            'http://www.nginx.com/',
-            'http://www.wikipedia.org/',
-            'http://www.youtube.com/',
-            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
-            'http://www.google.de/',
-            'http://instagram.com/',
-            'http://www.nazwa.pl/',
+            'https://vimeo.com/',
+            'https://calendar.google.com/calendar/render',
+            'https://www.facebook.com/',
+            'https://www.google.com/',
+            'https://www.google.com/analytics/',
+            'https://www.facebook.com/sharer.php',
+            'https://www.apache.org/',
+            'https://www.nginx.com/',
+            'https://www.wikipedia.org/',
+            'https://www.youtube.com/',
+            'https://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'https://www.google.de/',
+            'https://instagram.com/',
+            'https://www.nazwa.pl/',
             '/content/view/tagcloud/2',
-            'http://www.discuz.net/forum.php',
-            'http://support.google.com/chrome/answer/95647?hl=es',
-            'http://twitter.com/',
+            'https://www.discuz.net/forum.php',
+            'https://support.google.com/chrome/answer/95647?hl=es',
+            'https://twitter.com/',
             '/content/view/sitemap/2',
         ];
 
@@ -480,7 +480,7 @@ class URLServiceTest extends BaseURLServiceTest
      */
     public function testFindUrlsUsingVisibleOnlyCriterionReturnsUniqueItems(): void
     {
-        $exampleUrl = 'http://ezplatform.com';
+        $exampleUrl = 'https://ezplatform.com';
 
         $this->createContentWithLink('A', $exampleUrl);
         $this->createContentWithLink('B', $exampleUrl);
@@ -547,16 +547,16 @@ class URLServiceTest extends BaseURLServiceTest
     public function testFindUrlsWithOffset()
     {
         $expectedUrls = [
-            'http://www.discuz.net/forum.php',
-            'http://calendar.google.com/calendar/render',
-            'http://www.wikipedia.org/',
-            'http://www.google.com/analytics/',
-            'http://www.nazwa.pl/',
-            'http://www.apache.org/',
-            'http://www.nginx.com/',
-            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
-            'http://www.dropbox.com/',
-            'http://www.google.de/',
+            'https://www.discuz.net/forum.php',
+            'https://calendar.google.com/calendar/render',
+            'https://www.wikipedia.org/',
+            'https://www.google.com/analytics/',
+            'https://www.nazwa.pl/',
+            'https://www.apache.org/',
+            'https://www.nginx.com/',
+            'https://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'https://www.dropbox.com/',
+            'https://www.google.de/',
         ];
 
         $query = new URLQuery();
@@ -576,9 +576,9 @@ class URLServiceTest extends BaseURLServiceTest
     public function testFindUrlsWithOffsetAndLimit()
     {
         $expectedUrls = [
-            'http://www.discuz.net/forum.php',
-            'http://calendar.google.com/calendar/render',
-            'http://www.wikipedia.org/',
+            'https://www.discuz.net/forum.php',
+            'https://calendar.google.com/calendar/render',
+            'https://www.wikipedia.org/',
         ];
 
         $query = new URLQuery();
@@ -626,24 +626,24 @@ class URLServiceTest extends BaseURLServiceTest
         $urlsSortedById = [
             '/content/view/sitemap/2',
             '/content/view/tagcloud/2',
-            'http://twitter.com/',
-            'http://www.facebook.com/',
-            'http://www.google.com/',
-            'http://vimeo.com/',
-            'http://www.facebook.com/sharer.php',
-            'http://www.youtube.com/',
-            'http://support.google.com/chrome/answer/95647?hl=es',
-            'http://instagram.com/',
-            'http://www.discuz.net/forum.php',
-            'http://calendar.google.com/calendar/render',
-            'http://www.wikipedia.org/',
-            'http://www.google.com/analytics/',
-            'http://www.nazwa.pl/',
-            'http://www.apache.org/',
-            'http://www.nginx.com/',
-            'http://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
-            'http://www.dropbox.com/',
-            'http://www.google.de/',
+            'https://twitter.com/',
+            'https://www.facebook.com/',
+            'https://www.google.com/',
+            'https://vimeo.com/',
+            'https://www.facebook.com/sharer.php',
+            'https://www.youtube.com/',
+            'https://support.google.com/chrome/answer/95647?hl=es',
+            'https://instagram.com/',
+            'https://www.discuz.net/forum.php',
+            'https://calendar.google.com/calendar/render',
+            'https://www.wikipedia.org/',
+            'https://www.google.com/analytics/',
+            'https://www.nazwa.pl/',
+            'https://www.apache.org/',
+            'https://www.nginx.com/',
+            'https://windows.microsoft.com/en-US/internet-explorer/products/ie/home',
+            'https://www.dropbox.com/',
+            'https://www.google.de/',
         ];
 
         $urlsSortedByURL = $urlsSortedById;
@@ -745,7 +745,7 @@ class URLServiceTest extends BaseURLServiceTest
 
         $urlBeforeUpdate = $urlService->loadById($id);
         $updateStruct = $urlService->createUpdateStruct();
-        $updateStruct->url = 'http://www.youtube.com/';
+        $updateStruct->url = 'https://www.youtube.com/';
 
         // This call will fail with a InvalidArgumentException
         $urlService->updateUrl($urlBeforeUpdate, $updateStruct);
@@ -928,7 +928,7 @@ class URLServiceTest extends BaseURLServiceTest
         /* BEGIN: Use Case */
         $urlService = $repository->getURLService();
 
-        $loadedUrl = $urlService->loadByUrl('http://www.dropbox.com/');
+        $loadedUrl = $urlService->loadByUrl('https://www.dropbox.com/');
 
         $usagesSearchResults = $urlService->findUsages($loadedUrl);
         /* END: Use Case */

--- a/eZ/Publish/API/Repository/Values/URL/SearchResult.php
+++ b/eZ/Publish/API/Repository/Values/URL/SearchResult.php
@@ -17,7 +17,7 @@ class SearchResult extends ValueObject implements \IteratorAggregate
     /**
      * The total number of URLs.
      *
-     * @var int
+     * @var int|null
      */
     public $totalCount = 0;
 

--- a/eZ/Publish/API/Repository/Values/URL/URLQuery.php
+++ b/eZ/Publish/API/Repository/Values/URL/URLQuery.php
@@ -47,4 +47,11 @@ class URLQuery extends ValueObject
      * @var int
      */
     public $limit = 25;
+
+    /**
+     * If true, search engine should perform count even if that means extra lookup.
+     *
+     * @var bool
+     */
+    public $performCount = true;
 }

--- a/eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
@@ -129,7 +129,7 @@ class DoctrineStorageTest extends TestCase
 
         $statement = $query->execute();
 
-        $result = $statement->fetchAssociative();
+        $result = $statement->fetchAllAssociative();
 
         $expected = [
             [
@@ -159,7 +159,7 @@ class DoctrineStorageTest extends TestCase
         $query->select('*')->from('ezurl_object_link');
 
         $statement = $query->execute();
-        $result = $statement->fetchAssociative();
+        $result = $statement->fetchAllAssociative();
 
         $expected = [
             [

--- a/eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
@@ -11,10 +11,13 @@ use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage;
 use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
 
 /**
- * Url DoctrineStorage gateway tests.
+ * @covers \eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage
  */
 class DoctrineStorageTest extends TestCase
 {
+    /**
+     * @covers \eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage::getIdUrlMap
+     */
     public function testGetIdUrlMap()
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
@@ -32,6 +35,9 @@ class DoctrineStorageTest extends TestCase
         );
     }
 
+    /**
+     * @covers \eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage::getUrlIdMap
+     */
     public function testGetUrlIdMap()
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
@@ -53,6 +59,9 @@ class DoctrineStorageTest extends TestCase
         );
     }
 
+    /**
+     * @covers \eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage::insertUrl
+     */
     public function testInsertUrl()
     {
         $gateway = $this->getStorageGateway();
@@ -75,7 +84,7 @@ class DoctrineStorageTest extends TestCase
         ;
 
         $statement = $query->execute();
-        $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $result = $statement->fetchAllAssociative();
 
         $expected = [
             [
@@ -96,6 +105,9 @@ class DoctrineStorageTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    /**
+     * @covers \eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage::linkUrl
+     */
     public function testLinkUrl()
     {
         $gateway = $this->getStorageGateway();
@@ -117,7 +129,7 @@ class DoctrineStorageTest extends TestCase
 
         $statement = $query->execute();
 
-        $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $result = $statement->fetchAssociative();
 
         $expected = [
             [
@@ -130,6 +142,9 @@ class DoctrineStorageTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
+    /**
+     * @covers \eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway\DoctrineStorage::unlinkUrl
+     */
     public function testUnlinkUrl()
     {
         $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
@@ -144,7 +159,7 @@ class DoctrineStorageTest extends TestCase
         $query->select('*')->from('ezurl_object_link');
 
         $statement = $query->execute();
-        $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $result = $statement->fetchAssociative();
 
         $expected = [
             [
@@ -162,7 +177,7 @@ class DoctrineStorageTest extends TestCase
 
         $statement = $query->execute();
 
-        $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
+        $result = $statement->fetchAssociative();
 
         $expected = [
             [
@@ -179,9 +194,6 @@ class DoctrineStorageTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    /**
-     * @throws \Doctrine\DBAL\DBALException
-     */
     protected function getStorageGateway(): Gateway
     {
         if (!isset($this->storageGateway)) {

--- a/eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
@@ -177,7 +177,7 @@ class DoctrineStorageTest extends TestCase
 
         $statement = $query->execute();
 
-        $result = $statement->fetchAssociative();
+        $result = $statement->fetchAllAssociative();
 
         $expected = [
             [

--- a/eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
@@ -64,7 +64,7 @@ class DoctrineStorageTest extends TestCase
         $query = $this->connection->createQueryBuilder();
         $query
             ->select('*')
-            ->from(DoctrineStorage::URL_TABLE)
+            ->from('ezurl')
             ->where(
                 $query->expr()->eq(
                     $this->connection->quoteIdentifier('id'),
@@ -108,7 +108,7 @@ class DoctrineStorageTest extends TestCase
         $query = $this->connection->createQueryBuilder();
         $query
             ->select('*')
-            ->from(DoctrineStorage::URL_LINK_TABLE)
+            ->from('ezurl_object_link')
             ->where(
                 $query->expr()->eq($this->connection->quoteIdentifier('url_id'), ':urlId')
             )
@@ -141,7 +141,7 @@ class DoctrineStorageTest extends TestCase
         $gateway->unlinkUrl($fieldId, $versionNo);
 
         $query = $this->connection->createQueryBuilder();
-        $query->select('*')->from(DoctrineStorage::URL_LINK_TABLE);
+        $query->select('*')->from('ezurl_object_link');
 
         $statement = $query->execute();
         $result = $statement->fetchAll(\PDO::FETCH_ASSOC);
@@ -158,7 +158,7 @@ class DoctrineStorageTest extends TestCase
 
         // Check that orphaned URLs are correctly removed
         $query = $this->connection->createQueryBuilder();
-        $query->select('*')->from(DoctrineStorage::URL_TABLE);
+        $query->select('*')->from('ezurl');
 
         $statement = $query->execute();
 

--- a/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/Url/UrlStorage/Gateway/DoctrineStorage.php
@@ -9,12 +9,13 @@ namespace eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\ParameterType;
 use eZ\Publish\Core\FieldType\Url\UrlStorage\Gateway;
+use eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase;
 use PDO;
 
 class DoctrineStorage extends Gateway
 {
-    const URL_TABLE = 'ezurl';
-    const URL_LINK_TABLE = 'ezurl_object_link';
+    const URL_TABLE = DoctrineDatabase::URL_TABLE;
+    const URL_LINK_TABLE = DoctrineDatabase::URL_LINK_TABLE;
 
     /** @var \Doctrine\DBAL\Connection */
     protected $connection;

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Gateway/DoctrineDatabaseTest.php
@@ -25,45 +25,27 @@ class DoctrineDatabaseTest extends TestCase
      */
     protected $gateway;
 
-    protected $fixtureData = [
-        [
-            'id' => 23,
-            'created' => 1448832197,
-            'is_valid' => 1,
-            'last_checked' => 0,
-            'modified' => 1448832197,
-            'original_url_md5' => 'f76e41d421b2a72232264943026a6ee5',
-            'url' => 'https://doc.ez.no/display/USER/',
-        ],
-        [
-            'id' => 24,
-            'created' => 1448832277,
-            'is_valid' => 1,
-            'last_checked' => 0,
-            'modified' => 1505717756,
-            'original_url_md5' => 'a00ab36edb35bb641cc027eb27410934',
-            'url' => 'https://doc.ezplatform.com/en/latest/',
-        ],
-        [
-            'id' => 25,
-            'created' => 1448832412,
-            'is_valid' => 1,
-            'last_checked' => 0,
-            'modified' => 1505717756,
-            'original_url_md5' => '03c4188f5fdcb679192e25a7dad09c2d',
-            'url' => 'https://doc.ezplatform.com/en/latest/tutorials/platform_beginner/building_a_bicycle_route_tracker_in_ez_platform/',
-        ],
-    ];
+    /**
+     * @var array[]
+     */
+    protected $fixtureData;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $fixtureLocation = __DIR__ . '/_fixtures/urls.php';
+        $this->fixtureData = (require $fixtureLocation)['ezurl'];
+        $this->insertDatabaseFixture($fixtureLocation);
+        $this->initGateway();
+    }
 
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase::loadUrlData
      */
     public function testLoadUrlData()
     {
-        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
-        $gateway = $this->getGateway();
-
-        $row = $gateway->loadUrlData(23);
+        $row = $this->gateway->loadUrlData(23);
 
         self::assertEquals(
             $this->fixtureData[0],
@@ -76,10 +58,7 @@ class DoctrineDatabaseTest extends TestCase
      */
     public function testLoadUrlDataByUrl()
     {
-        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
-        $gateway = $this->getGateway();
-
-        $rows = $gateway->loadUrlDataByUrl('https://doc.ez.no/display/USER/');
+        $rows = $this->gateway->loadUrlDataByUrl('https://doc.ez.no/display/USER/');
 
         self::assertEquals(
             $this->fixtureData[0],
@@ -92,11 +71,8 @@ class DoctrineDatabaseTest extends TestCase
      */
     public function testFind()
     {
-        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
-        $gateway = $this->getGateway();
-
         $criterion = new \eZ\Publish\API\Repository\Values\URL\Query\Criterion\MatchAll();
-        $results = $gateway->find($criterion, 0, 10);
+        $results = $this->gateway->find($criterion, 0, 10);
 
         self::assertEquals(
             [
@@ -112,11 +88,8 @@ class DoctrineDatabaseTest extends TestCase
      */
     public function testFindWithDisabledCounting()
     {
-        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
-        $gateway = $this->getGateway();
-
         $criterion = new \eZ\Publish\API\Repository\Values\URL\Query\Criterion\MatchAll();
-        $results = $gateway->find($criterion, 0, 10, [], false);
+        $results = $this->gateway->find($criterion, 0, 10, [], false);
 
         self::assertEquals(
             [
@@ -130,7 +103,7 @@ class DoctrineDatabaseTest extends TestCase
     /**
      * Return the DoctrineDatabase gateway to test.
      */
-    protected function getGateway(): DoctrineDatabase
+    protected function initGateway(): DoctrineDatabase
     {
         if (!isset($this->gateway)) {
             $criteriaConverter = new CriteriaConverter([new MatchAll()]);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Gateway/DoctrineDatabaseTest.php
@@ -23,12 +23,10 @@ class DoctrineDatabaseTest extends TestCase
      *
      * @var \eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase
      */
-    protected $gateway;
+    private $gateway;
 
-    /**
-     * @var array[]
-     */
-    protected $fixtureData;
+    /** @var array[] */
+    private $fixtureData;
 
     protected function setUp(): void
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Gateway/DoctrineDatabaseTest.php
@@ -1,0 +1,142 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\Tests\URL\Gateway;
+
+use eZ\Publish\Core\Persistence\Legacy\Tests\TestCase;
+use eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase;
+use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriteriaConverter;
+use eZ\Publish\Core\Persistence\Legacy\URL\Query\CriterionHandler\MatchAll;
+
+/**
+ * @covers \eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase
+ */
+class DoctrineDatabaseTest extends TestCase
+{
+    /**
+     * Database gateway to test.
+     *
+     * @var \eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase
+     */
+    protected $gateway;
+
+    protected $fixtureData = [
+        [
+            'id' => 23,
+            'created' => 1448832197,
+            'is_valid' => 1,
+            'last_checked' => 0,
+            'modified' => 1448832197,
+            'original_url_md5' => 'f76e41d421b2a72232264943026a6ee5',
+            'url' => 'https://doc.ez.no/display/USER/',
+        ],
+        [
+            'id' => 24,
+            'created' => 1448832277,
+            'is_valid' => 1,
+            'last_checked' => 0,
+            'modified' => 1505717756,
+            'original_url_md5' => 'a00ab36edb35bb641cc027eb27410934',
+            'url' => 'https://doc.ezplatform.com/en/latest/',
+        ],
+        [
+            'id' => 25,
+            'created' => 1448832412,
+            'is_valid' => 1,
+            'last_checked' => 0,
+            'modified' => 1505717756,
+            'original_url_md5' => '03c4188f5fdcb679192e25a7dad09c2d',
+            'url' => 'https://doc.ezplatform.com/en/latest/tutorials/platform_beginner/building_a_bicycle_route_tracker_in_ez_platform/',
+        ],
+    ];
+
+    /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase::loadUrlData
+     */
+    public function testLoadUrlData()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
+        $gateway = $this->getGateway();
+
+        $row = $gateway->loadUrlData(23);
+
+        self::assertEquals(
+            $this->fixtureData[0],
+            $row[0]
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase::loadUrlDataByUrl
+     */
+    public function testLoadUrlDataByUrl()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
+        $gateway = $this->getGateway();
+
+        $rows = $gateway->loadUrlDataByUrl('https://doc.ez.no/display/USER/');
+
+        self::assertEquals(
+            $this->fixtureData[0],
+            $rows[0]
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase::find
+     */
+    public function testFind()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
+        $gateway = $this->getGateway();
+
+        $criterion = new \eZ\Publish\API\Repository\Values\URL\Query\Criterion\MatchAll();
+        $results = $gateway->find($criterion, 0, 10);
+
+        self::assertEquals(
+            [
+                'count' => count($this->fixtureData),
+                'rows' => $this->fixtureData,
+            ],
+            $results
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase::find
+     */
+    public function testFindWithDisabledCounting()
+    {
+        $this->insertDatabaseFixture(__DIR__ . '/_fixtures/urls.php');
+        $gateway = $this->getGateway();
+
+        $criterion = new \eZ\Publish\API\Repository\Values\URL\Query\Criterion\MatchAll();
+        $results = $gateway->find($criterion, 0, 10, [], false);
+
+        self::assertEquals(
+            [
+                'count' => null,
+                'rows' => $this->fixtureData,
+            ],
+            $results
+        );
+    }
+
+    /**
+     * Return the DoctrineDatabase gateway to test.
+     */
+    protected function getGateway(): DoctrineDatabase
+    {
+        if (!isset($this->gateway)) {
+            $criteriaConverter = new CriteriaConverter([new MatchAll()]);
+            $this->gateway = new DoctrineDatabase($this->getDatabaseConnection(), $criteriaConverter);
+        }
+
+        return $this->gateway;
+    }
+}

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Gateway/DoctrineDatabaseTest.php
@@ -43,7 +43,7 @@ class DoctrineDatabaseTest extends TestCase
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase::loadUrlData
      */
-    public function testLoadUrlData()
+    public function testLoadUrlData(): void
     {
         $row = $this->gateway->loadUrlData(23);
 
@@ -56,7 +56,7 @@ class DoctrineDatabaseTest extends TestCase
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase::loadUrlDataByUrl
      */
-    public function testLoadUrlDataByUrl()
+    public function testLoadUrlDataByUrl(): void
     {
         $rows = $this->gateway->loadUrlDataByUrl('https://doc.ez.no/display/USER/');
 
@@ -69,7 +69,7 @@ class DoctrineDatabaseTest extends TestCase
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase::find
      */
-    public function testFind()
+    public function testFind(): void
     {
         $criterion = new \eZ\Publish\API\Repository\Values\URL\Query\Criterion\MatchAll();
         $results = $this->gateway->find($criterion, 0, 10);
@@ -86,7 +86,7 @@ class DoctrineDatabaseTest extends TestCase
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\URL\Gateway\DoctrineDatabase::find
      */
-    public function testFindWithDisabledCounting()
+    public function testFindWithDisabledCounting(): void
     {
         $criterion = new \eZ\Publish\API\Repository\Values\URL\Query\Criterion\MatchAll();
         $results = $this->gateway->find($criterion, 0, 10, [], false);

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Gateway/_fixtures/urls.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Gateway/_fixtures/urls.php
@@ -1,4 +1,9 @@
 <?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 declare(strict_types=1);
 
 return [

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Gateway/_fixtures/urls.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/Gateway/_fixtures/urls.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+return [
+    'ezurl' => [
+        [
+            'id' => 23,
+            'created' => 1448832197,
+            'is_valid' => 1,
+            'last_checked' => 0,
+            'modified' => 1448832197,
+            'original_url_md5' => 'f76e41d421b2a72232264943026a6ee5',
+            'url' => 'https://doc.ez.no/display/USER/',
+        ],
+        [
+            'id' => 24,
+            'created' => 1448832277,
+            'is_valid' => 1,
+            'last_checked' => 0,
+            'modified' => 1505717756,
+            'original_url_md5' => 'a00ab36edb35bb641cc027eb27410934',
+            'url' => 'https://doc.ezplatform.com/en/latest/',
+        ],
+        [
+            'id' => 25,
+            'created' => 1448832412,
+            'is_valid' => 1,
+            'last_checked' => 0,
+            'modified' => 1505717756,
+            'original_url_md5' => '03c4188f5fdcb679192e25a7dad09c2d',
+            'url' => 'https://doc.ezplatform.com/en/latest/tutorials/platform_beginner/building_a_bicycle_route_tracker_in_ez_platform/',
+        ],
+    ],
+];

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/URL/HandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/URL/HandlerTest.php
@@ -84,7 +84,7 @@ class HandlerTest extends TestCase
         $this->gateway
             ->expects($this->once())
             ->method('find')
-            ->with($query->filter, $query->offset, $query->limit, $query->sortClauses)
+            ->with($query->filter, $query->offset, $query->limit, $query->sortClauses, $query->performCount)
             ->willReturn($results);
 
         $this->mapper

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Gateway.php
@@ -28,7 +28,10 @@ abstract class Gateway
      * @param SortClause[] $sortClauses
      * @param bool $doCount
      *
-     * @return array
+     * @return array{
+     *     "rows": mixed,
+     *     "count: int|null,
+     * }
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException if Criterion is not applicable to its target

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Gateway.php
@@ -30,7 +30,7 @@ abstract class Gateway
      *
      * @return array{
      *     "rows": mixed,
-     *     "count: int|null,
+     *     "count": int|null,
      * }
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Gateway/DoctrineDatabase.php
@@ -24,8 +24,11 @@ use RuntimeException;
  */
 class DoctrineDatabase extends Gateway
 {
-    const URL_TABLE = 'ezurl';
-    const URL_LINK_TABLE = 'ezurl_object_link';
+    /** @internal */
+    public const URL_TABLE = 'ezurl';
+
+    /** @internal */
+    public const URL_LINK_TABLE = 'ezurl_object_link';
 
     const COLUMN_ID = 'id';
     const COLUMN_URL = 'url';

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Gateway/DoctrineDatabase.php
@@ -88,7 +88,7 @@ class DoctrineDatabase extends Gateway
 
         return [
             'count' => $count,
-            'rows' => $statement->fetchAll(FetchMode::ASSOCIATIVE),
+            'rows' => $statement->fetchAllAssociative(),
         ];
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/URL/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/URL/Handler.php
@@ -58,7 +58,8 @@ class Handler implements HandlerInterface
             $query->filter,
             $query->offset,
             $query->limit,
-            $query->sortClauses
+            $query->sortClauses,
+            $query->performCount
         );
 
         return [


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-340](https://issues.ibexa.co/browse/IBX-340)
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no

Prevent multiple database `count` queries when paginating URL lists.

Without the patch:
![image](https://user-images.githubusercontent.com/3183926/117416703-eff84300-af19-11eb-8d51-01b7f8d38671.png)


With the patch:
![image](https://user-images.githubusercontent.com/3183926/117416664-e1aa2700-af19-11eb-842a-9f7633ccc8f8.png)


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
