### PR TITLE
RFC: Allowed schema & fixture files be accessed from Kernel

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
         "phpunit/phpunit": "^8.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "symfony/phpunit-bridge": "^5.1",
-        "symfony/proxy-manager-bridge": "^5.3"
+        "symfony/proxy-manager-bridge": "^5.3",
+        "dama/doctrine-test-bundle": "^6.6"
     },
     "conflict": {
         "symfony/dependency-injection": "5.3.7",

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/services/fixture-services.yaml
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/services/fixture-services.yaml
@@ -1,6 +1,7 @@
 services:
     eZ\Publish\API\Repository\Tests\LegacySchemaImporter:
         alias: 'test.ibexa.schema_importer'
+        public: true
 
     test.ibexa.schema_importer:
         class: eZ\Publish\API\Repository\Tests\LegacySchemaImporter
@@ -10,6 +11,7 @@ services:
 
     eZ\Publish\SPI\Tests\Persistence\FixtureImporter:
         alias: 'test.ibexa.fixture_importer'
+        public: true
 
     test.ibexa.fixture_importer:
         class: eZ\Publish\SPI\Tests\Persistence\FixtureImporter

--- a/src/contracts/Test/IbexaKernelTestCase.php
+++ b/src/contracts/Test/IbexaKernelTestCase.php
@@ -22,7 +22,6 @@ use eZ\Publish\API\Repository\Tests\LegacySchemaImporter;
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\SPI\Persistence\TransactionHandler;
 use eZ\Publish\SPI\Tests\Persistence\FixtureImporter;
-use eZ\Publish\SPI\Tests\Persistence\YamlFixture;
 use RuntimeException;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
@@ -46,11 +45,11 @@ abstract class IbexaKernelTestCase extends KernelTestCase
     }
 
     /**
-     * @return array<string>
+     * @return iterable<string>
      */
     protected static function getSchemaFiles(): iterable
     {
-        yield self::$kernel->locateResource('@EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml');
+        yield from self::$kernel->getSchemaFiles();
     }
 
     final protected static function loadFixtures(): void
@@ -73,7 +72,7 @@ abstract class IbexaKernelTestCase extends KernelTestCase
      */
     protected static function getFixtures(): iterable
     {
-        yield new YamlFixture(dirname(__DIR__, 3) . '/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/data/test_data.yaml');
+        yield from self::$kernel->getFixtures();
     }
 
     /**
@@ -108,7 +107,7 @@ abstract class IbexaKernelTestCase extends KernelTestCase
 
         $id = $id ?? $className;
 
-        return $kernel->getAliasServiceId($id);
+        return $kernel::getAliasServiceId($id);
     }
 
     protected static function getDoctrineConnection(): Connection

--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -16,6 +16,7 @@ use eZ\Bundle\EzPublishLegacySearchEngineBundle\EzPublishLegacySearchEngineBundl
 use eZ\Publish\API\Repository;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\SPI\Persistence\TransactionHandler;
+use eZ\Publish\SPI\Tests\Persistence\YamlFixture;
 use FOS\JsRoutingBundle\FOSJsRoutingBundle;
 use JMS\TranslationBundle\JMSTranslationBundle;
 use Liip\ImagineBundle\LiipImagineBundle;
@@ -97,6 +98,22 @@ class IbexaTestKernel extends Kernel
     public static function getAliasServiceId(string $id): string
     {
         return 'test.' . $id;
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    public function getSchemaFiles(): iterable
+    {
+        yield $this->locateResource('@EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml');
+    }
+
+    /**
+     * @return iterable<\eZ\Publish\SPI\Tests\Persistence\Fixture>
+     */
+    public function getFixtures(): iterable
+    {
+        yield new YamlFixture(dirname(__DIR__, 3) . '/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/data/test_data.yaml');
     }
 
     public function getCacheDir(): string


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

# Request for comments

This change proposes one of possible ways of exposing schema & fixture files for consumption in our & third party packages, so they can be coupled with https://github.com/dmaicher/doctrine-test-bundle, and subsequently improve the performance of database-related tests.

This solution directly provides new methods to `IbexaTestKernel`. A different solution I've come up would be to provide schema & fixture registry as a test service.

I have created a local test to change the performance impact on testing for a MySQL database (mind you, using a normal filesystem). The results are as follows:

_without transaction bundle & database bootstraping_
![image](https://user-images.githubusercontent.com/3183926/136699699-993ee7f4-cc97-4b36-8ad7-3b22f3148e60.png)

_with transaction bundle & database bootstraping_
(8 second execution)
![image](https://user-images.githubusercontent.com/3183926/136699666-42a8474e-e3e3-4e94-aee1-0e29133af54c.png)

Note that these include ~2-3 sec of container compilation & database setup, which means that each tests is reduced from ~300ms to a few ms in execution.

Samples bootstrapping (executed in context of ibexa migrations, used for result above)

```php
<?php

use eZ\Publish\API\Repository\Tests\LegacySchemaImporter;
use eZ\Publish\SPI\Tests\Persistence\FixtureImporter;
use eZ\Publish\SPI\Tests\Persistence\YamlFixture;

require_once __DIR__.'/../vendor/autoload.php';

function bootstrap(): void
{
    $kernel = new \Ibexa\Platform\Tests\Bundle\Migration\IbexaTestKernel('test', true);
    $kernel->boot();

    $application = new \Symfony\Bundle\FrameworkBundle\Console\Application($kernel);
    $application->setAutoExit(false);

    $application->run(new \Symfony\Component\Console\Input\ArrayInput([
        'command' => 'doctrine:database:drop',
        '--if-exists' => '1',
        '--force' => '1',
    ]));

    $application->run(new \Symfony\Component\Console\Input\ArrayInput([
        'command' => 'doctrine:database:create',
    ]));

    /** @var \eZ\Publish\API\Repository\Tests\LegacySchemaImporter $schemaImporter */
    $schemaImporter = $kernel->getContainer()->get(LegacySchemaImporter::class);
    foreach ($kernel->getSchemaFiles() as $schemaFile) {
        $schemaImporter->importSchema($schemaFile);
    }

    /** @var \eZ\Publish\SPI\Tests\Persistence\FixtureImporter $fixtureImporter */
    $fixtureImporter = $kernel->getContainer()->get(FixtureImporter::class);
    foreach ($kernel->getFixtures() as $fixture) {
        $fixtureImporter->import($fixture);
    }

    $kernel->shutdown();
}

bootstrap();

```

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
