### PR TITLE
IBX-850: [Tests] Fixed PSR-incompatible test namespaces

### DIFF
--- a/tests/bundle/Core/EventListener/BackwardCompatibleCommandListenerTest.php
+++ b/tests/bundle/Core/EventListener/BackwardCompatibleCommandListenerTest.php
@@ -46,7 +46,7 @@ final class BackwardCompatibleCommandListenerTest extends TestCase
             [
                 ConsoleEvents::COMMAND => [['onConsoleCommand', 128]],
             ],
-            $this->listener->getSubscribedEvents()
+            $this->listener::getSubscribedEvents()
         );
     }
 

--- a/tests/bundle/Core/EventListener/BackwardCompatibleCommandListenerTest.php
+++ b/tests/bundle/Core/EventListener/BackwardCompatibleCommandListenerTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace EzPublishCoreBundle\Tests\EventListener;
+namespace Ibexa\Tests\Bundle\Core\EventListener;
 
 use eZ\Bundle\EzPublishCoreBundle\Command\BackwardCompatibleCommand;
 use eZ\Bundle\EzPublishCoreBundle\EventListener\BackwardCompatibleCommandListener;

--- a/tests/integration/Core/FieldType/User/UserStorage/Gateway/UserDoctrineStorageGatewayTest.php
+++ b/tests/integration/Core/FieldType/User/UserStorage/Gateway/UserDoctrineStorageGatewayTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Integration\User\UserStorage;
+namespace Ibexa\Tests\Integration\Core\FieldType\User\UserStorage\Gateway;
 
 use eZ\Publish\Core\FieldType\Tests\Integration\User\UserStorage\UserStorageGatewayTest;
 use eZ\Publish\Core\FieldType\User\UserStorage\Gateway as UserStorageGateway;

--- a/tests/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Type/ContentTypeGroupIdQueryBuilderTest.php
+++ b/tests/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Type/ContentTypeGroupIdQueryBuilderTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Filter\CriterionQueryBuilder\Content\Type;
+namespace Ibexa\Tests\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Content\Type;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion\ContentTypeGroupId;
 use eZ\Publish\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Content\Type\GroupIdQueryBuilder;

--- a/tests/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Type/ContentTypeQueryBuildersTest.php
+++ b/tests/lib/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/Type/ContentTypeQueryBuildersTest.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Filter\CriterionQueryBuilder\Content\Type;
+namespace Ibexa\Tests\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Content\Type;
 
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Content\Type\IdentifierQueryBuilder;
@@ -19,7 +19,7 @@ use eZ\Publish\Core\Persistence\Legacy\Tests\Filter\BaseCriterionVisitorQueryBui
  * @covers \eZ\Publish\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Content\Type\IdQueryBuilder::buildQueryConstraint
  * @covers \eZ\Publish\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Content\Type\IdQueryBuilder::accepts
  */
-final class ContentTypeQueryBuildersQueryBuilderTest extends BaseCriterionVisitorQueryBuilderTestCase
+final class ContentTypeQueryBuildersTest extends BaseCriterionVisitorQueryBuilderTestCase
 {
     public function getFilteringCriteriaQueryData(): iterable
     {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-850](https://issues.ibexa.co/browse/IBX-850)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no, tests are package-internal

This PR fixes incorrect (PSR-{0,4}-incompatible) namespaces for test classes, created by accident.

The classes were moved in a forward-compatible way to the new `Ibexa\*` namespace, so we don't need to maintain BC layer in `ibexa/core`. The placement is based on a future placement of classes being under test.

As a bonus there's small fix of static method invocation, as it does not pollute the diff too much.

Fixed namespaces:
- [x] Integration\User\UserStorage\UserDoctrineStorageGatewayTest
- [x] Filter\CriterionQueryBuilder\Content\Type\ContentTypeQueryBuildersQueryBuilderTest
- [x] Filter\CriterionQueryBuilder\Content\Type\ContentTypeGroupIdQueryBuilderTest
- [x] EzPublishCoreBundle\Tests\EventListener\BackwardCompatibleCommandListenerTest


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
