### PR TITLE
IBX-1195: Added default value for `DATABASE_URL` for `IbexaTestKernel`

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/config/doctrine.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/config/doctrine.php
@@ -11,8 +11,12 @@ namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 use EzSystems\DoctrineSchema\Database\DbPlatform\SqliteDbPlatform;
 
 return static function (ContainerConfigurator $container): void {
+    if (!isset($_ENV['DATABASE_URL'])) {
+        $_ENV['DATABASE_URL'] = 'sqlite://:memory:';
+    }
+
     $platform = null;
-    if (substr(getenv('DATABASE_URL'), 0, strlen('sqlite://')) === 'sqlite://') {
+    if (substr($_ENV['DATABASE_URL'], 0, strlen('sqlite://')) === 'sqlite://') {
         $platform = SqliteDbPlatform::class;
     }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1195](https://issues.ibexa.co/browse/IBX-1195)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Default to in-memory SQLite database for integration tests.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
