### PR TITLE
IBX-1517: Made quotes in exception for Ancestor criterion consistent

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
+++ b/eZ/Publish/API/Repository/Values/Content/Query/Criterion/Ancestor.php
@@ -33,7 +33,7 @@ class Ancestor extends Criterion implements FilteringCriterion
         foreach ((array)$value as $pathString) {
             if (preg_match('/^(\/\w+)+\/$/', $pathString) !== 1) {
                 throw new InvalidArgumentException(
-                    "'$pathString' value must follow the pathString format, e.g. /1/2/"
+                    "'$pathString' value must follow the pathString format, e.g. '/1/2/'"
                 );
             }
         }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1517](https://issues.ibexa.co/browse/IBX-1517)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Original message looks as if value stored in database is quoted. This patch ensures that both compared values are presented with the same quotes.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
