### PR TITLE
[Tests] Aligned BinaryLoaderTest with symfony/mime 5.1.x

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/BinaryLoaderTest.php
@@ -79,31 +79,28 @@ class BinaryLoaderTest extends TestCase
         }
     }
 
-    public function testFind()
+    public function testFind(): void
     {
         $path = 'something.jpg';
         $mimeType = 'image/jpeg';
         $content = 'some content';
         $binaryFile = new BinaryFile(['id' => $path]);
         $this->ioService
-            ->expects($this->once())
             ->method('loadBinaryFile')
             ->with($path)
-            ->will($this->returnValue($binaryFile));
+            ->willReturn($binaryFile);
 
         $this->ioService
-            ->expects($this->once())
             ->method('getFileContents')
             ->with($binaryFile)
-            ->will($this->returnValue($content));
+            ->willReturn($content);
 
         $this->ioService
-            ->expects($this->once())
             ->method('getMimeType')
             ->with($binaryFile->id)
-            ->will($this->returnValue($mimeType));
+            ->willReturn($mimeType);
 
-        $expected = new Binary($content, $mimeType, 'jpg');
-        $this->assertEquals($expected, $this->binaryLoader->find($path));
+        $expected = new Binary($content, $mimeType, 'jpeg');
+        self::assertEquals($expected, $this->binaryLoader->find($path));
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | bug
| **Target Ibexa version** | `v3.2` only
| **BC breaks**                          | no
| **Doc needed**                       | no

Looks like a83c3ec for Symfony 5.2 was applied by accident on the Kernel branch 1.2 which supports Symfony 5.1.x.
See [failing nightly build](https://travis-ci.com/github/ezsystems/ezplatform-kernel/jobs/513313519#L1279).

To be restored on the merge up.

#### TODO
- [x] Wait for Travis before merging