### PR TITLE
IBX-154: Allowed to define if the alternative text for image field is required

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
@@ -114,6 +114,12 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
                     'default' => false,
                 ],
             ],
+            'AlternativeTextValidator' => [
+                'required' => [
+                    'type' => 'bool',
+                    'default' => false,
+                ],
+            ],
         ];
     }
 
@@ -127,6 +133,9 @@ class ImageIntegrationTest extends FileSearchBaseIntegrationTest
         return [
             'FileSizeValidator' => [
                 'maxFileSize' => 2 * 1024 * 1024, // 2 MB
+            ],
+            'AlternativeTextValidator' => [
+                'required' => true,
             ],
         ];
     }

--- a/eZ/Publish/Core/FieldType/Image/Type.php
+++ b/eZ/Publish/Core/FieldType/Image/Type.php
@@ -29,6 +29,12 @@ class Type extends FieldType
                 'default' => null,
             ],
         ],
+        'AlternativeTextValidator' => [
+            'required' => [
+                'type' => 'bool',
+                'default' => false,
+            ],
+        ],
     ];
 
     /** @var \eZ\Publish\Core\FieldType\Validator[] */
@@ -186,6 +192,16 @@ class Type extends FieldType
                         );
                     }
                     break;
+                case 'AlternativeTextValidator':
+                    if ($parameters['required'] && $fieldValue->isAlternativeTextEmpty()) {
+                        $errors[] = new ValidationError(
+                            'Alternative text is required.',
+                            null,
+                            [],
+                            'alternativeText'
+                        );
+                    }
+                    break;
             }
         }
 
@@ -228,6 +244,19 @@ class Type extends FieldType
                                 '%type%' => 'integer',
                             ],
                             "[$validatorIdentifier][maxFileSize]"
+                        );
+                    }
+                    break;
+                case 'AlternativeTextValidator':
+                    if (!array_key_exists('required', $parameters)) {
+                        $validationErrors[] = new ValidationError(
+                            'Validator %validator% expects parameter %parameter% to be set.',
+                            null,
+                            [
+                                '%validator%' => $validatorIdentifier,
+                                '%parameter%' => 'required',
+                            ],
+                            "[$validatorIdentifier]"
                         );
                     }
                     break;

--- a/eZ/Publish/Core/FieldType/Image/Value.php
+++ b/eZ/Publish/Core/FieldType/Image/Value.php
@@ -111,6 +111,11 @@ class Value extends BaseValue
         }
     }
 
+    public function isAlternativeTextEmpty(): bool
+    {
+        return $this->alternativeText === null || trim($this->alternativeText) === '';
+    }
+
     /**
      * Creates a value only from a file path.
      *

--- a/eZ/Publish/Core/FieldType/Tests/ImageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageTest.php
@@ -116,6 +116,12 @@ class ImageTest extends FieldTypeTest
                     'default' => null,
                 ],
             ],
+            'AlternativeTextValidator' => [
+                'required' => [
+                    'type' => 'bool',
+                    'default' => false,
+                ],
+            ],
         ];
     }
 
@@ -814,6 +820,56 @@ class ImageTest extends FieldTypeTest
                     ),
                     new ValidationError(
                         'A valid image file is required.', null, [], 'id'
+                    ),
+                ],
+            ],
+
+            // alternative text is null
+            [
+                [
+                    'validatorConfiguration' => [
+                        'AlternativeTextValidator' => [
+                            'required' => true,
+                        ],
+                    ],
+                ],
+                new ImageValue(
+                    [
+                        'id' => $this->getImageInputPath(),
+                        'fileName' => basename($this->getImageInputPath()),
+                        'fileSize' => filesize($this->getImageInputPath()),
+                        'alternativeText' => null,
+                        'uri' => '',
+                    ]
+                ),
+                [
+                    new ValidationError(
+                        'Alternative text is required.', null, [], 'alternativeText'
+                    ),
+                ],
+            ],
+
+            // alternative text is empty string
+            [
+                [
+                    'validatorConfiguration' => [
+                        'AlternativeTextValidator' => [
+                            'required' => true,
+                        ],
+                    ],
+                ],
+                new ImageValue(
+                    [
+                        'id' => $this->getImageInputPath(),
+                        'fileName' => basename($this->getImageInputPath()),
+                        'fileSize' => filesize($this->getImageInputPath()),
+                        'alternativeText' => '',
+                        'uri' => '',
+                    ]
+                ),
+                [
+                    new ValidationError(
+                        'Alternative text is required.', null, [], 'alternativeText'
                     ),
                 ],
             ],

--- a/eZ/Publish/Core/FieldType/Tests/ImageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageTest.php
@@ -664,8 +664,7 @@ class ImageTest extends FieldTypeTest
     public function provideInvalidDataForValidate()
     {
         return [
-            // File is too large
-            [
+            'file is too large' => [
                 [
                     'validatorConfiguration' => [
                         'FileSizeValidator' => [
@@ -693,9 +692,7 @@ class ImageTest extends FieldTypeTest
                     ),
                 ],
             ],
-
-            // file is not an image file
-            [
+            'file is not an image file' => [
                 [
                     'validatorConfiguration' => [
                         'FileSizeValidator' => [
@@ -724,9 +721,7 @@ class ImageTest extends FieldTypeTest
                     ),
                 ],
             ],
-
-            // file is too large and invalid
-            [
+            'file is too large and invalid' => [
                 [
                     'validatorConfiguration' => [
                         'FileSizeValidator' => [
@@ -761,9 +756,7 @@ class ImageTest extends FieldTypeTest
                     ),
                 ],
             ],
-
-            // file is an image file but filename ends with .php
-            [
+            'file is an image file but filename ends with .php' => [
                 [
                     'validatorConfiguration' => [
                         'FileSizeValidator' => [
@@ -792,9 +785,7 @@ class ImageTest extends FieldTypeTest
                     ),
                 ],
             ],
-
-            // file is an image file but filename ends with .PHP (upper case)
-            [
+            'file is an image file but filename ends with .PHP (upper case)' => [
                 [
                     'validatorConfiguration' => [
                         'FileSizeValidator' => [
@@ -823,9 +814,7 @@ class ImageTest extends FieldTypeTest
                     ),
                 ],
             ],
-
-            // alternative text is null
-            [
+            'alternative text is null' => [
                 [
                     'validatorConfiguration' => [
                         'AlternativeTextValidator' => [
@@ -848,9 +837,7 @@ class ImageTest extends FieldTypeTest
                     ),
                 ],
             ],
-
-            // alternative text is empty string
-            [
+            'alternative text is empty string' => [
                 [
                     'validatorConfiguration' => [
                         'AlternativeTextValidator' => [

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -8,8 +8,11 @@ namespace eZ\Publish\Core\Persistence\Legacy\Content\FieldValue\Converter;
 
 use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\UrlRedecoratorInterface;
+use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldDefinition;
 use eZ\Publish\Core\Persistence\Legacy\Content\StorageFieldValue;
+use eZ\Publish\SPI\Persistence\Content\FieldTypeConstraints;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
 use SimpleXMLElement;
 
 class ImageConverter extends BinaryFileConverter
@@ -174,6 +177,32 @@ EOT;
             return;
         }
         $fieldValue->data = $this->parseLegacyXml($value->dataText);
+    }
+
+    public function toStorageFieldDefinition(FieldDefinition $fieldDef, StorageFieldDefinition $storageDef): void
+    {
+        $validators = $fieldDef->fieldTypeConstraints->validators;
+
+        $storageDef->dataInt1 = $validators['FileSizeValidator']['maxFileSize'] ?? 0;
+        $storageDef->dataInt2 = (int)($validators['AlternativeTextValidator']['required'] ?? 0);
+    }
+
+    public function toFieldDefinition(StorageFieldDefinition $storageDef, FieldDefinition $fieldDef): void
+    {
+        $fieldDef->fieldTypeConstraints = new FieldTypeConstraints(
+            [
+                'validators' => [
+                    'FileSizeValidator' => [
+                        'maxFileSize' => ($storageDef->dataInt1 != 0
+                            ? $storageDef->dataInt1
+                            : null),
+                    ],
+                    'AlternativeTextValidator' => [
+                        'required' => (bool)$storageDef->dataInt2,
+                    ],
+                ],
+            ]
+        );
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/ImageConverter.php
@@ -193,9 +193,7 @@ EOT;
             [
                 'validators' => [
                     'FileSizeValidator' => [
-                        'maxFileSize' => ($storageDef->dataInt1 != 0
-                            ? $storageDef->dataInt1
-                            : null),
+                        'maxFileSize' => $storageDef->dataInt1 !== 0 ? $storageDef->dataInt1 : null,
                     ],
                     'AlternativeTextValidator' => [
                         'required' => (bool)$storageDef->dataInt2,

--- a/eZ/Publish/Core/Persistence/Tests/Legacy/FieldValue/Converter/ImageConverterTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/Legacy/FieldValue/Converter/ImageConverterTest.php
@@ -240,7 +240,7 @@ XML,
 
         $this->imageConverter->toStorageFieldDefinition($fieldDefinition, $storageFieldDefinition);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedStorageDef,
             $storageFieldDefinition
         );
@@ -320,7 +320,7 @@ XML,
 
         $this->imageConverter->toFieldDefinition($storageDef, $fieldDefinition);
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedFieldDefinition,
             $fieldDefinition
         );

--- a/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
+++ b/eZ/Publish/SPI/Tests/FieldType/ImageIntegrationTest.php
@@ -138,6 +138,9 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
                     'FileSizeValidator' => [
                         'maxFileSize' => 2 * 1024 * 1024, // 2 MB
                     ],
+                    'AlternativeTextValidator' => [
+                        'required' => true,
+                    ],
                 ],
             ]
         );
@@ -163,6 +166,9 @@ class ImageIntegrationTest extends FileBaseIntegrationTest
                         'validators' => [
                             'FileSizeValidator' => [
                                 'maxFileSize' => 2 * 1024 * 1024, // 2 MB
+                            ],
+                            'AlternativeTextValidator' => [
+                                'required' => true,
                             ],
                         ],
                     ]


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | https://issues.ibexa.co/browse/IBX-154
| **Type**                                   | feature
| **Target eZ Platform version** | `v4.0`
| **BC breaks**                          | no
| **Doc needed**                       | yes

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [ ] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
