### PR TITLE
Removed return statement from RepositoryAuthenticationProvider::checkAuthentication

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
@@ -39,6 +39,8 @@ class RepositoryAuthenticationProvider extends DaoAuthenticationProvider
     {
         if (!$user instanceof EzUserInterface) {
             parent::checkAuthentication($user, $token);
+            
+            return;
         }
 
         $apiUser = $user->getAPIUser();

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
@@ -39,7 +39,7 @@ class RepositoryAuthenticationProvider extends DaoAuthenticationProvider
     {
         if (!$user instanceof EzUserInterface) {
             parent::checkAuthentication($user, $token);
-            
+
             return;
         }
 

--- a/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Authentication/RepositoryAuthenticationProvider.php
@@ -38,7 +38,7 @@ class RepositoryAuthenticationProvider extends DaoAuthenticationProvider
     protected function checkAuthentication(UserInterface $user, UsernamePasswordToken $token)
     {
         if (!$user instanceof EzUserInterface) {
-            return parent::checkAuthentication($user, $token);
+            parent::checkAuthentication($user, $token);
         }
 
         $apiUser = $user->getAPIUser();


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | -
| **Type**                                   | bug/improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Fixed issue reported by IDE static code analysis:
`\Symfony\Component\Security\Core\Authentication\Provider\UserAuthenticationProvider::checkAuthentication` returns void so return statement is redundant

#### Checklist:
- [x] Provided PR description.
- [ ] ~Tested the solution manually.~ _I believe in my code_
- [ ] ~Provided automated test coverage.~ _I believe in my code_
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
