### PR TITLE
EZP-31859: Fixed field group names being not translated

### DIFF
--- a/eZ/Publish/Core/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsList.php
+++ b/eZ/Publish/Core/Helper/FieldsGroups/ArrayTranslatorFieldsGroupsList.php
@@ -26,20 +26,26 @@ final class ArrayTranslatorFieldsGroupsList implements FieldsGroupsList
     /** @var \Symfony\Contracts\Translation\TranslatorInterface */
     private $translator;
 
-    public function __construct(TranslatorInterface $translator, $defaultGroup, array $groups)
+    public function __construct(TranslatorInterface $translator, string $defaultGroup, array $groups)
     {
-        $translatedGroups = [];
-        foreach ($groups as $groupIdentifier) {
-            $translatedGroups[$groupIdentifier] = $translator->trans($groupIdentifier, [], 'ezplatform_fields_groups');
-        }
-        $this->groups = $translatedGroups;
+        $this->groups = $groups;
         $this->defaultGroup = $defaultGroup;
         $this->translator = $translator;
     }
 
     public function getGroups()
     {
-        return $this->groups;
+        $translatedGroups = [];
+
+        foreach ($this->groups as $groupIdentifier) {
+            $translatedGroups[$groupIdentifier] = $this->translator->trans(
+                $groupIdentifier,
+                [],
+                'ezplatform_fields_groups'
+            );
+        }
+
+        return $translatedGroups;
     }
 
     public function getDefaultGroup()


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-31859
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | yes

Given, groups are translated in the constructor, the proper locale setting doesn't kick in which results in no translations being picked up from the defined translator domain. Moved it to the `getGroups` method is enough to have it translated at the moment of fetching.

Also, I will create a doc PR once this solution is approved, to mention that changing BO language is necessary to have group names translated accordingly, ref: https://doc.ibexa.co/en/latest/guide/config_repository/#field-groups-configuration.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
