### PR TITLE
removed timezone for ezdate field from tests

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/DateRangeAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/DateRangeAggregationTest.php
@@ -75,22 +75,21 @@ final class DateRangeAggregationTest extends AbstractAggregationTest
 
     protected function createFixturesForAggregation(Aggregation $aggregation): void
     {
-        $timezone = new DateTimeZone('+0000');
 
         $generator = new FieldAggregationFixtureGenerator($this->getRepository());
         $generator->setContentTypeIdentifier('content_type');
         $generator->setFieldDefinitionIdentifier('date_field');
         $generator->setFieldTypeIdentifier('ezdate');
         $generator->setValues([
-            new DateTime('2020-05-01 00:00:00', $timezone),
-            new DateTime('2020-06-30 00:00:00', $timezone),
-            new DateTime('2020-06-30 12:00:00', $timezone),
-            new DateTime('2020-07-01 00:00:00', $timezone),
-            new DateTime('2020-07-01 12:00:00', $timezone),
-            new DateTime('2020-07-30 12:00:00', $timezone),
-            new DateTime('2020-08-01 00:00:01', $timezone),
-            new DateTime('2020-08-01 00:00:02', $timezone),
-            new DateTime('2020-08-01 00:00:03', $timezone),
+            new DateTime('2020-05-01 00:00:00'),
+            new DateTime('2020-06-30 00:00:00'),
+            new DateTime('2020-06-30 12:00:00'),
+            new DateTime('2020-07-01 00:00:00'),
+            new DateTime('2020-07-01 12:00:00'),
+            new DateTime('2020-07-30 12:00:00'),
+            new DateTime('2020-08-01 00:00:01'),
+            new DateTime('2020-08-01 00:00:02'),
+            new DateTime('2020-08-01 00:00:03'),
         ]);
 
         $generator->execute();

--- a/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/DateRangeAggregationTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/Aggregation/Field/DateRangeAggregationTest.php
@@ -75,7 +75,6 @@ final class DateRangeAggregationTest extends AbstractAggregationTest
 
     protected function createFixturesForAggregation(Aggregation $aggregation): void
     {
-
         $generator = new FieldAggregationFixtureGenerator($this->getRepository());
         $generator->setContentTypeIdentifier('content_type');
         $generator->setFieldDefinitionIdentifier('date_field');


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-415](https://issues.ibexa.co/browse/IBX-415)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.2+` 
| **BC breaks**                          | no
| **Doc needed**                       | no

I ran locally tests for SOLR on `eZ/Publish/API/Repository/Tests/SearchService/` dir with different time zones and all of them passed
Also, I restarted the test for SOLR in Travis 4-5 times and always test passed

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/php-dev-team`).
