### PR TITLE
Bugfix Selection Type - array_merge does not accept unknown parameters in multilingual options

### DIFF
--- a/eZ/Publish/Core/FieldType/Selection/Type.php
+++ b/eZ/Publish/Core/FieldType/Selection/Type.php
@@ -244,7 +244,7 @@ class Type extends FieldType
                 return array_keys($languageOptionIndexes);
             }, $fieldSettings['multilingualOptions']);
 
-            $possibleOptionIndexes = call_user_func_array('array_merge', $possibleOptionIndexesByLanguage);
+            $possibleOptionIndexes = call_user_func_array('array_merge', array_values($possibleOptionIndexesByLanguage));
 
             foreach ($fieldValue->selection as $optionIndex) {
                 if (!in_array($optionIndex, $possibleOptionIndexes)) {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | EZP-XXXXX
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.2.8`
| **BC breaks**                          | no
| **Doc needed**                       | no

With multilingual options sometimes this cause next error:
```
array_merge() does not accept unknown named parameters
```

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [ ] Provided automated test coverage.
- [X] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/php-dev-team`).
