### PR TITLE
IBX-1196: Started respecting `SEARCH_ENGINE` env variable in `IbexaTestKernel`

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/config/ezpublish.yaml
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/config/ezpublish.yaml
@@ -1,3 +1,6 @@
+parameters:
+    env(SEARCH_ENGINE): 'legacy'
+
 ezpublish:
     siteaccess:
           default_siteaccess: '__default_site_access__'
@@ -12,5 +15,5 @@ ezpublish:
         default:
             storage: ~
             search:
-                engine: legacy
+                engine: '%env(SEARCH_ENGINE)%'
                 connection: default


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1196](https://issues.ibexa.co/browse/IBX-1196)
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Allows `SEARCH_ENGINE` environment variable to be used to select a different search engine than `legacy`.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
