### PR TITLE
IBX-719: Introduced BatchIterator

### DIFF
--- a/eZ/Publish/API/Repository/Iterator/BatchIterator.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIterator.php
@@ -89,6 +89,6 @@ final class BatchIterator implements Iterator
 
     private function isInitialized(): bool
     {
-        return $this->innerIterator !== null;
+        return isset($this->innerIterator);
     }
 }

--- a/eZ/Publish/API/Repository/Iterator/BatchIterator.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIterator.php
@@ -53,7 +53,7 @@ final class BatchIterator implements Iterator
         ++$this->position;
         $this->innerIterator->next();
         if (!$this->innerIterator->valid() && ($this->position % $this->batchSize) === 0) {
-            $this->innerIterator = $this->adapter->fetch($this->position, $this->batchSize);
+            $this->innerIterator = $this->fetch();
         }
     }
 
@@ -83,12 +83,17 @@ final class BatchIterator implements Iterator
 
     private function initialize(): void
     {
-        $this->innerIterator = $this->adapter->fetch(0, $this->batchSize);
         $this->position = 0;
+        $this->innerIterator = $this->fetch();
     }
 
     private function isInitialized(): bool
     {
         return isset($this->innerIterator);
+    }
+
+    private function fetch(): Iterator
+    {
+        return $this->adapter->fetch($this->position, $this->batchSize);
     }
 }

--- a/eZ/Publish/API/Repository/Iterator/BatchIterator.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIterator.php
@@ -1,0 +1,94 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Iterator;
+
+use Iterator;
+
+final class BatchIterator implements Iterator
+{
+    public const DEFAULT_BATCH_SIZE = 25;
+
+    /** @var \eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter */
+    private $adapter;
+
+    /** @var Iterator|null */
+    private $innerIterator;
+
+    /** @var int */
+    private $batchSize;
+
+    /** @var int */
+    private $position;
+
+    public function __construct(
+        BatchIteratorAdapter $adapter,
+        int $batchSize = self::DEFAULT_BATCH_SIZE
+    ) {
+        $this->adapter = $adapter;
+        $this->batchSize = $batchSize;
+        $this->position = 0;
+    }
+
+    public function current()
+    {
+        if (!$this->isInitialized()) {
+            $this->initialize();
+        }
+
+        return $this->innerIterator->current();
+    }
+
+    public function next(): void
+    {
+        if (!$this->isInitialized()) {
+            $this->initialize();
+        }
+
+        ++$this->position;
+        $this->innerIterator->next();
+        if (!$this->innerIterator->valid()) {
+            $this->innerIterator = $this->adapter->fetch($this->position, $this->batchSize);
+        }
+    }
+
+    public function key(): int
+    {
+        return $this->position;
+    }
+
+    public function valid(): bool
+    {
+        if (!$this->isInitialized()) {
+            $this->initialize();
+        }
+
+        return $this->innerIterator->valid();
+    }
+
+    public function rewind(): void
+    {
+        $this->initialize();
+    }
+
+    public function setBatchSize(int $batchSize): void
+    {
+        $this->batchSize = $batchSize;
+    }
+
+    private function initialize(): void
+    {
+        $this->innerIterator = $this->adapter->fetch(0, $this->batchSize);
+        $this->position = 0;
+    }
+
+    private function isInitialized(): bool
+    {
+        return $this->innerIterator !== null;
+    }
+}

--- a/eZ/Publish/API/Repository/Iterator/BatchIterator.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIterator.php
@@ -52,7 +52,7 @@ final class BatchIterator implements Iterator
 
         ++$this->position;
         $this->innerIterator->next();
-        if (!$this->innerIterator->valid()) {
+        if (!$this->innerIterator->valid() && ($this->position % $this->batchSize) === 0) {
             $this->innerIterator = $this->adapter->fetch($this->position, $this->batchSize);
         }
     }

--- a/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Iterator;
 
 use Iterator;

--- a/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter.php
@@ -1,0 +1,14 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Iterator;
+
+use Iterator;
+
+interface BatchIteratorAdapter
+{
+    public function fetch(int $offset, int $limit): Iterator;
+}

--- a/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/AbstractSearchAdapter.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/AbstractSearchAdapter.php
@@ -8,12 +8,13 @@ declare(strict_types=1);
 
 namespace eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter;
 
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter;
 use eZ\Publish\API\Repository\SearchService;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
 use Iterator;
 
-abstract class AbstractSearchAdapter
+abstract class AbstractSearchAdapter implements BatchIteratorAdapter
 {
     /** @var \eZ\Publish\API\Repository\SearchService */
     protected $searchService;

--- a/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/AbstractSearchAdapter.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/AbstractSearchAdapter.php
@@ -1,0 +1,52 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter;
+
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use Iterator;
+
+abstract class AbstractSearchAdapter
+{
+    /** @var \eZ\Publish\API\Repository\SearchService */
+    protected $searchService;
+
+    /** @var \eZ\Publish\API\Repository\Values\Content\Query */
+    protected $query;
+
+    /** @var array */
+    protected $languageFilter;
+
+    /** @var bool */
+    protected $filterOnUserPermissions;
+
+    public function __construct(
+        SearchService $searchService,
+        Query $query,
+        array $languageFilter = [],
+        bool $filterOnUserPermissions = true
+    ) {
+        $this->searchService = $searchService;
+        $this->query = $query;
+        $this->languageFilter = $languageFilter;
+        $this->filterOnUserPermissions = $filterOnUserPermissions;
+    }
+
+    final public function fetch(int $offset, int $limit): Iterator
+    {
+        $query = clone $this->query;
+        $query->offset = $offset;
+        $query->limit = $limit;
+
+        return $this->executeSearch($query)->getIterator();
+    }
+
+    abstract protected function executeSearch(Query $query): SearchResult;
+}

--- a/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/AbstractSearchAdapter.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/AbstractSearchAdapter.php
@@ -22,7 +22,7 @@ abstract class AbstractSearchAdapter implements BatchIteratorAdapter
     /** @var \eZ\Publish\API\Repository\Values\Content\Query */
     protected $query;
 
-    /** @var array */
+    /** @var string[] */
     protected $languageFilter;
 
     /** @var bool */

--- a/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/ContentFilteringAdapter.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/ContentFilteringAdapter.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter;
+use eZ\Publish\API\Repository\Values\Filter\Filter;
+use Iterator;
+
+final class ContentFilteringAdapter implements BatchIteratorAdapter
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\Values\Filter\Filter */
+    private $filter;
+
+    /** @var array|null */
+    private $languages;
+
+    public function __construct(ContentService $contentService, Filter $filter, ?array $languages = null)
+    {
+        $this->contentService = $contentService;
+        $this->filter = $filter;
+        $this->languages = $languages;
+    }
+
+    public function fetch(int $offset, int $limit): Iterator
+    {
+        $filter = clone $this->filter;
+        $filter->sliceBy($limit, $offset);
+
+        return $this->contentService->find($filter, $this->languages)->getIterator();
+    }
+}

--- a/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/ContentFilteringAdapter.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/ContentFilteringAdapter.php
@@ -21,7 +21,7 @@ final class ContentFilteringAdapter implements BatchIteratorAdapter
     /** @var \eZ\Publish\API\Repository\Values\Filter\Filter */
     private $filter;
 
-    /** @var array|null */
+    /** @var string[]|null */
     private $languages;
 
     public function __construct(ContentService $contentService, Filter $filter, ?array $languages = null)

--- a/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/ContentInfoSearchAdapter.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/ContentInfoSearchAdapter.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+
+final class ContentInfoSearchAdapter extends AbstractSearchAdapter
+{
+    protected function executeSearch(Query $query): SearchResult
+    {
+        return $this->searchService->findContentInfo(
+            $query,
+            $this->languageFilter,
+            $this->filterOnUserPermissions
+        );
+    }
+}

--- a/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/ContentSearchAdapter.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/ContentSearchAdapter.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter;
+
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+
+final class ContentSearchAdapter extends AbstractSearchAdapter
+{
+    protected function executeSearch(Query $query): SearchResult
+    {
+        return $this->searchService->findContent(
+            $query,
+            $this->languageFilter,
+            $this->filterOnUserPermissions
+        );
+    }
+}

--- a/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/LocationFilteringAdapter.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/LocationFilteringAdapter.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter;
+
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Filter\Filter;
+use Iterator;
+
+final class LocationFilteringAdapter implements BatchIteratorAdapter
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /** @var \eZ\Publish\API\Repository\Values\Filter\Filter */
+    private $filter;
+
+    /** @var array|null */
+    private $languages;
+
+    public function __construct(LocationService $locationService, Filter $filter, ?array $languages = null)
+    {
+        $this->locationService = $locationService;
+        $this->filter = $filter;
+        $this->languages = $languages;
+    }
+
+    public function fetch(int $offset, int $limit): Iterator
+    {
+        $filter = clone $this->filter;
+        $filter->sliceBy($limit, $offset);
+
+        return $this->locationService->find($filter, $this->languages)->getIterator();
+    }
+}

--- a/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/LocationFilteringAdapter.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/LocationFilteringAdapter.php
@@ -21,7 +21,7 @@ final class LocationFilteringAdapter implements BatchIteratorAdapter
     /** @var \eZ\Publish\API\Repository\Values\Filter\Filter */
     private $filter;
 
-    /** @var array|null */
+    /** @var string[]|null */
     private $languages;
 
     public function __construct(LocationService $locationService, Filter $filter, ?array $languages = null)

--- a/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/LocationSearchAdapter.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIteratorAdapter/LocationSearchAdapter.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter;
+
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+
+final class LocationSearchAdapter extends AbstractSearchAdapter
+{
+    public function __construct(
+        SearchService $searchService,
+        LocationQuery $query,
+        array $languageFilter = [],
+        bool $filterOnUserPermissions = true
+    ) {
+        parent::__construct($searchService, $query, $languageFilter, $filterOnUserPermissions);
+    }
+
+    protected function executeSearch(Query $query): SearchResult
+    {
+        return $this->searchService->findLocations(
+            $query,
+            $this->languageFilter,
+            $this->filterOnUserPermissions
+        );
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/AbstractSearchAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/AbstractSearchAdapterTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Iterator\BatchIteratorAdapter;
+
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter\AbstractSearchAdapter;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchAll;
+use eZ\Publish\API\Repository\Values\Content\Search\SearchResult;
+use Iterator;
+use PHPUnit\Framework\TestCase;
+
+abstract class AbstractSearchAdapterTest extends TestCase
+{
+    protected const EXAMPLE_LANGUAGE_FILTER = [
+        'languages' => ['eng-GB', 'pol-PL'],
+        'useAlwaysAvailable' => true,
+    ];
+
+    protected const EXAMPLE_OFFSET = 7;
+    protected const EXAMPLE_LIMIT = 13;
+
+    final public function testFetch(): void
+    {
+        $expectedIterator = $this->createMock(Iterator::class);
+
+        $searchResults = $this->createMock(SearchResult::class);
+        $searchResults->method('getIterator')->willReturn($expectedIterator);
+
+        $originalQuery = $this->newQuery();
+        $originalQuery->filter = new MatchAll();
+
+        $expectedQuery = $this->newQuery();
+        $expectedQuery->filter = new MatchAll();
+        $expectedQuery->offset = self::EXAMPLE_OFFSET;
+        $expectedQuery->limit = self::EXAMPLE_LIMIT;
+
+        $searchService = $this->createMock(SearchService::class);
+        $searchService
+            ->expects($this->once())
+            ->method($this->getExpectedFindMethod())
+            ->with($expectedQuery, self::EXAMPLE_LANGUAGE_FILTER, true)
+            ->willReturn($searchResults);
+
+        $adapter = $this->createAdapterUnderTest($searchService, $originalQuery, self::EXAMPLE_LANGUAGE_FILTER, true);
+
+        $this->assertEquals(
+            $expectedIterator,
+            $adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT),
+        );
+
+        $this->assertEquals(0, $originalQuery->offset);
+        $this->assertEquals(25, $originalQuery->limit);
+    }
+
+    abstract protected function createAdapterUnderTest(
+        SearchService $searchService,
+        Query $query,
+        array $languageFilter,
+        bool $filterOnPermissions
+    ): AbstractSearchAdapter;
+
+    abstract protected function getExpectedFindMethod(): string;
+
+    protected function newQuery(): Query
+    {
+        return new Query();
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/AbstractSearchAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/AbstractSearchAdapterTest.php
@@ -50,7 +50,7 @@ abstract class AbstractSearchAdapterTest extends TestCase
 
         $adapter = $this->createAdapterUnderTest($searchService, $originalQuery, self::EXAMPLE_LANGUAGE_FILTER, true);
 
-        $this->assertEquals(
+        $this->assertSame(
             $expectedIterator,
             $adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT),
         );

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentFilteringAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentFilteringAdapterTest.php
@@ -46,7 +46,7 @@ final class ContentFilteringAdapterTest extends TestCase
 
         $adapter = new ContentFilteringAdapter($contentService, $originalFilter, self::EXAMPLE_LANGUAGE_FILTER);
 
-        $this->assertEquals(
+        $this->assertSame(
             $contentList->getIterator(),
             $adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT)
         );

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentFilteringAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentFilteringAdapterTest.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Iterator\BatchIteratorAdapter;
+
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter\ContentFilteringAdapter;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\Content\ContentList;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchAll;
+use eZ\Publish\API\Repository\Values\Filter\Filter;
+use PHPUnit\Framework\TestCase;
+
+final class ContentFilteringAdapterTest extends TestCase
+{
+    private const EXAMPLE_LANGUAGE_FILTER = ['eng-GB', 'pol-PL'];
+    private const EXAMPLE_OFFSET = 10;
+    private const EXAMPLE_LIMIT = 25;
+
+    public function testFetch(): void
+    {
+        $contentList = new ContentList(3, [
+            $this->createMock(Content::class),
+            $this->createMock(Content::class),
+            $this->createMock(Content::class),
+        ]);
+
+        $originalFilter = new Filter();
+        $originalFilter->withCriterion(new MatchAll());
+
+        $expectedFilter = new Filter();
+        $expectedFilter->withCriterion(new MatchAll());
+        $expectedFilter->sliceBy(self::EXAMPLE_LIMIT, self::EXAMPLE_OFFSET);
+
+        $contentService = $this->createMock(ContentService::class);
+        $contentService
+            ->expects($this->once())
+            ->method('find')
+            ->with($expectedFilter, self::EXAMPLE_LANGUAGE_FILTER)
+            ->willReturn($contentList);
+
+        $adapter = new ContentFilteringAdapter($contentService, $originalFilter, self::EXAMPLE_LANGUAGE_FILTER);
+
+        $this->assertEquals(
+            $contentList->getIterator(),
+            $adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT)
+        );
+
+        // Input $filter reminds untouched
+        $this->assertEquals(0, $originalFilter->getOffset());
+        $this->assertEquals(0, $originalFilter->getLimit());
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentInfoSearchAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentInfoSearchAdapterTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Iterator\BatchIteratorAdapter;
+
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter\AbstractSearchAdapter;
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter\ContentInfoSearchAdapter;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+final class ContentInfoSearchAdapterTest extends AbstractSearchAdapterTest
+{
+    protected function createAdapterUnderTest(
+        SearchService $searchService,
+        Query $query,
+        array $languageFilter,
+        bool $filterOnPermissions
+    ): AbstractSearchAdapter {
+        return new ContentInfoSearchAdapter(
+            $searchService,
+            $query,
+            self::EXAMPLE_LANGUAGE_FILTER,
+            true
+        );
+    }
+
+    protected function getExpectedFindMethod(): string
+    {
+        return 'findContentInfo';
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentSearchAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentSearchAdapterTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Iterator\BatchIteratorAdapter;
+
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter\AbstractSearchAdapter;
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter\ContentSearchAdapter;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+final class ContentSearchAdapterTest extends AbstractSearchAdapterTest
+{
+    protected function createAdapterUnderTest(
+        SearchService $searchService,
+        Query $query,
+        array $languageFilter,
+        bool $filterOnPermissions
+    ): AbstractSearchAdapter {
+        return new ContentSearchAdapter(
+            $searchService,
+            $query,
+            self::EXAMPLE_LANGUAGE_FILTER,
+            true
+        );
+    }
+
+    protected function getExpectedFindMethod(): string
+    {
+        return 'findContent';
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/LocationFilteringAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/LocationFilteringAdapterTest.php
@@ -49,7 +49,7 @@ final class LocationFilteringAdapterTest extends TestCase
 
         $adapter = new LocationFilteringAdapter($locationService, $originalFilter, self::EXAMPLE_LANGUAGE_FILTER);
 
-        $this->assertEquals(
+        $this->assertSame(
             $locationList->getIterator(),
             $adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT)
         );

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/LocationFilteringAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/LocationFilteringAdapterTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Iterator\BatchIteratorAdapter;
+
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter\LocationFilteringAdapter;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\Content\LocationList;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion\MatchAll;
+use eZ\Publish\API\Repository\Values\Filter\Filter;
+use PHPUnit\Framework\TestCase;
+
+final class LocationFilteringAdapterTest extends TestCase
+{
+    private const EXAMPLE_LANGUAGE_FILTER = ['eng-GB', 'pol-PL'];
+    private const EXAMPLE_OFFSET = 10;
+    private const EXAMPLE_LIMIT = 25;
+
+    public function testFetch(): void
+    {
+        $locationList = new LocationList([
+            'locations' => [
+                $this->createMock(Location::class),
+                $this->createMock(Location::class),
+                $this->createMock(Location::class),
+            ],
+            'totalCount' => 3,
+        ]);
+
+        $originalFilter = new Filter();
+        $originalFilter->withCriterion(new MatchAll());
+
+        $expectedFilter = new Filter();
+        $expectedFilter->withCriterion(new MatchAll());
+        $expectedFilter->sliceBy(self::EXAMPLE_LIMIT, self::EXAMPLE_OFFSET);
+
+        $locationService = $this->createMock(LocationService::class);
+        $locationService
+            ->expects($this->once())
+            ->method('find')
+            ->with($expectedFilter, self::EXAMPLE_LANGUAGE_FILTER)
+            ->willReturn($locationList);
+
+        $adapter = new LocationFilteringAdapter($locationService, $originalFilter, self::EXAMPLE_LANGUAGE_FILTER);
+
+        $this->assertEquals(
+            $locationList->getIterator(),
+            $adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT)
+        );
+
+        // Input $filter reminds untouched
+        $this->assertEquals(0, $originalFilter->getOffset());
+        $this->assertEquals(0, $originalFilter->getLimit());
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/LocationSearchAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/LocationSearchAdapterTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Iterator\BatchIteratorAdapter;
+
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter\AbstractSearchAdapter;
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter\LocationSearchAdapter;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\Values\Content\LocationQuery;
+use eZ\Publish\API\Repository\Values\Content\Query;
+
+final class LocationSearchAdapterTest extends AbstractSearchAdapterTest
+{
+    protected function createAdapterUnderTest(
+        SearchService $searchService,
+        Query $query,
+        array $languageFilter,
+        bool $filterOnPermissions
+    ): AbstractSearchAdapter {
+        return new LocationSearchAdapter(
+            $searchService,
+            $query,
+            self::EXAMPLE_LANGUAGE_FILTER,
+            true
+        );
+    }
+
+    protected function getExpectedFindMethod(): string
+    {
+        return 'findLocations';
+    }
+
+    protected function newQuery(): Query
+    {
+        return new LocationQuery();
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorTest.php
@@ -23,6 +23,16 @@ final class BatchIteratorTest extends TestCase
         $this->assertEquals($expectedData, iterator_to_array($iterator));
     }
 
+    public function testIterateOverResultSetSmallerThenBatchSize(): void
+    {
+        $expectedData = range(1, 10);
+
+        $iterator = new BatchIterator(new BatchIteratorTestAdapter($expectedData));
+        $iterator->setBatchSize(100);
+
+        $this->assertEquals($expectedData, iterator_to_array($iterator));
+    }
+
     public function testIterateOverEmptyResultSet(): void
     {
         $iterator = new BatchIterator(new BatchIteratorTestAdapter([]));

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorTest.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Iterator;
+
+use eZ\Publish\API\Repository\Iterator\BatchIterator;
+use PHPUnit\Framework\TestCase;
+
+final class BatchIteratorTest extends TestCase
+{
+    public function testIterateOverDummyResultSet(): void
+    {
+        $expectedData = range(1, 100);
+
+        $iterator = new BatchIterator(new BatchIteratorTestAdapter($expectedData));
+        $iterator->setBatchSize(7);
+
+        $this->assertEquals($expectedData, iterator_to_array($iterator));
+    }
+
+    public function testIterateOverEmptyResultSet(): void
+    {
+        $iterator = new BatchIterator(new BatchIteratorTestAdapter([]));
+        $iterator->setBatchSize(10);
+
+        $this->assertEquals([], iterator_to_array($iterator));
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorTest.php
@@ -16,28 +16,35 @@ final class BatchIteratorTest extends TestCase
     public function testIterateOverDummyResultSet(): void
     {
         $expectedData = range(1, 100);
+        $adapter = new BatchIteratorTestAdapter($expectedData);
 
-        $iterator = new BatchIterator(new BatchIteratorTestAdapter($expectedData));
+        $iterator = new BatchIterator($adapter);
         $iterator->setBatchSize(7);
 
         $this->assertEquals($expectedData, iterator_to_array($iterator));
+        $this->assertEquals(15, $adapter->getFetchCounter());
     }
 
     public function testIterateOverResultSetSmallerThenBatchSize(): void
     {
         $expectedData = range(1, 10);
+        $adapter = new BatchIteratorTestAdapter($expectedData);
 
-        $iterator = new BatchIterator(new BatchIteratorTestAdapter($expectedData));
+        $iterator = new BatchIterator($adapter);
         $iterator->setBatchSize(100);
 
         $this->assertEquals($expectedData, iterator_to_array($iterator));
+        $this->assertEquals(1, $adapter->getFetchCounter());
     }
 
     public function testIterateOverEmptyResultSet(): void
     {
-        $iterator = new BatchIterator(new BatchIteratorTestAdapter([]));
+        $adapter = new BatchIteratorTestAdapter([]);
+
+        $iterator = new BatchIterator($adapter);
         $iterator->setBatchSize(10);
 
         $this->assertEquals([], iterator_to_array($iterator));
+        $this->assertEquals(1, $adapter->getFetchCounter());
     }
 }

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorTestAdapter.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorTestAdapter.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\API\Repository\Tests\Iterator;
+
+use ArrayIterator;
+use eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter;
+use Iterator;
+
+final class BatchIteratorTestAdapter implements BatchIteratorAdapter
+{
+    /** @var array */
+    private $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function fetch(int $offset, int $limit): Iterator
+    {
+        return new ArrayIterator(array_slice($this->data, $offset, $limit));
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorTestAdapter.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorTestAdapter.php
@@ -17,13 +17,24 @@ final class BatchIteratorTestAdapter implements BatchIteratorAdapter
     /** @var array */
     private $data;
 
+    /** @var int */
+    private $fetchCounter;
+
     public function __construct(array $data)
     {
         $this->data = $data;
+        $this->fetchCounter = 0;
     }
 
     public function fetch(int $offset, int $limit): Iterator
     {
+        ++$this->fetchCounter;
+
         return new ArrayIterator(array_slice($this->data, $offset, $limit));
+    }
+
+    public function getFetchCounter(): int
+    {
+        return $this->fetchCounter;
     }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Search/SearchResult.php
@@ -10,8 +10,8 @@ namespace eZ\Publish\API\Repository\Values\Content\Search;
 
 use ArrayIterator;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use Iterator;
 use IteratorAggregate;
-use Traversable;
 
 /**
  * This class represents a search result.
@@ -86,7 +86,7 @@ class SearchResult extends ValueObject implements IteratorAggregate
         parent::__construct($properties);
     }
 
-    public function getIterator(): Traversable
+    public function getIterator(): Iterator
     {
         return new ArrayIterator($this->searchHits);
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | https://issues.ibexa.co/browse/IBX-719
| **Type**                                   | feature
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | yes

`BatchIterator`  allows iterate over result sets (e.g. content objects, locations) which cannot be loaded into memory at once.

Examples from existing code base:

https://github.com/ezsystems/ezplatform-kernel/blob/4c840747ef4a75782becc7dac987ff615775d242/eZ/Bundle/EzPublishCoreBundle/Command/CheckURLsCommand.php#L90-L108

https://github.com/ezsystems/ezplatform-kernel/blob/4c840747ef4a75782becc7dac987ff615775d242/eZ/Bundle/EzPublishCoreBundle/Command/ResizeOriginalImagesCommand.php#L210-L220
 
### Usage

```php
$filter = new Filter();
// ... add criteria, sort clauses etc.

$iterator = new BatchIterator(new ContentFilteringAdapter($contentService, $filter));
foreach ($iterator as $content) {
   // process content object
}
```

### Available adapters

All built-in adapters are places under `\eZ\Publish\API\Repository\Iterator\BatchIteratorAdapter\` namespace.

| Adapter                    | Method                                                      |
|----------------------------|-------------------------------------------------------------|
| `ContentFilteringAdapter`  | `\eZ\Publish\API\Repository\ContentService::find`           |
| `ContentInfoSearchAdapter` | `\eZ\Publish\API\Repository\SearchService::findContentInfo` |
| `ContentSearchAdapter`     | `\eZ\Publish\API\Repository\SearchService::findContent`     |
| `LocationFilteringAdapter` | `\eZ\Publish\API\Repository\LocationService::find`          |
| `LocationSearchAdapter`    | `\eZ\Publish\API\Repository\SearchService::findLocations`   |


#### Checklist:
- [x] Provided PR description.
- [X] Tested the solution manually.
- [x] Provided automated test coverage.
- [X] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [X] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
