### PR TITLE
IBX-1518: Provided separate messages for Subtree Limitation validation

### DIFF
--- a/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
@@ -72,15 +72,26 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
                 $subtreeRootLocationId = end($pathArray);
                 $spiLocation = $this->persistence->locationHandler()->load($subtreeRootLocationId);
             } catch (APINotFoundException $e) {
-            }
-
-            if (!isset($spiLocation) || strpos($spiLocation->pathString, $path) !== 0) {
                 $validationErrors[] = new ValidationError(
                     "limitationValues[%key%] => '%value%' does not exist in the backend",
                     null,
                     [
                         'value' => $path,
                         'key' => $key,
+                    ]
+                );
+
+                continue;
+            }
+
+            if (strpos($spiLocation->pathString, $path) !== 0) {
+                $validationErrors[] = new ValidationError(
+                    "limitationValues[%key%] => '%value%' does not equal Location's path string: '%path_string%'",
+                    null,
+                    [
+                        'value' => $path,
+                        'key' => $key,
+                        'path_string' => $spiLocation->pathString,
                     ]
                 );
             }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1518](https://issues.ibexa.co/browse/IBX-1518)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Provides a separate message for cases where:
 * Location ID was not found in the database
 * Path string does not match the one found in actually loaded Location

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
