### PR TITLE
IBX-1454: Replaced `TestLogger` in test Kernel with `NullLogger`

### DIFF
--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -17,7 +17,7 @@ use eZ\Publish\SPI\Persistence\TransactionHandler;
 use FOS\JsRoutingBundle\FOSJsRoutingBundle;
 use JMS\TranslationBundle\JMSTranslationBundle;
 use Liip\ImagineBundle\LiipImagineBundle;
-use Psr\Log\Test\TestLogger;
+use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
 use Symfony\Bundle\TwigBundle\TwigBundle;
@@ -193,6 +193,6 @@ class IbexaTestKernel extends Kernel
 
     private static function setUpTestLogger(ContainerBuilder $container): void
     {
-        $container->setDefinition('logger', new Definition(TestLogger::class));
+        $container->setDefinition('logger', new Definition(NullLogger::class));
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1454](https://issues.ibexa.co/browse/IBX-1454)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no - _`TestLogger` should not be relied upon there._

Replaces `TestLogger` with `NullLogger`.

`TestLogger` class is removed in `psr/log` 2.0 and 3.0.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
