### PR TITLE
Used tagged iterator for service injection instead of CompilerPass

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/SearchEngineFactory.php
@@ -25,9 +25,15 @@ class SearchEngineFactory
      */
     protected $searchEngines = [];
 
-    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider)
+    /**
+     * @param iterable<string, \eZ\Publish\SPI\Search\Handler> $searchEngines
+     */
+    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider, iterable $searchEngines = [])
     {
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
+        foreach ($searchEngines as $alias => $searchEngine) {
+            $this->registerSearchEngine($searchEngine, $alias);
+        }
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/ApiLoader/StorageEngineFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/ApiLoader/StorageEngineFactory.php
@@ -25,9 +25,15 @@ class StorageEngineFactory
      */
     protected $storageEngines = [];
 
-    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider)
+    /**
+     * @param iterable<string, \eZ\Publish\SPI\Persistence\Handler> $storageEngines
+     */
+    public function __construct(RepositoryConfigurationProvider $repositoryConfigurationProvider, iterable $storageEngines = [])
     {
         $this->repositoryConfigurationProvider = $repositoryConfigurationProvider;
+        foreach ($storageEngines as $alias => $storageEngine) {
+            $this->registerStorageEngine($storageEngine, $alias);
+        }
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterSearchEnginePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterSearchEnginePass.php
@@ -14,6 +14,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * This compiler pass will register eZ Publish search engines.
+ *
+ * @deprecated will be removed in 4.0 in favor of injecting via tagged iterator in service configuration
  */
 class RegisterSearchEnginePass implements CompilerPassInterface
 {

--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterStorageEnginePass.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/RegisterStorageEnginePass.php
@@ -13,6 +13,8 @@ use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * This compiler pass will register eZ Publish storage engines.
+ *
+ * @deprecated will be removed in 4.0 in favor of injecting via tagged iterator in service configuration
  */
 class RegisterStorageEnginePass implements CompilerPassInterface
 {

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -25,6 +25,7 @@ services:
         class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\StorageEngineFactory
         arguments:
             - "@ezpublish.api.repository_configuration_provider"
+            - !tagged_iterator { tag: 'ezpublish.storageEngine', index_by: 'alias' }
 
     ezpublish.api.persistence_handler:
         #To disable cache, switch alias to ezpublish.api.storage_engine
@@ -39,6 +40,7 @@ services:
         class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\SearchEngineFactory
         arguments:
             - "@ezpublish.api.repository_configuration_provider"
+            - !tagged_iterator { tag: 'ezplatform.search_engine', index_by: 'alias' }
 
     ezpublish.api.search_engine.indexer.factory:
             class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\SearchEngineIndexerFactory

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -25,7 +25,7 @@ services:
         class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\StorageEngineFactory
         arguments:
             - "@ezpublish.api.repository_configuration_provider"
-            - !tagged_iterator { tag: 'ezpublish.storageEngine', index_by: 'alias' }
+            - !tagged_iterator { tag: 'ezpublish.storage_engine', index_by: 'alias' }
 
     ezpublish.api.persistence_handler:
         #To disable cache, switch alias to ezpublish.api.storage_engine

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/papi.yml
@@ -25,7 +25,7 @@ services:
         class: eZ\Bundle\EzPublishCoreBundle\ApiLoader\StorageEngineFactory
         arguments:
             - "@ezpublish.api.repository_configuration_provider"
-            - !tagged_iterator { tag: 'ezpublish.storage_engine', index_by: 'alias' }
+            - !tagged_iterator { tag: 'ezpublish.storageEngine', index_by: 'alias' }
 
     ezpublish.api.persistence_handler:
         #To disable cache, switch alias to ezpublish.api.storage_engine


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | yes, if compiler passes were extended
| **Doc needed**                       | no

This PR removes the need for a few compiler passes that inject services into `storage` and `search` engines.

It has proven locally to be a solution for misbehaving CompilerPasses for integration tests in commerce feature.

CompilerPasses in question have been marked as deprecated. Since those factories allow the same engine to be registered more than once (they overwrite the previous entry for an alias) it shouldn't cause any BC breaks.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
