### PR TITLE
Added `ibexa.core.test.resource_dir` parameter for resources moved out of bundle

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/config/framework.yaml
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/config/framework.yaml
@@ -9,4 +9,4 @@ framework:
     cache:
         app: cache.adapter.array
     router:
-        resource: '@EzPublishCoreBundle/Tests/Resources/config/routes.yaml'
+        resource: '%ibexa.core.test.resource_dir%/config/routes.yaml'

--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -127,6 +127,10 @@ class IbexaTestKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
+        $loader->load(static function (ContainerBuilder $container): void {
+            $container->setParameter('ibexa.core.test.resource_dir', self::getResourcesPath());
+        });
+
         $this->loadConfiguration($loader);
         $this->loadServices($loader);
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | no

Makes the `IbexaTestKernel` less reliant on test configuration files being present in Core bundle.

**Current test failure on Travis cannot be related to these changes**

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
