### PR TITLE
Added static analysis declaration to `ProxyGeneratorInterface`

### DIFF
--- a/eZ/Publish/Core/Repository/ProxyFactory/ProxyGeneratorInterface.php
+++ b/eZ/Publish/Core/Repository/ProxyFactory/ProxyGeneratorInterface.php
@@ -16,6 +16,15 @@ use ProxyManager\Proxy\VirtualProxyInterface;
  */
 interface ProxyGeneratorInterface
 {
+    /**
+     * @template T
+     *
+     * @param class-string<T> $className
+     * @param \Closure $initializer
+     * @param array<string, mixed> $proxyOptions
+     *
+     * @return \ProxyManager\Proxy\VirtualProxyInterface&T
+     */
     public function createProxy(string $className, Closure $initializer, array $proxyOptions = []): VirtualProxyInterface;
 
     public function warmUp(iterable $classes): void;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Adds static analysis information to `ProxyGeneratorInterface`, which allows tools like PHPStan to understand that the returned object will have a specific class.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
