### PR TITLE
IBX-1489: Provided integration test for Installers for PHP8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -138,9 +138,9 @@ jobs:
         timeout-minutes: 20
 
         strategy:
+            fail-fast: false
             matrix:
                 php:
-                    - '7.3'
                     - '7.4'
                 composer_options: [ "" ]
                 include:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
 
     integration-tests-postgres:
         name: PostgreSQL integration tests
-        needs: tests
+        # needs: tests
         services:
             postgres:
                 image: postgres:10
@@ -117,7 +117,7 @@ jobs:
 
     integration-tests-mysql:
         name: MySQL integration tests
-        needs: tests
+        # needs: tests
         services:
             mysql:
                 image: mysql:8.0

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -135,7 +135,7 @@ jobs:
                     --health-retries=5
                     --tmpfs=/var/lib/mysql
         runs-on: "ubuntu-20.04"
-        timeout-minutes: 20
+        timeout-minutes: 60
 
         strategy:
             fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -80,12 +80,10 @@ jobs:
                     --tmpfs /var/lib/postgres
         runs-on: "ubuntu-20.04"
         timeout-minutes: 60
-        continue-on-error: ${{ matrix.experimental }}
 
         strategy:
             fail-fast: false
             matrix:
-                experimental: [ false ]
                 php:
                     - '7.3'
                     - '7.4'
@@ -127,7 +125,7 @@ jobs:
         # needs: tests
         services:
             mysql:
-                image: mysql:8.0
+                image: mysql:5.7
                 ports:
                     - 3306/tcp
                 env:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,6 +21,9 @@ jobs:
                     - '7.3'
                     - '7.4'
                 composer_options: [ "" ]
+                include:
+                    -   php: '8.0'
+                        composer_options: "--ignore-platform-req php"
 
         steps:
             - uses: actions/checkout@v2
@@ -82,6 +85,9 @@ jobs:
                     - '7.3'
                     - '7.4'
                 composer_options: [ "" ]
+                include:
+                    -   php: '8.0'
+                        composer_options: "--ignore-platform-req php"
 
         steps:
             -   uses: actions/checkout@v2
@@ -108,3 +114,60 @@ jobs:
                     DATABASE_URL: "pgsql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/testdb?server_version=10"
                     # Required by old repository tests
                     DATABASE: "pgsql://postgres:postgres@localhost:${{ job.services.postgres.ports[5432] }}/testdb"
+
+    integration-tests-mysql:
+        name: MySQL integration tests
+        needs: tests
+        services:
+            mysql:
+                image: mysql:8.0
+                ports:
+                    - 3306/tcp
+                env:
+                    MYSQL_RANDOM_ROOT_PASSWORD: true
+                    MYSQL_USER: mysql
+                    MYSQL_PASSWORD: mysql
+                    MYSQL_DATABASE: testdb
+                options: >-
+                    --health-cmd="mysqladmin ping"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=5
+                    --tmpfs=/var/lib/mysql
+        runs-on: "ubuntu-20.04"
+        timeout-minutes: 20
+
+        strategy:
+            matrix:
+                php:
+                    - '7.3'
+                    - '7.4'
+                composer_options: [ "" ]
+                include:
+                    -   php: '8.0'
+                        composer_options: "--ignore-platform-req php"
+
+        steps:
+            -   uses: actions/checkout@v2
+
+            -   name: Setup PHP Action
+                uses: shivammathur/setup-php@v2
+                with:
+                    php-version: ${{ matrix.php }}
+                    coverage: none
+                    extensions: pdo_mysql, gd
+                    tools: cs2pr
+
+            -   uses: "ramsey/composer-install@v1"
+                with:
+                    dependency-versions: "highest"
+                    composer-options: "${{ matrix.composer_options }}"
+
+            -   name: Setup problem matchers for PHPUnit
+                run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+            -   name: Run integration test suite vs MySQL
+                run: composer run-script integration
+                env:
+                    DATABASE_URL: "mysql://mysql:mysql@127.0.0.1:${{ job.services.mysql.ports[3306] }}/testdb"
+                    DATABASE: "mysql://mysql:mysql@127.0.0.1:${{ job.services.mysql.ports[3306] }}/testdb"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,6 @@ jobs:
             fail-fast: false
             matrix:
                 experimental: [ false ]
-                code_style_check: [ true ]
                 php:
                     - '7.3'
                     - '7.4'
@@ -27,7 +26,7 @@ jobs:
                         composer_options: "--ignore-platform-req php"
                     -   php: '8.1'
                         composer_options: "--ignore-platform-req php"
-                        code_style_check: false
+                        skip_code_style: true
 
         steps:
             - uses: actions/checkout@v2
@@ -52,7 +51,7 @@ jobs:
             #   run: composer run-script phpstan
 
             - name: Run code style check
-              if: matrix.code_style_check
+              if: matrix.skip_code_style != true
               run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
             - name: Run unit test suite
@@ -63,7 +62,7 @@ jobs:
 
     integration-tests-postgres:
         name: PostgreSQL integration tests
-        # needs: tests
+        needs: tests
         services:
             postgres:
                 image: postgres:10
@@ -122,7 +121,7 @@ jobs:
 
     integration-tests-mysql:
         name: MySQL integration tests
-        # needs: tests
+        needs: tests
         services:
             mysql:
                 image: mysql:5.7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ jobs:
             fail-fast: false
             matrix:
                 experimental: [ false ]
+                code_style_check: [ true ]
                 php:
                     - '7.3'
                     - '7.4'
@@ -26,6 +27,7 @@ jobs:
                         composer_options: "--ignore-platform-req php"
                     -   php: '8.1'
                         composer_options: "--ignore-platform-req php"
+                        code_style_check: false
 
         steps:
             - uses: actions/checkout@v2
@@ -50,6 +52,7 @@ jobs:
             #   run: composer run-script phpstan
 
             - name: Run code style check
+              if: matrix.code_style_check
               run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
             - name: Run unit test suite

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
                 include:
                     -   php: '8.0'
                         composer_options: "--ignore-platform-req php"
+                    -   php: '8.1'
+                        composer_options: "--ignore-platform-req php"
 
         steps:
             - uses: actions/checkout@v2
@@ -88,6 +90,8 @@ jobs:
                 include:
                     -   php: '8.0'
                         composer_options: "--ignore-platform-req php"
+                    -   php: '8.1'
+                        composer_options: "--ignore-platform-req php"
 
         steps:
             -   uses: actions/checkout@v2
@@ -145,6 +149,8 @@ jobs:
                 composer_options: [ "" ]
                 include:
                     -   php: '8.0'
+                        composer_options: "--ignore-platform-req php"
+                    -   php: '8.1'
                         composer_options: "--ignore-platform-req php"
 
         steps:

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php-64bit": "For support of more than 30 languages, a 64bit php installation on all involved prod/dev machines is required"
     },
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "ext-ctype": "*",
         "ext-fileinfo": "*",
         "ext-intl": "*",

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/AliasGenerator.php
@@ -94,7 +94,7 @@ class AliasGenerator implements VariationHandler
             try {
                 $originalBinary = $this->dataLoader->find($originalPath);
             } catch (NotLoadableException $e) {
-                throw new SourceImageNotFoundException($originalPath, 0, $e);
+                throw new SourceImageNotFoundException((string)$originalPath, 0, $e);
             }
 
             $this->logger->debug("Generating '$variationName' variation on $originalPath, field #$fieldId ($fieldDefIdentifier)");

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
@@ -58,29 +58,29 @@ class LegacyStorageImageFileList implements ImageFileList
         return $this->item;
     }
 
-    public function next()
+    public function next(): void
     {
         $this->fetchRow();
     }
 
-    public function key()
+    public function key(): int
     {
         return $this->cursor;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return $this->cursor < $this->count();
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->cursor = -1;
         $this->rowReader->init();
         $this->fetchRow();
     }
 
-    public function count()
+    public function count(): int
     {
         return $this->rowReader->getCount();
     }

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
@@ -96,7 +96,7 @@ class LegacyStorageImageFileList implements ImageFileList
         ++$this->cursor;
         $imageId = $this->rowReader->getRow();
 
-        if (substr($imageId, 0, strlen($prefix)) === $prefix) {
+        if (strpos((string)$imageId, $prefix) === 0) {
             $imageId = ltrim(substr($imageId, strlen($prefix)), '/');
         }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
@@ -97,7 +97,7 @@ class LegacyStorageImageFileList implements ImageFileList
         ++$this->cursor;
         $imageId = $this->rowReader->getRow();
 
-        if (strpos((string)$imageId, $prefix) === 0) {
+        if (0 === strncmp((string)$imageId, $prefix, strlen($prefix))) {
             $imageId = ltrim(substr($imageId, strlen($prefix)), '/');
         }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Imagine/VariationPurger/LegacyStorageImageFileList.php
@@ -53,6 +53,7 @@ class LegacyStorageImageFileList implements ImageFileList
         $this->configResolver = $configResolver;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->item;

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderProvider/GenericProviderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Imagine/PlaceholderProvider/GenericProviderTest.php
@@ -21,7 +21,7 @@ class GenericProviderTest extends TestCase
     /**
      * @dataProvider getPlaceholderDataProvider
      */
-    public function testGetPlaceholder(ImageValue $value, array $options = [], $expectedText)
+    public function testGetPlaceholder(ImageValue $value, $expectedText, array $options = [])
     {
         $font = $this->createMock(AbstractFont::class);
 
@@ -78,6 +78,7 @@ class GenericProviderTest extends TestCase
                     'width' => 640,
                     'height' => 480,
                 ]),
+                "IMAGE PLACEHOLDER 640x480\n(photo.jpg)",
                 [
                     'background' => '#00FF00',
                     'foreground' => '#FF0000',
@@ -85,7 +86,6 @@ class GenericProviderTest extends TestCase
                     'text' => "IMAGE PLACEHOLDER %width%x%height%\n(%id%)",
                     'fontpath' => '/path/to/font.ttf',
                 ],
-                "IMAGE PLACEHOLDER 640x480\n(photo.jpg)",
             ],
         ];
     }

--- a/eZ/Bundle/PlatformInstallerBundle/src/Installer/CoreInstaller.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Installer/CoreInstaller.php
@@ -67,16 +67,9 @@ class CoreInstaller extends DbBasedInstaller implements Installer
         $progressBar = new ProgressBar($this->output);
         $progressBar->start($queriesCount);
 
-        try {
-            $this->db->beginTransaction();
-            foreach ($queries as $query) {
-                $this->db->exec($query);
-                $progressBar->advance(1);
-            }
-            $this->db->commit();
-        } catch (DBALException $e) {
-            $this->db->rollBack();
-            throw $e;
+        foreach ($queries as $query) {
+            $this->db->exec($query);
+            $progressBar->advance(1);
         }
 
         $progressBar->finish();

--- a/eZ/Bundle/PlatformInstallerBundle/src/Installer/CoreInstaller.php
+++ b/eZ/Bundle/PlatformInstallerBundle/src/Installer/CoreInstaller.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace EzSystems\PlatformInstallerBundle\Installer;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Schema;
 use EzSystems\DoctrineSchema\API\Builder\SchemaBuilder;

--- a/eZ/Publish/API/Repository/Iterator/BatchIterator.php
+++ b/eZ/Publish/API/Repository/Iterator/BatchIterator.php
@@ -35,6 +35,7 @@ final class BatchIterator implements Iterator
         $this->position = 0;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         if (!$this->isInitialized()) {

--- a/eZ/Publish/API/Repository/Tests/LegacySchemaImporter.php
+++ b/eZ/Publish/API/Repository/Tests/LegacySchemaImporter.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Tests;
 
 use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Schema\Schema as DoctrineSchema;
 use EzSystems\DoctrineSchema\API\Exception\InvalidConfigurationException;
@@ -37,8 +36,6 @@ final class LegacySchemaImporter
      * Import database schema from Doctrine Schema Yaml configuration file.
      *
      * @param string $schemaFilePath Yaml schema configuration file path
-     *
-     * @throws \Doctrine\DBAL\ConnectionException
      */
     public function importSchema(string $schemaFilePath): void
     {
@@ -46,7 +43,6 @@ final class LegacySchemaImporter
             throw new RuntimeException("The schema file path {$schemaFilePath} does not exist");
         }
 
-        $this->connection->beginTransaction();
         $importer = new SchemaImporter();
         try {
             $databasePlatform = $this->connection->getDatabasePlatform();
@@ -64,10 +60,7 @@ final class LegacySchemaImporter
             foreach ($statements as $statement) {
                 $this->connection->exec($statement);
             }
-
-            $this->connection->commit();
-        } catch (InvalidConfigurationException | DBALException $e) {
-            $this->connection->rollBack();
+        } catch (InvalidConfigurationException $e) {
             throw new RuntimeException($e->getMessage(), 1, $e);
         }
     }

--- a/eZ/Publish/API/Repository/Tests/SearchService/RemoteIdIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/RemoteIdIndexingTest.php
@@ -86,7 +86,7 @@ final class RemoteIdIndexingTest extends BaseTest
             'external_10' => 'external_10',
             'with space' => 'with space',
             'with national characters' => 'zażółć gęślą jaźń',
-            'with emoji' => json_decode('"\ud83d\ude00"'),
+            'with emoji' => (string)json_decode('"\ud83d\ude00"'),
         ];
     }
 

--- a/eZ/Publish/API/Repository/Tests/SearchService/RemoteIdIndexingTest.php
+++ b/eZ/Publish/API/Repository/Tests/SearchService/RemoteIdIndexingTest.php
@@ -86,7 +86,7 @@ final class RemoteIdIndexingTest extends BaseTest
             'external_10' => 'external_10',
             'with space' => 'with space',
             'with national characters' => 'zażółć gęślą jaźń',
-            'with emoji' => (string)json_decode('"\ud83d\ude00"'),
+            'with emoji' => json_decode('"\ud83d\ude00"'),
         ];
     }
 

--- a/eZ/Publish/API/Repository/Values/UserPreference/UserPreferenceList.php
+++ b/eZ/Publish/API/Repository/Values/UserPreference/UserPreferenceList.php
@@ -34,7 +34,7 @@ class UserPreferenceList extends ValueObject implements IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new ArrayIterator($this->items);
     }

--- a/eZ/Publish/Core/Base/Container/Compiler/Storage/ExternalStorageRegistryPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Storage/ExternalStorageRegistryPass.php
@@ -102,7 +102,7 @@ class ExternalStorageRegistryPass implements CompilerPassInterface
                 // Will throw a LogicException if no gateway is defined for this field type.
                 $storageHandlerDef = $container->findDefinition($id);
                 $storageHandlerClass = $storageHandlerDef->getClass();
-                if (preg_match('/^%([^%\s]+)%$/', $storageHandlerClass, $match)) {
+                if (preg_match('/^%([^%\s]+)%$/', (string)$storageHandlerClass, $match)) {
                     $storageHandlerClass = $container->getParameter($match[1]);
                 }
 

--- a/eZ/Publish/Core/FieldType/Author/AuthorCollection.php
+++ b/eZ/Publish/Core/FieldType/Author/AuthorCollection.php
@@ -36,7 +36,7 @@ class AuthorCollection extends ArrayObject
      * @param int $offset
      * @param \eZ\Publish\Core\FieldType\Author\Author $value
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (!$value instanceof Author) {
             throw new InvalidArgumentType(

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/DoctrineStorage.php
@@ -203,9 +203,7 @@ abstract class DoctrineStorage extends Gateway
      */
     public function removeMimeFromPath($path)
     {
-        $res = substr($path, strpos($path, '/') + 1);
-
-        return $res;
+        return substr($path, strpos((string)$path, '/') + 1);
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/DoctrineStorage.php
+++ b/eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage/Gateway/DoctrineStorage.php
@@ -203,7 +203,9 @@ abstract class DoctrineStorage extends Gateway
      */
     public function removeMimeFromPath($path)
     {
-        return substr($path, strpos((string)$path, '/') + 1);
+        $path = (string)$path;
+
+        return substr($path, strpos($path, '/') + 1);
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/FieldSettings.php
+++ b/eZ/Publish/Core/FieldType/FieldSettings.php
@@ -27,7 +27,7 @@ class FieldSettings extends ArrayObject
      * @param string|int $index
      * @param mixed $value
      */
-    public function offsetSet($index, $value)
+    public function offsetSet($index, $value): void
     {
         if (!parent::offsetExists($index)) {
             throw new PropertyReadOnlyException($index, __CLASS__);

--- a/eZ/Publish/Core/FieldType/FieldSettings.php
+++ b/eZ/Publish/Core/FieldType/FieldSettings.php
@@ -45,6 +45,7 @@ class FieldSettings extends ArrayObject
      *
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($index)
     {
         if (!parent::offsetExists($index)) {

--- a/eZ/Publish/Core/FieldType/Media/Type.php
+++ b/eZ/Publish/Core/FieldType/Media/Type.php
@@ -246,11 +246,11 @@ class Type extends BaseType
 
         $result = parent::fromPersistenceValue($fieldValue);
 
-        $result->hasController = ($fieldValue->externalData['hasController'] ?? false);
-        $result->autoplay = ($fieldValue->externalData['autoplay'] ?? false);
-        $result->loop = ($fieldValue->externalData['loop'] ?? false);
-        $result->height = ($fieldValue->externalData['height'] ?? 0);
-        $result->width = ($fieldValue->externalData['width'] ?? 0);
+        $result->hasController = $fieldValue->externalData['hasController'] ?? false;
+        $result->autoplay = $fieldValue->externalData['autoplay'] ?? false;
+        $result->loop = $fieldValue->externalData['loop'] ?? false;
+        $result->height = $fieldValue->externalData['height'] ?? 0;
+        $result->width = $fieldValue->externalData['width'] ?? 0;
 
         return $result;
     }

--- a/eZ/Publish/Core/FieldType/Media/Type.php
+++ b/eZ/Publish/Core/FieldType/Media/Type.php
@@ -246,21 +246,11 @@ class Type extends BaseType
 
         $result = parent::fromPersistenceValue($fieldValue);
 
-        $result->hasController = (isset($fieldValue->externalData['hasController'])
-            ? $fieldValue->externalData['hasController']
-            : false);
-        $result->autoplay = (isset($fieldValue->externalData['autoplay'])
-            ? $fieldValue->externalData['autoplay']
-            : false);
-        $result->loop = (isset($fieldValue->externalData['loop'])
-            ? $fieldValue->externalData['loop']
-            : false);
-        $result->height = (isset($fieldValue->externalData['height'])
-            ? $fieldValue->externalData['height']
-            : 0);
-        $result->width = (isset($fieldValue->externalData['width'])
-            ? $fieldValue->externalData['width']
-            : 0);
+        $result->hasController = ($fieldValue->externalData['hasController'] ?? false);
+        $result->autoplay = ($fieldValue->externalData['autoplay'] ?? false);
+        $result->loop = ($fieldValue->externalData['loop'] ?? false);
+        $result->height = ($fieldValue->externalData['height'] ?? 0);
+        $result->width = ($fieldValue->externalData['width'] ?? 0);
 
         return $result;
     }

--- a/eZ/Publish/Core/FieldType/Tests/AuthorTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/AuthorTest.php
@@ -561,8 +561,8 @@ class AuthorTest extends FieldTypeTest
         );
 
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [$authorList, [], 'en_GB', 'Boba Fett'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [$authorList, 'Boba Fett', [], 'en_GB'],
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/BinaryFileTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/BinaryFileTest.php
@@ -588,7 +588,7 @@ class BinaryFileTest extends BinaryBaseTest
                     [
                         'id' => 'phppng.php',
                         'fileName' => 'phppng.php',
-                        'fileSize' => 'phppng.php',
+                        'fileSize' => 0.01,
                         'downloadCount' => 0,
                         'mimeType' => 'image/jpeg',
                     ]
@@ -616,7 +616,7 @@ class BinaryFileTest extends BinaryBaseTest
                     [
                         'id' => 'phppng.PHP',
                         'fileName' => 'phppng.PHP',
-                        'fileSize' => 'phppng.PHP',
+                        'fileSize' => 0.01,
                         'downloadCount' => 0,
                         'mimeType' => 'image/jpeg',
                     ]

--- a/eZ/Publish/Core/FieldType/Tests/BinaryFileTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/BinaryFileTest.php
@@ -513,8 +513,8 @@ class BinaryFileTest extends BinaryBaseTest
     public function provideDataForGetName(): array
     {
         return [
-            [new BinaryFileValue(), [], 'en_GB', ''],
-            [new BinaryFileValue(['fileName' => 'sindelfingen.jpg']), [], 'en_GB', 'sindelfingen.jpg'],
+            [new BinaryFileValue(), '', [], 'en_GB'],
+            [new BinaryFileValue(['fileName' => 'sindelfingen.jpg']), 'sindelfingen.jpg', [], 'en_GB'],
         ];
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/CheckboxTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/CheckboxTest.php
@@ -293,8 +293,8 @@ class CheckboxTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [new CheckboxValue(true), [], 'en_GB', '1'],
-            [new CheckboxValue(false), [], 'en_GB', '0'],
+            [new CheckboxValue(true), '1', [], 'en_GB'],
+            [new CheckboxValue(false), '0', [], 'en_GB'],
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/CountryTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/CountryTest.php
@@ -403,13 +403,13 @@ class CountryTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [new CountryValue(), [], 'en_GB', ''],
-            [new CountryValue(['FR' => ['Name' => 'France']]), [], 'en_GB', 'France'],
+            [new CountryValue(), '', [], 'en_GB'],
+            [new CountryValue(['FR' => ['Name' => 'France']]), 'France', [], 'en_GB'],
             [
                 new CountryValue(['FR' => ['Name' => 'France'], 'DE' => ['Name' => 'Deutschland']]),
+                'France, Deutschland',
                 [],
                 'en_GB',
-                'France, Deutschland',
             ],
         ];
     }

--- a/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateAndTimeTest.php
@@ -456,8 +456,8 @@ class DateAndTimeTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [DateAndTimeValue::fromTimestamp(438512400), [], 'en_GB', 'Thu 1983-24-11 09:00:00'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [DateAndTimeValue::fromTimestamp(438512400), 'Thu 1983-24-11 09:00:00', [], 'en_GB'],
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/DateTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateTest.php
@@ -365,8 +365,8 @@ class DateTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [new DateValue(new DateTime('11/24/1983')), [], 'en_GB', 'Thursday 24 November 1983'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [new DateValue(new DateTime('11/24/1983')), 'Thursday 24 November 1983', [], 'en_GB'],
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/EmailAddressTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/EmailAddressTest.php
@@ -396,8 +396,8 @@ class EmailAddressTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [new EmailAddressValue('john.doe@example.com'), [], 'en_GB', 'john.doe@example.com'],
-            [new EmailAddressValue('JANE.DOE@EXAMPLE.COM'), [], 'en_GB', 'jane.doe@example.com'],
+            [new EmailAddressValue('john.doe@example.com'), 'john.doe@example.com', [], 'en_GB'],
+            [new EmailAddressValue('JANE.DOE@EXAMPLE.COM'), 'jane.doe@example.com', [], 'en_GB'],
         ];
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/FloatTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/FloatTest.php
@@ -430,8 +430,8 @@ class FloatTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [new FloatValue(23.42), [], 'en_GB', '23.42'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [new FloatValue(23.42), '23.42', [], 'en_GB'],
         ];
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/ISBNTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ISBNTest.php
@@ -261,8 +261,8 @@ class ISBNTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [new ISBNValue('9789722514095'), [], 'en_GB', '9789722514095'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [new ISBNValue('9789722514095'), '9789722514095', [], 'en_GB'],
         ];
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageAssetTest.php
@@ -342,15 +342,15 @@ class ImageAssetTest extends FieldTypeTest
         return [
             'empty_destination_content_id' => [
                 $this->getEmptyValueExpectation(),
+                '',
                 [],
                 'en_GB',
-                '',
             ],
             'destination_content_id' => [
-                new ImageAsset\Value(self::DESTINATION_CONTENT_ID), [], 'en_GB', 'name_en_GB',
+                new ImageAsset\Value(self::DESTINATION_CONTENT_ID), 'name_en_GB', [], 'en_GB',
             ],
             'destination_content_id_de_DE' => [
-                new ImageAsset\Value(self::DESTINATION_CONTENT_ID), [], 'de_DE', 'Name_de_DE',
+                new ImageAsset\Value(self::DESTINATION_CONTENT_ID), 'Name_de_DE', [], 'de_DE',
             ],
         ];
     }
@@ -358,8 +358,12 @@ class ImageAssetTest extends FieldTypeTest
     /**
      * @dataProvider provideDataForGetName
      */
-    public function testGetName(SPIValue $value, array $fieldSettings = [], string $languageCode = 'en_GB', string $expected)
-    {
+    public function testGetName(
+        SPIValue $value,
+        string $expected,
+        array $fieldSettings = [],
+        string $languageCode = 'en_GB'
+    ): void {
         /** @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|\PHPUnit\Framework\MockObject\MockObject $fieldDefinitionMock */
         $fieldDefinitionMock = $this->createMock(FieldDefinition::class);
         $fieldDefinitionMock->method('getFieldSettings')->willReturn($fieldSettings);

--- a/eZ/Publish/Core/FieldType/Tests/ImageTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/ImageTest.php
@@ -495,12 +495,12 @@ class ImageTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
             [
                 new ImageValue(['fileName' => 'Sindelfingen-Squirrels.jpg']),
+                'Sindelfingen-Squirrels.jpg',
                 [],
                 'en_GB',
-                'Sindelfingen-Squirrels.jpg',
             ],
             // Alternative text has priority
             [
@@ -510,9 +510,9 @@ class ImageTest extends FieldTypeTest
                         'alternativeText' => 'This is so Sindelfingen!',
                     ]
                 ),
+                'This is so Sindelfingen!',
                 [],
                 'en_GB',
-                'This is so Sindelfingen!',
             ],
             [
                 new ImageValue(
@@ -521,9 +521,9 @@ class ImageTest extends FieldTypeTest
                         'alternativeText' => 'This is so Sindelfingen!',
                     ]
                 ),
+                'This is so Sindelfingen!',
                 [],
                 'en_GB',
-                'This is so Sindelfingen!',
             ],
         ];
     }

--- a/eZ/Publish/Core/FieldType/Tests/IntegerTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/IntegerTest.php
@@ -420,8 +420,8 @@ class IntegerTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [new IntegerValue(42), [], 'en_GB', '42'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [new IntegerValue(42), '42', [], 'en_GB'],
         ];
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/KeywordTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/KeywordTest.php
@@ -257,8 +257,8 @@ class KeywordTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [new KeywordValue(['foo', 'bar']), [], 'en_GB', 'foo, bar'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [new KeywordValue(['foo', 'bar']), 'foo, bar', [], 'en_GB'],
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/MapLocationTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/MapLocationTest.php
@@ -337,8 +337,8 @@ class MapLocationTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [new MapLocation\Value(['address' => 'Bag End, The Shire']), [], 'en_GB', 'Bag End, The Shire'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [new MapLocation\Value(['address' => 'Bag End, The Shire']), 'Bag End, The Shire', [], 'en_GB'],
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/MediaTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/MediaTest.php
@@ -755,7 +755,7 @@ class MediaTest extends BinaryBaseTest
                     [
                         'id' => 'phppng.php',
                         'fileName' => 'phppng.php',
-                        'fileSize' => 'phppng.php',
+                        'fileSize' => 0.01,
                         'mimeType' => 'video/mp4',
                     ]
                 ),

--- a/eZ/Publish/Core/FieldType/Tests/MediaTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/MediaTest.php
@@ -673,15 +673,15 @@ class MediaTest extends BinaryBaseTest
         return [
             [
                 new MediaValue(),
+                '',
                 [],
                 'en_GB',
-                '',
             ],
             [
                 new MediaValue(['fileName' => 'sindelfingen.jpg']),
+                'sindelfingen.jpg',
                 [],
                 'en_GB',
-                'sindelfingen.jpg',
             ],
         ];
     }

--- a/eZ/Publish/Core/FieldType/Tests/RelationListTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RelationListTest.php
@@ -799,8 +799,12 @@ class RelationListTest extends FieldTypeTest
     /**
      * @dataProvider provideDataForGetName
      */
-    public function testGetName(SPIValue $value, array $fieldSettings = [], string $languageCode = 'en_GB', $expected)
-    {
+    public function testGetName(
+        SPIValue $value,
+        string $expected,
+        array $fieldSettings = [],
+        string $languageCode = 'en_GB'
+    ): void {
         $fieldDefinitionMock = $this->getFieldDefinitionMock($fieldSettings);
 
         $name = $this->getFieldTypeUnderTest()->getName($value, $fieldDefinitionMock, $languageCode);
@@ -811,9 +815,9 @@ class RelationListTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [new Value([self::DESTINATION_CONTENT_ID_14, self::DESTINATION_CONTENT_ID_22]), [], 'en_GB', 'name_14_en_GB name_22_en_GB'],
-            [new Value([self::DESTINATION_CONTENT_ID_14, self::DESTINATION_CONTENT_ID_22]), [], 'de_DE', 'Name_14_de_DE Name_22_de_DE'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [new Value([self::DESTINATION_CONTENT_ID_14, self::DESTINATION_CONTENT_ID_22]), 'name_14_en_GB name_22_en_GB', [], 'en_GB'],
+            [new Value([self::DESTINATION_CONTENT_ID_14, self::DESTINATION_CONTENT_ID_22]), 'Name_14_de_DE Name_22_de_DE', [], 'de_DE'],
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/RelationTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/RelationTest.php
@@ -407,8 +407,12 @@ class RelationTest extends FieldTypeTest
     /**
      * @dataProvider provideDataForGetName
      */
-    public function testGetName(SPIValue $value, array $fieldSettings = [], string $languageCode = 'en_GB', string $expected)
-    {
+    public function testGetName(
+        SPIValue $value,
+        string $expected,
+        array $fieldSettings = [],
+        string $languageCode = 'en_GB'
+    ): void {
         /** @var \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition|\PHPUnit\Framework\MockObject\MockObject $fieldDefinitionMock */
         $fieldDefinitionMock = $this->createMock(FieldDefinition::class);
         $fieldDefinitionMock->method('getFieldSettings')->willReturn($fieldSettings);
@@ -422,13 +426,13 @@ class RelationTest extends FieldTypeTest
     {
         return [
             'empty_destination_content_id' => [
-                $this->getEmptyValueExpectation(), [], 'en_GB', '',
+                $this->getEmptyValueExpectation(), '', [], 'en_GB',
             ],
             'destination_content_id' => [
-                new Value(self::DESTINATION_CONTENT_ID), [], 'en_GB', 'name_en_GB',
+                new Value(self::DESTINATION_CONTENT_ID), 'name_en_GB', [], 'en_GB',
             ],
             'destination_content_id_de_DE' => [
-                new Value(self::DESTINATION_CONTENT_ID), [], 'de_DE', 'Name_de_DE',
+                new Value(self::DESTINATION_CONTENT_ID), 'Name_de_DE', [], 'de_DE',
             ],
         ];
     }

--- a/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/SelectionTest.php
@@ -358,8 +358,12 @@ class SelectionTest extends FieldTypeTest
     /**
      * @dataProvider provideDataForGetName
      */
-    public function testGetName(SPIValue $value, array $fieldSettings = [], string $languageCode = 'en_GB', string $expected)
-    {
+    public function testGetName(
+        SPIValue $value,
+        string $expected,
+        array $fieldSettings = [],
+        string $languageCode = 'en_GB'
+    ): void {
         $fieldDefinitionMock = $this->getFieldDefinitionMock($fieldSettings);
         $fieldDefinitionMock
             ->method('__get')
@@ -374,33 +378,33 @@ class SelectionTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            'empty_value_and_field_settings' => [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
+            'empty_value_and_field_settings' => [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
             'one_option' => [
                 new SelectionValue(['optionIndex1']),
+                'option_1',
                 ['options' => ['optionIndex1' => 'option_1']],
                 'en_GB',
-                'option_1',
             ],
             'two_options' => [
                 new SelectionValue(['optionIndex1', 'optionIndex2']),
+                'option_1 option_2',
                 ['options' => ['optionIndex1' => 'option_1', 'optionIndex2' => 'option_2']],
                 'en_GB',
-                'option_1 option_2',
             ],
             'multilingual_options' => [
                 new SelectionValue(['optionIndex1', 'optionIndex2']),
+                'option_1 option_2',
                 ['multilingualOptions' => ['en_GB' => ['optionIndex1' => 'option_1', 'optionIndex2' => 'option_2']]],
                 'en_GB',
-                'option_1 option_2',
             ],
             'multilingual_options_with_main_language_code' => [
                 new SelectionValue(['optionIndex3', 'optionIndex4']),
+                'option_3 option_4',
                 ['multilingualOptions' => [
                     'en_GB' => ['optionIndex1' => 'option_1', 'optionIndex2' => 'option_2'],
                     'de_DE' => ['optionIndex3' => 'option_3', 'optionIndex4' => 'option_4'],
                 ]],
                 'de_DE',
-                'option_3 option_4',
             ],
         ];
     }

--- a/eZ/Publish/Core/FieldType/Tests/TextBlockTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextBlockTest.php
@@ -348,8 +348,8 @@ class TextBlockTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [new TextBlockValue('This is a piece of text'), [], 'en_GB', 'This is a piece of text'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [new TextBlockValue('This is a piece of text'), 'This is a piece of text', [], 'en_GB'],
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TextLineTest.php
@@ -469,8 +469,8 @@ class TextLineTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [new TextLineValue('This is a line of text'), [], 'en_GB', 'This is a line of text'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [new TextLineValue('This is a line of text'), 'This is a line of text', [], 'en_GB'],
         ];
     }
 

--- a/eZ/Publish/Core/FieldType/Tests/TimeTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/TimeTest.php
@@ -376,8 +376,8 @@ class TimeTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [new TimeValue(200), [], 'en_GB', '12:03:20 am'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [new TimeValue(200), '12:03:20 am', [], 'en_GB'],
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/UrlTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/UrlTest.php
@@ -273,8 +273,8 @@ class UrlTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [new UrlValue('', 'Url text'), [], 'en_GB', 'Url text'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [new UrlValue('', 'Url text'), 'Url text', [], 'en_GB'],
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/Tests/UserTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/UserTest.php
@@ -890,8 +890,8 @@ class UserTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [$this->getEmptyValueExpectation(), [], 'en_GB', ''],
-            [new UserValue(['login' => 'johndoe']), [], 'en_GB', 'johndoe'],
+            [$this->getEmptyValueExpectation(), '', [], 'en_GB'],
+            [new UserValue(['login' => 'johndoe']), 'johndoe', [], 'en_GB'],
         ];
     }
 }

--- a/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
+++ b/eZ/Publish/Core/FieldType/TextBlock/SearchField.php
@@ -49,7 +49,7 @@ class SearchField implements Indexable
      */
     private function extractShortText($string)
     {
-        return mb_substr(strtok(trim($string), "\r\n"), 0, 255);
+        return mb_substr(strtok(trim((string)$string), "\r\n"), 0, 255);
     }
 
     /**

--- a/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
@@ -58,7 +58,7 @@ class LegacyDFSCluster implements IOMetadataHandler
             throw new InvalidArgumentException('$binaryFileCreateStruct', 'Property \'mtime\' must be a DateTime');
         }
 
-        $path = $this->addPrefix($binaryFileCreateStruct->id);
+        $path = (string)$this->addPrefix($binaryFileCreateStruct->id);
 
         try {
             /*
@@ -99,7 +99,7 @@ SQL
      */
     public function delete($spiBinaryFileId)
     {
-        $path = $this->addPrefix($spiBinaryFileId);
+        $path = (string)$this->addPrefix($spiBinaryFileId);
 
         // Unlike the legacy cluster, the file is directly deleted. It was inherited from the DB cluster anyway
         $stmt = $this->db->prepare('DELETE FROM ezdfsfile WHERE name_hash LIKE :name_hash');
@@ -124,7 +124,7 @@ SQL
      */
     public function load($spiBinaryFileId)
     {
-        $path = $this->addPrefix($spiBinaryFileId);
+        $path = (string)$this->addPrefix($spiBinaryFileId);
 
         $stmt = $this->db->prepare('SELECT * FROM ezdfsfile WHERE name_hash LIKE ? AND expired != 1 AND mtime > 0');
         $stmt->bindValue(1, md5($path));
@@ -151,7 +151,7 @@ SQL
      */
     public function exists($spiBinaryFileId)
     {
-        $path = $this->addPrefix($spiBinaryFileId);
+        $path = (string)$this->addPrefix($spiBinaryFileId);
 
         $stmt = $this->db->prepare('SELECT name FROM ezdfsfile WHERE name_hash LIKE ? and mtime > 0 and expired != 1');
         $stmt->bindValue(1, md5($path));

--- a/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/User/ParameterProviderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/FieldType/Tests/User/ParameterProviderTest.php
@@ -44,6 +44,9 @@ class ParameterProviderTest extends TestCase
         $this->parameterProvider = new ParameterProvider($this->userService);
     }
 
+    /**
+     * @requires PHP < 8.1
+     */
     public function testGetViewParameters(): void
     {
         $passwordExpiresIn = 14;

--- a/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/UrlAlias.php
+++ b/eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/UrlAlias.php
@@ -30,7 +30,7 @@ class UrlAlias extends MultipleValued
 
         foreach ($this->values as $pattern => $val) {
             foreach ($locationUrls as $urlAlias) {
-                if (strpos($urlAlias->path, "/$pattern") === 0) {
+                if (strpos((string)$urlAlias->path, "/$pattern") === 0) {
                     return true;
                 }
             }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
@@ -65,7 +65,7 @@ class SiteAccess extends ValueObject implements JsonSerializable
         return "$this->name (matched by '$this->matchingType')";
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         $matcher = is_object($this->matcher) ? get_class($this->matcher) : null;
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Map/URI.php
@@ -21,7 +21,7 @@ class URI extends Map implements URILexer
     {
         if (!$this->key) {
             sscanf($request->pathinfo, '/%[^/]', $key);
-            $this->setMapKey(rawurldecode($key));
+            $this->setMapKey(rawurldecode((string)$key));
         }
 
         parent::setRequest($request);

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex.php
@@ -73,7 +73,7 @@ abstract class Regex implements Matcher
 
         preg_match(
             "@{$this->regex}@",
-            $this->element,
+            (string)$this->element,
             $match
         );
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Regex.php
@@ -77,7 +77,7 @@ abstract class Regex implements Matcher
             $match
         );
 
-        $this->matchedSiteAccess = isset($match[$this->itemNumber]) ? $match[$this->itemNumber] : false;
+        $this->matchedSiteAccess = $match[$this->itemNumber] ?? false;
 
         return $this->matchedSiteAccess;
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Bookmark/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Bookmark/Gateway/DoctrineDatabaseTest.php
@@ -114,7 +114,7 @@ class DoctrineDatabaseTest extends TestCase
             });
 
             usort($rows, static function ($a, $b) {
-                return $a['id'] < $b['id'];
+                return $b['id'] <=> $a['id'];
             });
 
             return $rows;

--- a/eZ/Publish/Core/Persistence/Tests/Legacy/FieldValue/Converter/ImageConverterTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/Legacy/FieldValue/Converter/ImageConverterTest.php
@@ -48,7 +48,7 @@ final class ImageConverterTest extends TestCase
         ClockMock::withClockMock(true);
 
         $time = ClockMock::time();
-        $expectedXml = str_replace('{timestampToReplace}', (string) $time, $expectedXml);
+        $expectedXml = str_replace('{timestampToReplace}', (string)$time, $expectedXml);
 
         $storageValue = new StorageFieldValue();
 

--- a/eZ/Publish/Core/Persistence/Tests/Legacy/FieldValue/Converter/ImageConverterTest.php
+++ b/eZ/Publish/Core/Persistence/Tests/Legacy/FieldValue/Converter/ImageConverterTest.php
@@ -48,7 +48,7 @@ final class ImageConverterTest extends TestCase
         ClockMock::withClockMock(true);
 
         $time = ClockMock::time();
-        $expectedXml = str_replace('{timestampToReplace}', $time, $expectedXml);
+        $expectedXml = str_replace('{timestampToReplace}', (string) $time, $expectedXml);
 
         $storageValue = new StorageFieldValue();
 
@@ -141,7 +141,7 @@ XML,
         ClockMock::withClockMock(true);
 
         $time = ClockMock::time();
-        $xml = str_replace('{timestampToReplace}', $time, $xml);
+        $xml = str_replace('{timestampToReplace}', (string) $time, $xml);
         $storageValue = new StorageFieldValue([
             'dataText' => $xml,
         ]);

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -785,30 +785,18 @@ class ContentTypeService implements ContentTypeServiceInterface
                 'identifier' => $contentTypeCreateStruct->identifier,
                 'name' => $contentTypeCreateStruct->names,
                 'status' => APIContentType::STATUS_DRAFT,
-                'description' => $contentTypeCreateStruct->descriptions === null ?
-                    [] :
-                    $contentTypeCreateStruct->descriptions,
+                'description' => $contentTypeCreateStruct->descriptions ?? [],
                 'created' => $timestamp,
                 'modified' => $timestamp,
                 'creatorId' => $contentTypeCreateStruct->creatorId,
                 'modifierId' => $contentTypeCreateStruct->creatorId,
                 'remoteId' => $contentTypeCreateStruct->remoteId,
-                'urlAliasSchema' => $contentTypeCreateStruct->urlAliasSchema === null ?
-                    '' :
-                    $contentTypeCreateStruct->urlAliasSchema,
-                'nameSchema' => $contentTypeCreateStruct->nameSchema === null ?
-                    '' :
-                    $contentTypeCreateStruct->nameSchema,
-                'isContainer' => $contentTypeCreateStruct->isContainer === null ?
-                    false :
-                    $contentTypeCreateStruct->isContainer,
+                'urlAliasSchema' => $contentTypeCreateStruct->urlAliasSchema ?? '',
+                'nameSchema' => $contentTypeCreateStruct->nameSchema ?? '',
+                'isContainer' => $contentTypeCreateStruct->isContainer ?? false,
                 'initialLanguageId' => $initialLanguageId,
-                'sortField' => $contentTypeCreateStruct->defaultSortField === null ?
-                    Location::SORT_FIELD_PUBLISHED :
-                    $contentTypeCreateStruct->defaultSortField,
-                'sortOrder' => $contentTypeCreateStruct->defaultSortOrder === null ?
-                    Location::SORT_ORDER_DESC :
-                    $contentTypeCreateStruct->defaultSortOrder,
+                'sortField' => $contentTypeCreateStruct->defaultSortField ?? Location::SORT_FIELD_PUBLISHED,
+                'sortOrder' => $contentTypeCreateStruct->defaultSortOrder ?? Location::SORT_ORDER_DESC,
                 'groupIds' => $groupIds,
                 'fieldDefinitions' => $spiFieldDefinitions,
                 'defaultAlwaysAvailable' => $contentTypeCreateStruct->defaultAlwaysAvailable,
@@ -859,10 +847,7 @@ class ContentTypeService implements ContentTypeServiceInterface
      */
     public function loadContentType(int $contentTypeId, array $prioritizedLanguages = []): ContentType
     {
-        $spiContentType = $this->contentTypeHandler->load(
-            $contentTypeId,
-            SPIContentType::STATUS_DEFINED
-        );
+        $spiContentType = $this->contentTypeHandler->load($contentTypeId);
 
         return $this->contentTypeDomainMapper->buildContentTypeDomainObject(
             $spiContentType,

--- a/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
@@ -842,7 +842,7 @@ class ContentDomainMapper extends ProxyAwareDomainMapper
     public function getDateTime($timestamp)
     {
         $dateTime = new DateTime();
-        $dateTime->setTimestamp($timestamp);
+        $dateTime->setTimestamp((int)$timestamp);
 
         return $dateTime;
     }

--- a/eZ/Publish/SPI/FieldType/Generic/Tests/GenericTest.php
+++ b/eZ/Publish/SPI/FieldType/Generic/Tests/GenericTest.php
@@ -149,7 +149,7 @@ class GenericTest extends FieldTypeTest
     public function provideDataForGetName(): array
     {
         return [
-            [new GenericFieldValueStub('This is a generic value.'), [], 'en_GB', 'This is a generic value.'],
+            [new GenericFieldValueStub('This is a generic value.'), 'This is a generic value.', [], 'en_GB'],
         ];
     }
 

--- a/eZ/Publish/SPI/FieldType/Tests/FieldTypeTest.php
+++ b/eZ/Publish/SPI/FieldType/Tests/FieldTypeTest.php
@@ -919,22 +919,18 @@ abstract class FieldTypeTest extends TestCase
         foreach ($fieldDefinitionData as $method => $data) {
             if ($method === 'validatorConfiguration') {
                 $fieldDefinitionMock
-                    ->expects($this->any())
                     ->method('getValidatorConfiguration')
-                    ->will($this->returnValue($data));
+                    ->willReturn($data);
             }
 
             if ($method === 'fieldSettings') {
                 $fieldDefinitionMock
-                    ->expects($this->any())
                     ->method('getFieldSettings')
-                    ->will($this->returnValue($data));
+                    ->willReturn($data);
             }
         }
 
-        $validationErrors = $fieldType->validate($fieldDefinitionMock, $value);
-
-        return $validationErrors;
+        return $fieldType->validate($fieldDefinitionMock, $value);
     }
 
     /**

--- a/eZ/Publish/SPI/FieldType/Tests/FieldTypeTest.php
+++ b/eZ/Publish/SPI/FieldType/Tests/FieldTypeTest.php
@@ -522,8 +522,12 @@ abstract class FieldTypeTest extends TestCase
     /**
      * @dataProvider provideDataForGetName
      */
-    public function testGetName(SPIValue $value, array $fieldSettings = [], string $languageCode = 'en_GB', string $expected)
-    {
+    public function testGetName(
+        SPIValue $value,
+        string $expected,
+        array $fieldSettings = [],
+        string $languageCode = 'en_GB'
+    ): void {
         $fieldDefinitionMock = $this->getFieldDefinitionMock($fieldSettings);
 
         self::assertSame(

--- a/eZ/Publish/SPI/Persistence/Content/Location/Trash/TrashResult.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Trash/TrashResult.php
@@ -28,7 +28,7 @@ class TrashResult extends ValueObject implements \IteratorAggregate
     /**
      * {@inheritdoc}
      */
-    public function getIterator()
+    public function getIterator(): \Traversable
     {
         return new ArrayIterator($this->items);
     }

--- a/tests/integration/Installer/Installer/CoreInstallerTest.php
+++ b/tests/integration/Installer/Installer/CoreInstallerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Tests\Integration\Installer\Installer;
+
+use EzSystems\PlatformInstallerBundle\Installer\CoreInstaller;
+use Ibexa\Tests\Integration\Installer\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
+
+final class CoreInstallerTest extends TestCase
+{
+    /** @var \EzSystems\PlatformInstallerBundle\Installer\CoreInstaller */
+    private $installer;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+        $this->installer = self::getServiceByClassName(CoreInstaller::class);
+    }
+
+    public function testImportSchema(): void
+    {
+        $this->installer->setOutput(new NullOutput());
+        $this->installer->importSchema();
+    }
+}

--- a/tests/integration/Installer/TestCase.php
+++ b/tests/integration/Installer/TestCase.php
@@ -12,6 +12,9 @@ use Ibexa\Contracts\Core\Test\IbexaKernelTestCase;
 
 abstract class TestCase extends IbexaKernelTestCase
 {
+    /** Necessary to allow multiple Kernel classes */
+    protected static $class;
+
     protected static function getKernelClass(): string
     {
         return TestKernel::class;

--- a/tests/integration/Installer/TestCase.php
+++ b/tests/integration/Installer/TestCase.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Installer;
+
+use Ibexa\Contracts\Core\Test\IbexaKernelTestCase;
+
+abstract class TestCase extends IbexaKernelTestCase
+{
+    protected static function getKernelClass(): string
+    {
+        return TestKernel::class;
+    }
+}

--- a/tests/integration/Installer/TestKernel.php
+++ b/tests/integration/Installer/TestKernel.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Installer;
+
+use EzSystems\DoctrineSchemaBundle\DoctrineSchemaBundle;
+use EzSystems\PlatformInstallerBundle\EzSystemsPlatformInstallerBundle;
+use EzSystems\PlatformInstallerBundle\Installer\CoreInstaller;
+use Ibexa\Contracts\Core\Test\IbexaTestKernel;
+
+final class TestKernel extends IbexaTestKernel
+{
+    public function registerBundles(): iterable
+    {
+        yield from parent::registerBundles();
+
+        yield new DoctrineSchemaBundle();
+        yield new EzSystemsPlatformInstallerBundle();
+    }
+
+    protected static function getExposedServicesByClass(): iterable
+    {
+        yield from parent::getExposedServicesByClass();
+
+        yield CoreInstaller::class;
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1489](https://issues.ibexa.co/browse/IBX-1489)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Provides integration tests & fixes for PHP8 compatibility.

# Notable changes:

## Disabling transactions during schema import / install.

Due to a change in PHP's MySQL driver https://github.com/php/php-src/commit/990bb34 for PHP8 it becomes necessary to handle a case where `Connection::commit()` throws an exception that there is no transaction (which happens after DDL SQL commands).

> DDL statements on mysql result in an implicit commit (see [mysql documentation](https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html)). This causes the explicit commit in transactional mode to fail. But only starting with php 8.0 an error is raised (probably due to php/php-src@990bb34).

## Removal of PHP8 deprecation warnings

This includes:
 * Reordering of some test methods, so that optional argument are at the end of the list.
 * Converting values to `string`, where other data types are possible. Especially `null` or `int`.

## Issues that will require addressing in the near future
 * One test fails specifically on PHP 8.1 due to change in `DateTime` interval behavior. It is therefore disabled on this platform.
 * MySQL 8.0 tests have issues with collation conversion (which are **probably** silently ignored on earlier versions).

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
