### PR TITLE
IBX-300 changed search field data to using timezone for timestamp

### DIFF
--- a/eZ/Publish/Core/FieldType/Date/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Date/SearchField.php
@@ -28,7 +28,9 @@ class SearchField implements Indexable
     public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
     {
         if ($field->value->data !== null) {
-            $dateTime = new DateTime("@{$field->value->data['timestamp']}");
+            $dateTime = new DateTime();
+            $dateTime->setTimestamp($field->value->data['timestamp']);
+
             $value = $dateTime->format('Y-m-d\\Z');
         } else {
             $value = null;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-300](https://issues.ibexa.co/browse/IBX-300)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.2`, `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no


After merged up to the master, appeared a problem with the test SOLR, so I changed the searchField class to using timezone like another place with a date field


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/php-dev-team`).
