### PR TITLE
Fixed compatibility with Symfony 5.4

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/HttpBasicFactory.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/HttpBasicFactory.php
@@ -15,7 +15,7 @@ use Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\HttpBasic
  */
 class HttpBasicFactory extends BaseHttpBasicFactory
 {
-    public function getKey()
+    public function getKey(): string
     {
         return 'ezpublish_http_basic';
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | yes/no

This fixes a PHP fatal error that will start occuring once Symfony 5.4 is released.

Due to our dependency on one of internal classes, added return type will cause installations to fail with the following message:
```
PHP Fatal error:  Declaration of eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\HttpBasicFactory::getKey() 
must be compatible with Symfony\Bundle\SecurityBundle\DependencyInjection\Security\Factory\HttpBasicFactory::getKey(): 
string in vendor/ezsystems/ezplatform-kernel/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/HttpBasicFactory.php on line 18
```

See upcoming Symfony 5.4 method definition: https://github.com/symfony/symfony/blob/fc47953166af8081af9dbace9548e82fd243acc9/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/HttpBasicFactory.php#L81

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
