### PR TITLE
Dropped PHP 7.3 for next major release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,7 +18,6 @@ jobs:
             matrix:
                 experimental: [ false ]
                 php:
-                    - '7.3'
                     - '7.4'
                 composer_options: [ "" ]
 
@@ -79,7 +78,6 @@ jobs:
             matrix:
                 experimental: [ false ]
                 php:
-                    - '7.3'
                     - '7.4'
                 composer_options: [ "" ]
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,9 @@ env:
 matrix:
   fast_finish: true
   include:
-# 7.3
+# 7.4
     - name: "Kernel Behat Core tests"
-      php: 7.3
+      php: 7.4
       env:
         - COMPOSE_FILE="doc/docker/base-dev.yml:doc/docker/selenium.yml"
         - BEHAT_OPTS="--mode=standard --profile=core --tags=~@broken -c=behat_ibexa_oss.yaml"
@@ -32,10 +32,10 @@ matrix:
         - APP_DEBUG=1
         - PROJECT_VERSION=^4.0.x-dev
     - name: 'Solr 7.7.3 integration tests (using shared cores) with Redis cache pool'
-      php: 7.3
+      php: 7.4
       env: SOLR_VERSION="7.7.3" TEST_CONFIG="phpunit-integration-legacy-solr.xml" CUSTOM_CACHE_POOL="singleredis" CORES_SETUP="shared" SOLR_CONFIG="vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/schema.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/custom-fields-types.xml vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/language-fieldtypes.xml" JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64/jre/"
     - name: 'MySQL integration tests'
-      php: 7.3
+      php: 7.4
       env: TEST_CONFIG="phpunit-integration-legacy.xml" DB="mysql" DATABASE="mysql://root@localhost/testdb"
 
 # test only master, stable branches and pull requests

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php-64bit": "For support of more than 30 languages, a 64bit php installation on all involved prod/dev machines is required"
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.4",
         "ext-ctype": "*",
         "ext-fileinfo": "*",
         "ext-intl": "*",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v4.0`
| **BC breaks**                          | yes (between 3.3 & 4.0)

Ibexa 4.0 is not expected to support PHP 7.3 anymore.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
