### PR TITLE
[Tests] Fixed Repository BatchIteratorAdapter tests 

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentFilteringAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentFilteringAdapterTest.php
@@ -60,13 +60,13 @@ final class ContentFilteringAdapterTest extends TestCase
 
         $adapter = new ContentFilteringAdapter($contentService, $originalFilter, self::EXAMPLE_LANGUAGE_FILTER);
 
-        self::assertEqualsCanonicalizing(
+        self::assertSame(
             $expectedResults,
             iterator_to_array($adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT))
         );
 
         // Input $filter remains untouched
-        self::assertEquals(0, $originalFilter->getOffset());
-        self::assertEquals(0, $originalFilter->getLimit());
+        self::assertSame(0, $originalFilter->getOffset());
+        self::assertSame(0, $originalFilter->getLimit());
     }
 }

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentFilteringAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentFilteringAdapterTest.php
@@ -28,11 +28,21 @@ final class ContentFilteringAdapterTest extends TestCase
      */
     public function testFetch(): void
     {
+        $content1 = $this->createMock(Content::class);
+        $content2 = $this->createMock(Content::class);
+        $content3 = $this->createMock(Content::class);
+
         $contentList = new ContentList(3, [
-            $this->createMock(Content::class),
-            $this->createMock(Content::class),
-            $this->createMock(Content::class),
+            $content1,
+            $content2,
+            $content3,
         ]);
+
+        $expectedResults = [
+            $content1,
+            $content2,
+            $content3,
+        ];
 
         $originalFilter = new Filter();
         $originalFilter->withCriterion(new MatchAll());
@@ -51,8 +61,8 @@ final class ContentFilteringAdapterTest extends TestCase
         $adapter = new ContentFilteringAdapter($contentService, $originalFilter, self::EXAMPLE_LANGUAGE_FILTER);
 
         self::assertEqualsCanonicalizing(
-            $contentList->getIterator(),
-            $adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT)
+            $expectedResults,
+            iterator_to_array($adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT))
         );
 
         // Input $filter remains untouched

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentFilteringAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/ContentFilteringAdapterTest.php
@@ -22,6 +22,10 @@ final class ContentFilteringAdapterTest extends TestCase
     private const EXAMPLE_OFFSET = 10;
     private const EXAMPLE_LIMIT = 25;
 
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
     public function testFetch(): void
     {
         $contentList = new ContentList(3, [
@@ -46,13 +50,13 @@ final class ContentFilteringAdapterTest extends TestCase
 
         $adapter = new ContentFilteringAdapter($contentService, $originalFilter, self::EXAMPLE_LANGUAGE_FILTER);
 
-        $this->assertSame(
+        self::assertEqualsCanonicalizing(
             $contentList->getIterator(),
             $adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT)
         );
 
-        // Input $filter reminds untouched
-        $this->assertEquals(0, $originalFilter->getOffset());
-        $this->assertEquals(0, $originalFilter->getLimit());
+        // Input $filter remains untouched
+        self::assertEquals(0, $originalFilter->getOffset());
+        self::assertEquals(0, $originalFilter->getLimit());
     }
 }

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/LocationFilteringAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/LocationFilteringAdapterTest.php
@@ -28,14 +28,24 @@ final class LocationFilteringAdapterTest extends TestCase
      */
     public function testFetch(): void
     {
+        $location1 = $this->createMock(Location::class);
+        $location2 = $this->createMock(Location::class);
+        $location3 = $this->createMock(Location::class);
+
         $locationList = new LocationList([
             'locations' => [
-                $this->createMock(Location::class),
-                $this->createMock(Location::class),
-                $this->createMock(Location::class),
+                $location1,
+                $location2,
+                $location3,
             ],
             'totalCount' => 3,
         ]);
+
+        $expectedResults = [
+            $location1,
+            $location2,
+            $location3,
+        ];
 
         $originalFilter = new Filter();
         $originalFilter->withCriterion(new MatchAll());
@@ -53,13 +63,13 @@ final class LocationFilteringAdapterTest extends TestCase
 
         $adapter = new LocationFilteringAdapter($locationService, $originalFilter, self::EXAMPLE_LANGUAGE_FILTER);
 
-        self::assertEqualsCanonicalizing(
-            $locationList->getIterator(),
-            $adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT)
+        self::assertSame(
+            $expectedResults,
+            iterator_to_array($adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT))
         );
 
         // Input $filter remains untouched
-        self::assertEquals(0, $originalFilter->getOffset());
-        self::assertEquals(0, $originalFilter->getLimit());
+        self::assertSame(0, $originalFilter->getOffset());
+        self::assertSame(0, $originalFilter->getLimit());
     }
 }

--- a/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/LocationFilteringAdapterTest.php
+++ b/eZ/Publish/API/Repository/Tests/Iterator/BatchIteratorAdapter/LocationFilteringAdapterTest.php
@@ -22,6 +22,10 @@ final class LocationFilteringAdapterTest extends TestCase
     private const EXAMPLE_OFFSET = 10;
     private const EXAMPLE_LIMIT = 25;
 
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
     public function testFetch(): void
     {
         $locationList = new LocationList([
@@ -49,13 +53,13 @@ final class LocationFilteringAdapterTest extends TestCase
 
         $adapter = new LocationFilteringAdapter($locationService, $originalFilter, self::EXAMPLE_LANGUAGE_FILTER);
 
-        $this->assertSame(
+        self::assertEqualsCanonicalizing(
             $locationList->getIterator(),
             $adapter->fetch(self::EXAMPLE_OFFSET, self::EXAMPLE_LIMIT)
         );
 
-        // Input $filter reminds untouched
-        $this->assertEquals(0, $originalFilter->getOffset());
-        $this->assertEquals(0, $originalFilter->getLimit());
+        // Input $filter remains untouched
+        self::assertEquals(0, $originalFilter->getOffset());
+        self::assertEquals(0, $originalFilter->getLimit());
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -73,6 +73,9 @@
     <testsuite name="eZ\Publish\API\Repository\Values\Content">
       <directory>eZ/Publish/API/Repository/Tests/Values</directory>
     </testsuite>
+    <testsuite name="eZ\Publish\API\Repository\Iterator">
+      <directory>eZ/Publish/API/Repository/Tests/Iterator</directory>
+    </testsuite>
   </testsuites>
   <filter>
     <whitelist>


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | Follow-up for [IBX-719](https://issues.ibexa.co/browse/IBX-719)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR fixes broken tests introduced via #211. The tests were never executed because they were not a part of the test suites.
The iterator instance is never gonna be the same instance, hence `assertSame` fails. What we need here is a check if the iterators contain the same objects.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
