### PR TITLE
IBX-1410: Made `ezuser` searchable

### DIFF
--- a/eZ/Publish/Core/FieldType/User/SearchField.php
+++ b/eZ/Publish/Core/FieldType/User/SearchField.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace eZ\Publish\Core\FieldType\User;
+
+use eZ\Publish\SPI\FieldType\Indexable as IndexableInterface;
+use eZ\Publish\SPI\Persistence\Content\Field;
+use eZ\Publish\SPI\Persistence\Content\Type\FieldDefinition;
+use eZ\Publish\SPI\Search;
+
+final class SearchField implements IndexableInterface
+{
+    /**
+     * @return \eZ\Publish\SPI\Search\Field[]
+     */
+    public function getIndexData(Field $field, FieldDefinition $fieldDefinition): array
+    {
+        return [
+            new Search\Field(
+                'user_login',
+                $field->value->externalData['login'],
+                new Search\FieldType\StringField()
+            ),
+            new Search\Field(
+                'user_email',
+                $field->value->externalData['email'],
+                new Search\FieldType\StringField()
+            ),
+        ];
+    }
+
+    /**
+     * @return \eZ\Publish\SPI\Search\FieldType[]
+     */
+    public function getIndexDefinition(): array
+    {
+        return [
+            'user_login' => new Search\FieldType\StringField(),
+            'user_email' => new Search\FieldType\StringField(),
+        ];
+    }
+
+    public function getDefaultMatchField(): string
+    {
+        return '';
+    }
+
+    public function getDefaultSortField(): string
+    {
+        return '';
+    }
+}

--- a/eZ/Publish/Core/FieldType/User/SearchField.php
+++ b/eZ/Publish/Core/FieldType/User/SearchField.php
@@ -1,5 +1,9 @@
 <?php
 
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
 namespace eZ\Publish\Core\FieldType\User;
 
 use eZ\Publish\SPI\FieldType\Indexable as IndexableInterface;
@@ -41,11 +45,11 @@ final class SearchField implements IndexableInterface
 
     public function getDefaultMatchField(): string
     {
-        return '';
+        return 'user_login';
     }
 
     public function getDefaultSortField(): string
     {
-        return '';
+        return $this->getDefaultMatchField();
     }
 }

--- a/eZ/Publish/Core/FieldType/User/Type.php
+++ b/eZ/Publish/Core/FieldType/User/Type.php
@@ -178,6 +178,11 @@ class Type extends FieldType
         // Does nothing
     }
 
+    public function isSearchable()
+    {
+        return true;
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -110,6 +110,11 @@ services:
         tags:
             - {name: ezplatform.field_type.indexable, alias: ezurl}
 
+    ezpublish.fieldType.indexable.ezuser:
+        class: eZ\Publish\Core\FieldType\User\SearchField
+        tags:
+            - { name: ezplatform.field_type.indexable, alias: ezuser }
+
     ezpublish.fieldType.indexable.ezimageasset:
         class: eZ\Publish\Core\FieldType\ImageAsset\SearchField
         tags:
@@ -119,7 +124,6 @@ services:
     ezpublish.fieldType.indexable.unindexed:
         class: eZ\Publish\Core\FieldType\Unindexed
         tags:
-            - {name: ezplatform.field_type.indexable, alias: ezuser}
             - {name: ezplatform.field_type.indexable, alias: ezenum}
             - {name: ezplatform.field_type.indexable, alias: ezidentifier}
             - {name: ezplatform.field_type.indexable, alias: ezinisetting}

--- a/eZ/Publish/Core/settings/indexable_fieldtypes.yml
+++ b/eZ/Publish/Core/settings/indexable_fieldtypes.yml
@@ -111,7 +111,7 @@ services:
             - {name: ezplatform.field_type.indexable, alias: ezurl}
 
     ezpublish.fieldType.indexable.ezuser:
-        class: eZ\Publish\Core\FieldType\User\SearchField
+        class: Ibexa\Bundle\Core\FieldType\User\SearchField
         tags:
             - { name: ezplatform.field_type.indexable, alias: ezuser }
 

--- a/src/bundle/Core/FieldType/User/SearchField.php
+++ b/src/bundle/Core/FieldType/User/SearchField.php
@@ -4,7 +4,7 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace eZ\Publish\Core\FieldType\User;
+namespace Ibexa\Bundle\Core\FieldType\User;
 
 use eZ\Publish\SPI\FieldType\Indexable as IndexableInterface;
 use eZ\Publish\SPI\Persistence\Content\Field;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1410](https://issues.ibexa.co/browse/IBX-1410)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

_I'm looking for a suitable tests, and if they should be added._

This PR makes login & email information of the users searchable.

Screenshot from Solr when combined with this patch:
![image](https://user-images.githubusercontent.com/3183926/140887393-46223e64-1ad8-416a-9f76-8f4020658713.png)



#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
