### PR TITLE
IBX-947: Fixed deleteVersion method to remove Content if necessary

### DIFF
--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1717,8 +1717,9 @@ class ContentService implements ContentServiceInterface
             null,
             2
         );
+        $versionsCount = count($versionList);
 
-        if (count($versionList) === 1 && !$versionInfo->isDraft()) {
+        if ($versionsCount === 1 && !$versionInfo->isDraft()) {
             throw new BadStateException(
                 '$versionInfo',
                 'The Version is the last version of the Content item and cannot be removed'
@@ -1727,10 +1728,12 @@ class ContentService implements ContentServiceInterface
 
         $this->repository->beginTransaction();
         try {
-            $this->persistenceHandler->contentHandler()->deleteVersion(
+            $versionsCount === 1 && $versionInfo->isDraft()
+            ? $this->persistenceHandler->contentHandler()->deleteContent($versionInfo->contentInfo->id)
+            : $this->persistenceHandler->contentHandler()->deleteVersion(
                 $versionInfo->getContentInfo()->id,
                 $versionInfo->versionNo
-            );
+              );
             $this->repository->commit();
         } catch (Exception $e) {
             $this->repository->rollback();

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1728,7 +1728,7 @@ class ContentService implements ContentServiceInterface
 
         $this->repository->beginTransaction();
         try {
-            $versionsCount === 1 && $versionInfo->isDraft()
+            $versionsCount === 1
             ? $this->persistenceHandler->contentHandler()->deleteContent($versionInfo->contentInfo->id)
             : $this->persistenceHandler->contentHandler()->deleteVersion(
                 $versionInfo->getContentInfo()->id,


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-947](https://issues.ibexa.co/browse/IBX-947)
| **Type**                                   |bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

There is a problem with providing a test for such a case. Actually, [this particular test](https://github.com/ezsystems/ezplatform-kernel/blob/master/eZ/Publish/API/Repository/Tests/ContentServiceTest.php#L3125) should handle this problem. However, it doesn't check for records to exist in `ezcontentobject` table which may be orphaned. We don't have an API method to load a single record from `ezcontentobject` table. The `loadContent` method loads content using the join and that's why it throws the `NotFoundException`, however, this record still exists and causes problems elsewhere.

ping @ezsystems/php-dev-team 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
