### PR TITLE
Corrected DateMapper and SearchField for Date to using timezone

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
@@ -386,7 +386,7 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
             return $this->getValidSearchValueOne();
         }
 
-        return '1970-01-02T00:00:00Z';
+        return '1970-01-02T00:00:00';
     }
 
     protected function getSearchTargetValueTwo()
@@ -396,7 +396,7 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
             return $this->getValidSearchValueTwo();
         }
 
-        return '1970-01-03T00:00:00Z';
+        return '1970-01-03T00:00:00';
     }
 
     protected function getValueOneDate(): DateTime

--- a/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
@@ -386,7 +386,7 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
             return $this->getValidSearchValueOne();
         }
 
-        return '1970-01-02T00:00:00';
+        return '1970-01-02T00:00:00Z';
     }
 
     protected function getSearchTargetValueTwo()
@@ -396,7 +396,7 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
             return $this->getValidSearchValueTwo();
         }
 
-        return '1970-01-03T00:00:00';
+        return '1970-01-03T00:00:00Z';
     }
 
     protected function getValueOneDate(): DateTime

--- a/eZ/Publish/Core/FieldType/Date/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Date/SearchField.php
@@ -28,7 +28,7 @@ class SearchField implements Indexable
     public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
     {
         if ($field->value->data !== null) {
-            $dateTime = new \DateTime();
+            $dateTime = new DateTime();
             $dateTime->setTimestamp($field->value->data['timestamp']);
             $value = $dateTime->format('Y-m-d\\Z');
         } else {

--- a/eZ/Publish/Core/FieldType/Date/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Date/SearchField.php
@@ -28,7 +28,8 @@ class SearchField implements Indexable
     public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
     {
         if ($field->value->data !== null) {
-            $dateTime = new DateTime("@{$field->value->data['timestamp']}");
+            $dateTime = new \DateTime();
+            $dateTime->setTimestamp($field->value->data['timestamp']);
             $value = $dateTime->format('Y-m-d\\Z');
         } else {
             $value = null;

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/DateMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/DateMapper.php
@@ -40,7 +40,7 @@ class DateMapper extends FieldValueMapper
     public function map(Field $field)
     {
         if (is_numeric($field->value)) {
-            $date = new \DateTime();
+            $date = new DateTime();
             $date->setTimestamp($field->value);
         } else {
             try {

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/DateMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/DateMapper.php
@@ -40,7 +40,8 @@ class DateMapper extends FieldValueMapper
     public function map(Field $field)
     {
         if (is_numeric($field->value)) {
-            $date = new DateTime("@{$field->value}");
+            $date = new \DateTime();
+            $date->setTimestamp($field->value);
         } else {
             try {
                 $date = new DateTime($field->value);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-XXXXX
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.2` 
| **BC breaks**                          | no
| **Doc needed**                       | no

After merge up to master, tests failed because not changed generate Date in DateMapper and search field.

Probably after this, the customers need to reindex SOLR to regenerate ezdate field

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/php-dev-team`).
