### PR TITLE
IBX-1218: Fixed a Symfony\Component\HttpFoundation::getSession() call…

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionInitByPostListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionInitByPostListener.php
@@ -27,14 +27,16 @@ class SessionInitByPostListener implements EventSubscriberInterface
     public function onSiteAccessMatch(PostSiteAccessMatchEvent $event)
     {
         $request = $event->getRequest();
-        $session = $request->getSession();
-
-        if (!$session || $event->getRequestType() !== HttpKernelInterface::MAIN_REQUEST) {
+        if ($event->getRequestType() !== HttpKernelInterface::MAIN_REQUEST) {
             return;
         }
 
+        if (!$request->hasSession()) {
+            return;
+        }
+        $session = $request->getSession();
+
         $sessionName = $session->getName();
-        $request = $event->getRequest();
 
         if (
             !$session->isStarted()


### PR DESCRIPTION
… without checking its existence with hasSession()

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1218](https://issues.ibexa.co/browse/IBX-1218)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR fix a thrown exception (\Symfony\Component\HttpFoundation\Exception\SessionNotFoundException) if no session is available in the request.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
