### PR TITLE
IBX-527: Fixed phpdoc return type mismatch in RepositoryParamConverter

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Converter/RepositoryParamConverter.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Converter/RepositoryParamConverter.php
@@ -25,7 +25,7 @@ abstract class RepositoryParamConverter implements ParamConverterInterface
     abstract protected function getPropertyName();
 
     /**
-     * @return string classes with its namespace
+     * @return \eZ\Publish\API\Repository\Values\ValueObject
      */
     abstract protected function loadValueObject($id);
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-527](https://issues.ibexa.co/browse/IBX-527) (depends on this for static analysis)
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no, phpdoc only
| **Doc needed**                       | no

`eZ\Bundle\EzPublishCoreBundle\Converter\ContentParamConverter` & `eZ\Bundle\EzPublishCoreBundle\Converter\LocationParamConverter` (descendants) both return `ValueObject`s, not strings.

New `CustomerGroupParamConverter` will also return a `ValueObject`.

#### Checklist:
- [x] Provided PR description.
- [ ] ~Tested the solution manually.~
- [ ] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
