### PR TITLE
LimitationValidationException: $errors → $validationErrors

### DIFF
--- a/eZ/Publish/Core/Base/Exceptions/LimitationValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/LimitationValidationException.php
@@ -23,7 +23,7 @@ class LimitationValidationException extends APILimitationValidationException imp
      *
      * @var \eZ\Publish\Core\FieldType\ValidationError[]
      */
-    protected $errors;
+    public $validationErrors;
 
     /**
      * Generates: Limitations did not validate.
@@ -46,6 +46,6 @@ class LimitationValidationException extends APILimitationValidationException imp
      */
     public function getLimitationErrors()
     {
-        return $this->errors;
+        return $this->validationErrors;
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | bug
| **Target eZ Platform version** | `v3.3` or `v4`
| **BC breaks**                          | yes/no (TODO)
| **Doc needed**                       | yes/no (TODO)

- `\eZ\Publish\API\Repository\Exceptions\LimitationValidationException::getLimitationErrors` seems never used nor tested, and was previously useless, alway returning `null`.
- `$errors` seems alway null and never used.
- Regarding `@var` and `@return`, `$errors` is, in fact, `$validationErrors`

With this fix, `getLimitationErrors` now returns the desired `ValidationError[]`.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/php-dev-team`).
