### PR TITLE
IBX-175: Fixed invalid VersionValidator errors output when validation fails for multilingual content

### DIFF
--- a/eZ/Publish/API/Repository/Tests/ContentService/VersionValidatorTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentService/VersionValidatorTest.php
@@ -4,6 +4,8 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace eZ\Publish\API\Repository\Tests\ContentService;
 
 use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
@@ -15,7 +17,10 @@ use eZ\Publish\Core\Repository\Validator\VersionValidator;
 use eZ\Publish\Core\Repository\Values\Content\TrashItem;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 
-class VersionValidatorTest extends BaseTest
+/**
+ * @internal
+ */
+final class VersionValidatorTest extends BaseTest
 {
     private const CONTENT_TYPE_IDENTIFIER = 'single-text';
     private const FIELD_IDENTIFIER = 'name';
@@ -47,12 +52,12 @@ class VersionValidatorTest extends BaseTest
 
     public function testSupportsKnownValidationObject(): void
     {
-        $this->assertTrue($this->validator->supports(new VersionInfo()));
+        self::assertTrue($this->validator->supports(new VersionInfo()));
     }
 
     public function testSupportsUnknownValidationObject(): void
     {
-        $this->assertFalse($this->validator->supports(new TrashItem()));
+        self::assertFalse($this->validator->supports(new TrashItem()));
     }
 
     public function testValidateMultilingualContent(): void
@@ -72,7 +77,7 @@ class VersionValidatorTest extends BaseTest
             $this->updateContentTranslation($content);
         } catch (ContentFieldValidationException $e) {
             // since we updated only one translation, we expect one field error to be thrown (related to null value for eng-GB version)
-            $this->assertCount(1, $e->getFieldErrors());
+            self::assertCount(1, $e->getFieldErrors());
         }
     }
 
@@ -105,9 +110,7 @@ class VersionValidatorTest extends BaseTest
     }
 
     /**
-     * @param Content $content
-     *
-     * @throws ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException

--- a/eZ/Publish/API/Repository/Tests/ContentService/VersionValidatorTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentService/VersionValidatorTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace eZ\Publish\API\Repository\Tests\ContentService;
+
+use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\Content\Content;
+use eZ\Publish\API\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\FieldType\FieldTypeRegistry;
+use eZ\Publish\Core\Repository\Validator\VersionValidator;
+use eZ\Publish\Core\Repository\Values\Content\TrashItem;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+
+class VersionValidatorTest extends BaseTest
+{
+    private const CONTENT_TYPE_IDENTIFIER = 'single-text';
+    private const FIELD_IDENTIFIER = 'name';
+    private const ENG_GB = 'eng-GB';
+    private const GER_DE = 'ger-DE';
+
+    /** @var \eZ\Publish\Core\Repository\Validator\VersionValidator */
+    private $validator;
+
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    /** @var \eZ\Publish\API\Repository\ContentTypeService */
+    private $contentTypeService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->validator = new VersionValidator(
+            $this->createMock(FieldTypeRegistry::class)
+        );
+
+        $repository = $this->getRepository();
+
+        $this->contentService = $repository->getContentService();
+        $this->contentTypeService = $repository->getContentTypeService();
+    }
+
+    public function testSupportsKnownValidationObject(): void
+    {
+        $this->assertTrue($this->validator->supports(new VersionInfo()));
+    }
+
+    public function testSupportsUnknownValidationObject(): void
+    {
+        $this->assertFalse($this->validator->supports(new TrashItem()));
+    }
+
+    public function testValidateMultilingualContent(): void
+    {
+        $contentType = $this->createSimpleContentType(
+            self::CONTENT_TYPE_IDENTIFIER,
+            self::ENG_GB,
+            [
+                self::FIELD_IDENTIFIER => 'ezstring',
+            ],
+        );
+
+        $content = $this->createAndPublishMultilingualContent($contentType);
+        $this->makeContentTypeFieldRequired($contentType);
+
+        try {
+            $this->updateContentTranslation($content);
+        } catch (ContentFieldValidationException $e) {
+            // since we updated only one translation, we expect one field error to be thrown (related to null value for eng-GB version)
+            $this->assertCount(1, $e->getFieldErrors());
+        }
+    }
+
+    private function createAndPublishMultilingualContent(ContentType $contentType): Content
+    {
+        $contentCreate = $this->contentService->newContentCreateStruct($contentType, self::ENG_GB);
+        $contentCreate->setField(self::FIELD_IDENTIFIER, null, self::ENG_GB);
+        $contentCreate->setField(self::FIELD_IDENTIFIER, 'Name DE', self::GER_DE);
+
+        $contentDraft = $this->contentService->createContent($contentCreate);
+
+        return $this->contentService->publishVersion($contentDraft->versionInfo);
+    }
+
+    private function makeContentTypeFieldRequired(ContentType $contentType): void
+    {
+        $contentTypeDraft = $this->contentTypeService->createContentTypeDraft($contentType);
+        $nameField = $contentTypeDraft->getFieldDefinition(self::FIELD_IDENTIFIER);
+
+        $fieldDefinitionUpdate = $this->contentTypeService->newFieldDefinitionUpdateStruct();
+        $fieldDefinitionUpdate->isRequired = true;
+
+        $this->contentTypeService->updateFieldDefinition(
+            $contentTypeDraft,
+            $nameField,
+            $fieldDefinitionUpdate
+        );
+
+        $this->contentTypeService->publishContentTypeDraft($contentTypeDraft);
+    }
+
+    /**
+     * @param Content $content
+     * @throws ContentFieldValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    private function updateContentTranslation(Content $content): void
+    {
+        $contentDraft = $this->contentService->createContentDraft($content->contentInfo);
+        $contentUpdate = $this->contentService->newContentUpdateStruct();
+        $contentUpdate->setField(self::FIELD_IDENTIFIER, 'Updated name DE', self::GER_DE);
+
+        $this->contentService->updateContent($contentDraft->getVersionInfo(), $contentUpdate);
+        $this->contentService->publishVersion($contentDraft->versionInfo);
+    }
+}

--- a/eZ/Publish/API/Repository/Tests/ContentService/VersionValidatorTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentService/VersionValidatorTest.php
@@ -106,6 +106,7 @@ class VersionValidatorTest extends BaseTest
 
     /**
      * @param Content $content
+     *
      * @throws ContentFieldValidationException
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException

--- a/eZ/Publish/Core/Repository/Validator/VersionValidator.php
+++ b/eZ/Publish/Core/Repository/Validator/VersionValidator.php
@@ -68,7 +68,7 @@ final class VersionValidator implements ContentValidator
             );
 
             foreach ($languageCodes as $languageCode) {
-                $fieldValue = $content->getField($fieldDefinition->identifier)->value ?? $fieldDefinition->defaultValue;
+                $fieldValue = $content->getField($fieldDefinition->identifier, $languageCode)->value ?? $fieldDefinition->defaultValue;
                 $fieldValue = $fieldType->acceptValue($fieldValue);
 
                 if ($fieldType->isEmptyValue($fieldValue)) {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-175](https://issues.ibexa.co/browse/IBX-175)
| **Type**                                   |bug
| **Target eZ Platform version** | `v3.3`
| **BC breaks**                          | no
| **Doc needed**                       | no

Due to the missing `$language` option, while fetching fields to be validated, we end up with a validation error for each content translation, regardless of field value's correctness.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
