### PR TITLE
Allow to autowire eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -92,6 +92,9 @@ services:
         calls:
             - [setSiteAccess, ['@ezpublish.siteaccess']]
 
+    eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface:
+        alias: 'ezpublish.siteaccess_service'
+
     ezpublish.siteaccess_router:
         class: eZ\Publish\Core\MVC\Symfony\SiteAccess\Router
         arguments:

--- a/eZ/Publish/Core/settings/tests/common.yml
+++ b/eZ/Publish/Core/settings/tests/common.yml
@@ -69,6 +69,9 @@ services:
         calls:
             - [setSiteAccess, ['@ezpublish.siteaccess']]
 
+    eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface:
+        alias: 'ezpublish.siteaccess_service'
+
     ezpublish.siteaccess.provider.chain:
         class: eZ\Publish\Core\MVC\Symfony\SiteAccess\Provider\ChainSiteAccessProvider
         arguments:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | feature
| **Target eZ Platform version** | `v4.x`
| **BC breaks**                          | no
| **Doc needed**                       | no

Added `eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface` service definition

```yaml
eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface:
    alias: 'ezpublish.siteaccess_service'
```

for the needs of autowiring. 

#### Checklist:
- [X] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [X] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [X] Asked for a review (ping `@ezsystems/php-dev-team`).
