### PR TITLE
IBX-1516: Enforced strict comparison between Limitation & Location path strings

### DIFF
--- a/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
+++ b/eZ/Publish/Core/Limitation/SubtreeLimitationType.php
@@ -74,7 +74,7 @@ class SubtreeLimitationType extends AbstractPersistenceLimitationType implements
             } catch (APINotFoundException $e) {
             }
 
-            if (!isset($spiLocation) || strpos($spiLocation->pathString, $path) !== 0) {
+            if (!isset($spiLocation) || $spiLocation->pathString !== $path) {
                 $validationErrors[] = new ValidationError(
                     "limitationValues[%key%] => '%value%' does not exist in the backend",
                     null,


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1516](https://issues.ibexa.co/browse/IBX-1516)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | yes - :exclamation: it might cause previously valid values to be rejected :exclamation: 

# Needs discussion

There is a mismatch between validation in Criterion and Limitation.

Criterion uses regex to check that Subtree Limitation is valid.
Subtree Limitation does not validate using this regex and "only" checks that Location path string and Limitation path string use the same beginning.

Early solution presented here ensures that values passed to Limition as path string is the same as the one present in Location (which ends with a trailing slash).

:exclamation: However, because I'm not certain if they should be always exactly equal, I'm marking this as a BC break until discussed.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
