### PR TITLE
Fixed Criterion phpdoc mismatch

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
@@ -50,8 +50,8 @@ abstract class Criterion implements CriterionInterface
      * @param string|null $operator
      *        The operator the Criterion uses. If null is given, will default to Operator::IN if $value is an array,
      *        Operator::EQ if it is not.
-     * @param string[]|int[]|int|string $value
-     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value $valueData
+     * @param string[]|int[]|int|string|bool $value
+     * @param \eZ\Publish\API\Repository\Values\Content\Query\Criterion\Value|null $valueData
      *
      * @todo Add a dedicated exception
      *


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no

Fixed phpdoc declaration for `Criterion` to match it's actual usage.

This will prevent PHPStan errors reported by invalid criterion usage from popping up in dependent packages.

#### Checklist:
- [x] Provided PR description.
- [ ] ~Tested the solution manually.~
- [ ] ~Provided automated test coverage.~ PHPStan analysis is not present in kernel. Yet.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
