### PR TITLE
Added generic template annotation for static analysis

### DIFF
--- a/eZ/Publish/SPI/FieldType/GatewayBasedStorage.php
+++ b/eZ/Publish/SPI/FieldType/GatewayBasedStorage.php
@@ -11,6 +11,8 @@ use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 
 /**
  * Field Type External Storage gateway base class.
+ *
+ * @template T of \eZ\Publish\SPI\FieldType\StorageGateway
  */
 abstract class GatewayBasedStorage implements FieldStorage
 {
@@ -18,11 +20,13 @@ abstract class GatewayBasedStorage implements FieldStorage
      * Field Type External Storage Gateway.
      *
      * @var \eZ\Publish\SPI\FieldType\StorageGateway
+     * @phpstan-var T
      */
     protected $gateway;
 
     /**
      * @param \eZ\Publish\SPI\FieldType\StorageGateway $gateway
+     * @phpstan-param T $gateway
      */
     public function __construct(StorageGateway $gateway)
     {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no

Adds `@template` annotation with corresponding `phpstan-param` (for `__construct`) & `phpstan-var` (for property) that will allow static analysis of extending classes to pass when annotated:

```php
/**
 * @extends \eZ\Publish\SPI\FieldType\GatewayBasedStorage<
 *     StorageGateway
 * >
 */
final class Storage extends GatewayBasedStorage
{
}
```

See https://phpstan.org/blog/generics-in-php-using-phpdocs

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually. (in dependent repository)
- [ ] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
