### PR TITLE
Fixed router failure when performing matching in `IbexaTestKernel`

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/config/framework.yaml
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/config/framework.yaml
@@ -9,4 +9,4 @@ framework:
     cache:
         app: cache.adapter.array
     router:
-        resource: foo
+        resource: '@EzPublishCoreBundle/Tests/Resources/config/routes.yaml'

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/config/routes.yaml
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/config/routes.yaml
@@ -1,0 +1,2 @@
+ibexa.test:
+    path: /

--- a/tests/integration/BasicKernelTest.php
+++ b/tests/integration/BasicKernelTest.php
@@ -29,4 +29,11 @@ final class BasicKernelTest extends IbexaKernelTestCase
         self::getServiceByClassName(Repository::class);
         $this->expectNotToPerformAssertions();
     }
+
+    public function testRouterIsAvailable(): void
+    {
+        $router = self::getContainer()->get('router');
+        $router->match('/');
+        $this->expectNotToPerformAssertions();
+    }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Fixes an issue occuring when `IbexaTestKernel` is used combined with `WebTestCase` (used for testing route response).

While technically route matching is not yet supported (due to packages being too tightly coupled, which usually results in the need to include most, if not all, Ibexa packages), this makes it so tests against routes will not crash with a confusing message.

Error & stacktrace is as follows:
```
InvalidArgumentException: Class "foo" does not exist.


vendor/symfony/routing/Loader/AnnotationClassLoader.php:116
vendor/symfony/config/Loader/DelegatingLoader.php:40
vendor/symfony/framework-bundle/Routing/DelegatingLoader.php:69
vendor/symfony/framework-bundle/Routing/Router.php:70
vendor/symfony/routing/Router.php:358
vendor/symfony/routing/Router.php:289
vendor/symfony/config/ResourceCheckerConfigCacheFactory.php:39
vendor/symfony/routing/Router.php:297
vendor/symfony/routing/Router.php:243
vendor/ezsystems/ezplatform-kernel/eZ/Bundle/EzPublishCoreBundle/Routing/DefaultRouter.php:67
vendor/symfony/http-kernel/EventListener/RouterListener.php:112
vendor/symfony/event-dispatcher/Debug/WrappedListener.php:117
vendor/symfony/event-dispatcher/EventDispatcher.php:230
vendor/symfony/event-dispatcher/EventDispatcher.php:59
vendor/symfony/event-dispatcher/Debug/TraceableEventDispatcher.php:151
vendor/symfony/http-kernel/HttpKernel.php:132
vendor/symfony/http-kernel/HttpKernel.php:78
vendor/symfony/http-kernel/Kernel.php:199
vendor/symfony/http-kernel/HttpKernelBrowser.php:65
vendor/symfony/framework-bundle/KernelBrowser.php:172
vendor/symfony/browser-kit/AbstractBrowser.php:402
```

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
