### PR TITLE
[Composer] Added conflict with symfony/dependency-injection v3.5.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,7 @@
         "symfony/proxy-manager-bridge": "^5.3"
     },
     "conflict": {
+        "symfony/dependency-injection": "5.3.7",
         "symfony/security-core": "5.3.0",
         "doctrine/dbal": "2.7.0",
         "ezsystems/ezpublish-legacy": "*",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Type**                                   | external BC break
| **Target Ibexa version** | v3.3, v4.0
| **BC breaks**                          | no

Exact thing as in https://github.com/ibexa/oss/pull/16, but this time I'm adding the conflict to kernel directly - the conflict in `ibexa/oss` is not taken into account when integration tests in the Kernel are run, which results in failed builds:
https://app.travis-ci.com/github/ezsystems/ezplatform-kernel/jobs/534628414

```
1) Warning

The data provider specified for eZ\Publish\API\Repository\Tests\Values\User\Limitation\RolePolicyLimitationTest::testRolePoliciesWithOverlappingLimitations is invalid.

Symfony\Component\DependencyInjection\Exception\RuntimeException: Cannot autowire service "ezplatform.search.solr.query.common.aggregation_result_extractor.subtree_term.nested": argument "$innerResultExtractor" of method "EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor\NestedAggregationResultExtractor::__construct()" references interface "EzSystems\EzPlatformSolrSearchEngine\ResultExtractor\AggregationResultExtractor" but no such service exists. You should maybe alias this interface to one of these existing services: "ezpublish.search.solr.query.content.aggregation_result_extractor.dispatcher", 
```

Looks like in the future we should be adding conflicts only to the kernel, to avoid making the same PR twice?

#### Checklist:
- [x] Provided PR description.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
