### PR TITLE
Provided PHP8 compatibility for moving content

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -231,7 +231,7 @@ final class DoctrineDatabase extends Gateway
         $results = $statement->fetchAll($onlyIds ? (FetchMode::COLUMN | PDO::FETCH_GROUP) : FetchMode::ASSOCIATIVE);
         // array_map() is used to map all elements stored as $results[$i][0] to $results[$i]
         return $onlyIds
-            ? array_map(static function ($result) {
+            ? array_map(static function (array $result) {
                 return $result[0];
             }, $results)
             : $results;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -229,8 +229,12 @@ final class DoctrineDatabase extends Gateway
         $statement = $query->execute();
 
         $results = $statement->fetchAll($onlyIds ? (FetchMode::COLUMN | PDO::FETCH_GROUP) : FetchMode::ASSOCIATIVE);
-        // array_map() is used to to map all elements stored as $results[$i][0] to $results[$i]
-        return $onlyIds ? array_map('reset', $results) : $results;
+        // array_map() is used to map all elements stored as $results[$i][0] to $results[$i]
+        return $onlyIds
+            ? array_map(static function ($result) {
+                return $result[0];
+            }, $results)
+            : $results;
     }
 
     /**


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1521](https://issues.ibexa.co/browse/IBX-1521)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`, `v4.0`
| **BC breaks**                          | no

After moving content we end up with the following warning:
`Warning: reset(): Argument #1 ($array) must be passed by reference, value given`

`reset` function is waiting for a variable reference which isn't the case while passing it to `array_map`.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
