### PR TITLE
IBX-801: Fixed timezone for DateTime fields in content name pattern

### DIFF
--- a/eZ/Publish/Core/FieldType/DateAndTime/Value.php
+++ b/eZ/Publish/Core/FieldType/DateAndTime/Value.php
@@ -66,7 +66,10 @@ class Value extends BaseValue
     public static function fromTimestamp($timestamp)
     {
         try {
-            return new static(new DateTime("@{$timestamp}"));
+            $dateTime = new DateTime();
+            $dateTime->setTimestamp($timestamp);
+
+            return new static($dateTime);
         } catch (Exception $e) {
             throw new InvalidArgumentValue('$timestamp', $timestamp, __CLASS__, $e);
         }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | IBX-801
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.3.6`
| **BC breaks**                          | no
| **Doc needed**                       | no

**Steps to reproduce**
1. Make sure PHP `date.timezone` is set to `America/New_York` (or any other but not UTC)
2. Create "Event" content type with the following field:
    - Name (Identifier: name, Type: ezstring)
    - Date (Identifier: date, Type: ezdatetime)
3. Make sure "Event" content type has `<name> <date>` "Content name pattern".
4. Create a new "Event" content type:
    - Name: Meeting
    - Date: August 31, 2021 14:00

**Expected result**
The new event content item should have "Meeting Tue 2021-31-08 14:00:00" name.

**Actual result**
The new event content item's name is "Meeting Tue 2021-31-08 18:00:00".

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/php-dev-team`).
