### PR TITLE
IBX-688: SettingService::buildSettingDomainObject deserialize hashes as stdClass

### DIFF
--- a/eZ/Publish/API/Repository/Tests/SettingServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/SettingServiceTest.php
@@ -47,22 +47,63 @@ final class SettingServiceTest extends BaseTest
 
     /**
      * @covers \eZ\Publish\API\Repository\SettingService::createSetting()
+     *
+     * @dataProvider dataProviderForCreateSetting
      */
-    public function testCreateSetting(): void
+    public function testCreateSetting(string $identifier, $value): void
     {
         $settingService = $this->getSettingService();
 
         $settingCreate = $settingService->newSettingCreateStruct();
         $settingCreate->setGroup('test_group');
-        $settingCreate->setIdentifier('test_identifier');
-        $settingCreate->setValue('test_value');
+        $settingCreate->setIdentifier($identifier);
+        $settingCreate->setValue($value);
 
         $setting = $settingService->createSetting($settingCreate);
+
         self::assertEquals(new Setting([
             'group' => 'test_group',
-            'identifier' => 'test_identifier',
-            'value' => 'test_value',
+            'identifier' => $identifier,
+            'value' => $value,
         ]), $setting);
+    }
+
+    public function dataProviderForCreateSetting(): iterable
+    {
+        yield 'null' => [
+            'example_null',
+            null,
+        ];
+
+        yield 'boolean' => [
+            'example_boolean',
+            true,
+        ];
+
+        yield 'string' => [
+            'example_string',
+            'string',
+        ];
+
+        yield 'int' => [
+            'example_int',
+            2,
+        ];
+
+        yield 'float' => [
+            'example_number',
+            3.14,
+        ];
+
+        yield 'array' => [
+            'example_hash',
+            [
+                'foo' => 'foo',
+                'bar' => 2,
+                'baz' => 3.14,
+                'foobar' => range(1, 10),
+            ],
+        ];
     }
 
     /**

--- a/eZ/Publish/Core/Repository/SettingService.php
+++ b/eZ/Publish/Core/Repository/SettingService.php
@@ -125,7 +125,7 @@ final class SettingService implements SettingServiceInterface
         return new Setting([
             'group' => $setting->group,
             'identifier' => $setting->identifier,
-            'value' => json_decode($setting->serializedValue),
+            'value' => json_decode($setting->serializedValue, true),
         ]);
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | IBX-688
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | yes
| **Doc needed**                       | ?

Setting value representation should not be changed when loading it from persistence.

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [X] Provided automated test coverage.
- [X] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [X] Asked for a review (ping `@ezsystems/php-dev-team`).
