### PR TITLE
Fixed invalid PHPDoc for `Criterion::$value`

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion.php
@@ -25,7 +25,7 @@ abstract class Criterion implements CriterionInterface
     /**
      * The value(s) matched by the criteria.
      *
-     * @var array(int|string)
+     * @var string[]|int[]|int|string|bool
      */
     public $value;
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Fixed invalid PHPDoc declaration for `Criterion::$value` to allow proper static analysis in dependent packages.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
