### PR TITLE
Added \eZ\Publish\API\Repository\Values\Filter\Filter::{withOffset,withLimit} methods

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Values/Filter/FilterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/Filter/FilterTest.php
@@ -331,6 +331,22 @@ final class FilterTest extends TestCase
             0,
             1,
         ];
+
+        yield 'withLimit(limit=10)' => [
+            (new Filter())->withLimit(10),
+            null,
+            [],
+            10,
+            0,
+        ];
+
+        yield 'withOffset(offset=10)' => [
+            (new Filter())->withOffset(10),
+            null,
+            [],
+            0,
+            10,
+        ];
     }
 
     /**

--- a/eZ/Publish/API/Repository/Values/Filter/Filter.php
+++ b/eZ/Publish/API/Repository/Values/Filter/Filter.php
@@ -62,7 +62,7 @@ final class Filter
     /**
      * Reset Filter so it can be built from scratch.
      */
-    public function reset(): Filter
+    public function reset(): self
     {
         $this->criterion = null;
         $this->sortClauses = [];
@@ -86,7 +86,7 @@ final class Filter
      * @see \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalOr
      * @see \eZ\Publish\API\Repository\Values\Content\Query\Criterion\LogicalAnd
      */
-    public function withCriterion(FilteringCriterion $criterion): Filter
+    public function withCriterion(FilteringCriterion $criterion): self
     {
         if (null !== $this->criterion) {
             throw new BadStateException(
@@ -105,7 +105,7 @@ final class Filter
     /**
      * @see withCriterion
      */
-    public function andWithCriterion(FilteringCriterion $criterion): Filter
+    public function andWithCriterion(FilteringCriterion $criterion): self
     {
         if (null === $this->criterion) {
             // for better DX allow operation on uninitialized Criterion by setting it as-is
@@ -122,7 +122,7 @@ final class Filter
     /**
      * @see withCriterion
      */
-    public function orWithCriterion(FilteringCriterion $criterion): Filter
+    public function orWithCriterion(FilteringCriterion $criterion): self
     {
         if (null === $this->criterion) {
             // for better DX allow operation on uninitialized Criterion by setting it as-is
@@ -136,21 +136,21 @@ final class Filter
         return $this;
     }
 
-    public function withSortClause(FilteringSortClause $sortClause): Filter
+    public function withSortClause(FilteringSortClause $sortClause): self
     {
         $this->sortClauses[] = $sortClause;
 
         return $this;
     }
 
-    public function withOffset(int $offset): Filter
+    public function withOffset(int $offset): self
     {
         $this->offset = $offset;
 
         return $this;
     }
 
-    public function withLimit(int $limit): Filter
+    public function withLimit(int $limit): self
     {
         $this->limit = $limit;
 
@@ -165,7 +165,7 @@ final class Filter
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
-    public function sliceBy(int $limit, int $offset): Filter
+    public function sliceBy(int $limit, int $offset): self
     {
         if ($limit < 0) {
             throw new InvalidArgumentException(

--- a/eZ/Publish/API/Repository/Values/Filter/Filter.php
+++ b/eZ/Publish/API/Repository/Values/Filter/Filter.php
@@ -143,6 +143,20 @@ final class Filter
         return $this;
     }
 
+    public function withOffset(int $offset): Filter
+    {
+        $this->offset = $offset;
+
+        return $this;
+    }
+
+    public function withLimit(int $limit): Filter
+    {
+        $this->limit = $limit;
+
+        return $this;
+    }
+
     /**
      * Request result dataset slice by setting page limit and offset.
      * Both values MUST be `>=0`.


### PR DESCRIPTION

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | i
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | ?

Added `withOffset` and `withLimit` metods to `\eZ\Publish\API\Repository\Values\Filter\Filter`. 

Primary use case is batch processing using Filtering API. In such scenario limit (batch size) is set at the beginning of data processing and only offset (data pointer) is changing over iteration. 

Currently with `\eZ\Publish\API\Repository\Values\Filter\Filter::sliceBy(...)`  developer is forced to set both limit and offset at once.

#### Checklist:
- [X] Provided PR description.
- [X] Tested the solution manually.
- [X] Provided automated test coverage.
- [X] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [X] Asked for a review (ping `@ezsystems/php-dev-team`).
