### PR TITLE
IBX-431: Added event dispatching after building the View

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
@@ -7,6 +7,7 @@
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
 
 use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilderRegistry;
+use eZ\Publish\Core\MVC\Symfony\View\Event\BuildViewEvent;
 use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewBuilderParametersEvent;
 use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
 use Psr\Log\LoggerInterface;
@@ -66,6 +67,7 @@ class ViewControllerListener implements EventSubscriberInterface
         $parameterEvent = new FilterViewBuilderParametersEvent(clone $request);
         $this->eventDispatcher->dispatch($parameterEvent, ViewEvents::FILTER_BUILDER_PARAMETERS);
         $view = $viewBuilder->buildView($parameterEvent->getParameters()->all());
+        $this->eventDispatcher->dispatch(new BuildViewEvent($view));
         $request->attributes->set('view', $view);
 
         // View parameters are added as request attributes so that they are available as controller action parameters

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ViewControllerListener.php
@@ -7,9 +7,9 @@
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
 
 use eZ\Publish\Core\MVC\Symfony\View\Builder\ViewBuilderRegistry;
-use eZ\Publish\Core\MVC\Symfony\View\Event\BuildViewEvent;
 use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewBuilderParametersEvent;
 use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
+use Ibexa\Contracts\Core\Event\View\PostBuildViewEvent;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -67,7 +67,7 @@ class ViewControllerListener implements EventSubscriberInterface
         $parameterEvent = new FilterViewBuilderParametersEvent(clone $request);
         $this->eventDispatcher->dispatch($parameterEvent, ViewEvents::FILTER_BUILDER_PARAMETERS);
         $view = $viewBuilder->buildView($parameterEvent->getParameters()->all());
-        $this->eventDispatcher->dispatch(new BuildViewEvent($view));
+        $this->eventDispatcher->dispatch(new PostBuildViewEvent($view));
         $request->attributes->set('view', $view);
 
         // View parameters are added as request attributes so that they are available as controller action parameters

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -173,26 +173,19 @@ class ViewControllerListenerTest extends TestCase
             ->method('buildView')
             ->will($this->returnValue($viewObject));
 
-        $eventDispatcher = new TraceableEventDispatcher(
-            new EventDispatcher(),
-            new Stopwatch()
-        );
-
-        // FilterViewBuilderParametersEvent
-        $eventDispatcher->addListener(
-            ViewEvents::FILTER_BUILDER_PARAMETERS,
-            static function (FilterViewBuilderParametersEvent $event): void {
-                self::assertTrue(true);
-            }
-        );
-
-        // PostBuildViewEvent
-        $eventDispatcher->addListener(
-            PostBuildViewEvent::class,
-            static function (PostBuildViewEvent $event): void {
-                self::assertTrue(true);
-            }
-        );
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher
+            ->expect($this->exactly(2))
+            ->method('dispatch')
+            ->withConsecutive(
+                [
+                    $this->assertInstanceOf(ViewEvent::class),
+                    $this->assertSame(ViewEvents::FILTER_BUILDER_PARAMETERS),
+                ], [
+                    $this->assertInstanceOf(PostBuildViewEvent::class),
+                    $this->assertSame(PostBuildViewEvent::class),
+                ])
+            ->willReturnArgument(0);
 
         $viewControllerListener = new ViewControllerListener(
             $this->controllerResolver,

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -16,6 +16,7 @@ use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
 use Ibexa\Contracts\Core\Event\View\PostBuildViewEvent;
 use PHPUnit\Framework\Constraint\IsIdentical;
 use PHPUnit\Framework\Constraint\IsInstanceOf;
+use PHPUnit\Framework\Constraint\IsNull;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -182,6 +183,7 @@ class ViewControllerListenerTest extends TestCase
                     new IsIdentical(ViewEvents::FILTER_BUILDER_PARAMETERS),
                 ], [
                     new IsInstanceOf(PostBuildViewEvent::class),
+                    new IsNull(),
                 ])
             ->willReturnArgument(0);
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -166,7 +166,7 @@ class ViewControllerListenerTest extends TestCase
         $this->viewBuilderRegistry
             ->expects($this->once())
             ->method('getFromRegistry')
-            ->will($this->returnValue($this->viewBuilderMock));
+            ->willReturn($this->viewBuilderMock);
 
         $this->viewBuilderMock
             ->expects($this->once())

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -170,8 +170,7 @@ class ViewControllerListenerTest extends TestCase
             ->method('buildView')
             ->willReturn($viewObject);
 
-        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
-        $eventDispatcher
+        $this->eventDispatcher
             ->expects($this->exactly(2))
             ->method('dispatch')
             ->withConsecutive(
@@ -184,14 +183,7 @@ class ViewControllerListenerTest extends TestCase
                 ])
             ->willReturnArgument(0);
 
-        $viewControllerListener = new ViewControllerListener(
-            $this->controllerResolver,
-            $this->viewBuilderRegistry,
-            $eventDispatcher,
-            $this->logger
-        );
-
-        $viewControllerListener->getController($this->event);
+        $this->controllerListener->getController($this->event);
     }
 
     /**

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -14,9 +14,6 @@ use eZ\Publish\Core\MVC\Symfony\View\ContentView;
 use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewBuilderParametersEvent;
 use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
 use Ibexa\Contracts\Core\Event\View\PostBuildViewEvent;
-use PHPUnit\Framework\Constraint\IsIdentical;
-use PHPUnit\Framework\Constraint\IsInstanceOf;
-use PHPUnit\Framework\Constraint\IsNull;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -179,11 +176,11 @@ class ViewControllerListenerTest extends TestCase
             ->method('dispatch')
             ->withConsecutive(
                 [
-                    new IsInstanceOf(FilterViewBuilderParametersEvent::class),
-                    new IsIdentical(ViewEvents::FILTER_BUILDER_PARAMETERS),
+                    $this->isInstanceOf(FilterViewBuilderParametersEvent::class),
+                    $this->identicalTo(ViewEvents::FILTER_BUILDER_PARAMETERS),
                 ], [
-                    new IsInstanceOf(PostBuildViewEvent::class),
-                    new IsNull(),
+                    $this->isInstanceOf(PostBuildViewEvent::class),
+                    $this->isNull(),
                 ])
             ->willReturnArgument(0);
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -171,7 +171,7 @@ class ViewControllerListenerTest extends TestCase
         $this->viewBuilderMock
             ->expects($this->once())
             ->method('buildView')
-            ->will($this->returnValue($viewObject));
+            ->willReturn($viewObject);
 
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcher

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/ViewControllerListenerTest.php
@@ -14,18 +14,17 @@ use eZ\Publish\Core\MVC\Symfony\View\ContentView;
 use eZ\Publish\Core\MVC\Symfony\View\Event\FilterViewBuilderParametersEvent;
 use eZ\Publish\Core\MVC\Symfony\View\ViewEvents;
 use Ibexa\Contracts\Core\Event\View\PostBuildViewEvent;
+use PHPUnit\Framework\Constraint\IsIdentical;
+use PHPUnit\Framework\Constraint\IsInstanceOf;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
-use Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher;
-use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
-use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\HttpKernel\Event\ControllerEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\Stopwatch\Stopwatch;
 
 class ViewControllerListenerTest extends TestCase
 {
@@ -175,15 +174,14 @@ class ViewControllerListenerTest extends TestCase
 
         $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
         $eventDispatcher
-            ->expect($this->exactly(2))
+            ->expects($this->exactly(2))
             ->method('dispatch')
             ->withConsecutive(
                 [
-                    $this->assertInstanceOf(ViewEvent::class),
-                    $this->assertSame(ViewEvents::FILTER_BUILDER_PARAMETERS),
+                    new IsInstanceOf(FilterViewBuilderParametersEvent::class),
+                    new IsIdentical(ViewEvents::FILTER_BUILDER_PARAMETERS),
                 ], [
-                    $this->assertInstanceOf(PostBuildViewEvent::class),
-                    $this->assertSame(PostBuildViewEvent::class),
+                    new IsInstanceOf(PostBuildViewEvent::class),
                 ])
             ->willReturnArgument(0);
 
@@ -195,17 +193,6 @@ class ViewControllerListenerTest extends TestCase
         );
 
         $viewControllerListener->getController($this->event);
-
-        $eventsEmitted = array_map(static function (array $calledListener): string {
-            return $calledListener['event'];
-        }, $eventDispatcher->getCalledListeners());
-
-        self::assertSame([
-            ViewEvents::FILTER_BUILDER_PARAMETERS,
-            PostBuildViewEvent::class,
-        ], $eventsEmitted);
-
-        self::assertEmpty($eventDispatcher->getOrphanedEvents());
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/View/Event/BuildViewEvent.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Event/BuildViewEvent.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\MVC\Symfony\View\Event;
+
+use eZ\Publish\Core\MVC\Symfony\View\View;
+use Symfony\Contracts\EventDispatcher\Event;
+
+final class BuildViewEvent extends Event
+{
+    /** @var \eZ\Publish\Core\MVC\Symfony\View\View */
+    private $view;
+
+    public function __construct(View $view)
+    {
+        $this->view = $view;
+    }
+
+    public function getView(): View
+    {
+        return $this->view;
+    }
+}

--- a/src/contracts/Event/View/PostBuildViewEvent.php
+++ b/src/contracts/Event/View/PostBuildViewEvent.php
@@ -6,12 +6,12 @@
  */
 declare(strict_types=1);
 
-namespace eZ\Publish\Core\MVC\Symfony\View\Event;
+namespace Ibexa\Contracts\Core\Event\View;
 
 use eZ\Publish\Core\MVC\Symfony\View\View;
 use Symfony\Contracts\EventDispatcher\Event;
 
-final class BuildViewEvent extends Event
+final class PostBuildViewEvent extends Event
 {
     /** @var \eZ\Publish\Core\MVC\Symfony\View\View */
     private $view;

--- a/tests/lib/Event/View/PostBuildViewEventTest.php
+++ b/tests/lib/Event/View/PostBuildViewEventTest.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Event\View;
+
+use eZ\Publish\Core\MVC\Symfony\View\BaseView;
+use Ibexa\Contracts\Core\Event\View\PostBuildViewEvent;
+use PHPUnit\Framework\TestCase;
+
+class PostBuildViewEventTest extends TestCase
+{
+    public function testEventConstruction(): void
+    {
+        $view = new class() extends BaseView {
+        };
+
+        $event = new PostBuildViewEvent($view);
+
+        self::assertSame($view, $event->getView());
+    }
+}

--- a/tests/lib/Event/View/PostBuildViewEventTest.php
+++ b/tests/lib/Event/View/PostBuildViewEventTest.php
@@ -12,7 +12,7 @@ use eZ\Publish\Core\MVC\Symfony\View\BaseView;
 use Ibexa\Contracts\Core\Event\View\PostBuildViewEvent;
 use PHPUnit\Framework\TestCase;
 
-class PostBuildViewEventTest extends TestCase
+final class PostBuildViewEventTest extends TestCase
 {
     public function testEventConstruction(): void
     {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-431](https://issues.ibexa.co/browse/IBX-431)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Lock and Unlock feature requires a way to react to building `ContentEditView`. Emitting the event after building the `View` object (whatever `View` object it would be) seems appropriate.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
