### PR TITLE
Added PHPStan analysis

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,8 +47,8 @@ jobs:
             - name: Setup problem matchers for PHPUnit
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
-            # - name: Run PHPStan analysis
-            #   run: composer run-script phpstan
+            - name: Run PHPStan analysis
+              run: composer run-script phpstan
 
             - name: Run code style check
               if: matrix.skip_code_style != true

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ var/
 composer.lock
 .php-cs-fixer.cache
 .phpunit.result.cache
+phpstan.neon
 .rules/

--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,8 @@
         "phpunit/phpunit": "^8.2",
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "symfony/phpunit-bridge": "^5.1",
-        "symfony/proxy-manager-bridge": "^5.3"
+        "symfony/proxy-manager-bridge": "^5.3",
+        "phpstan/phpstan": "^1.2"
     },
     "conflict": {
         "symfony/dependency-injection": "5.3.7",
@@ -115,6 +116,7 @@
         "check-cs": "@fix-cs --dry-run",
         "fix-cs": "php-cs-fixer fix -v --show-progress=dots",
         "unit": "phpunit -c phpunit.xml",
+        "phpstan": "phpstan analyse",
         "integration": [
             "Composer\\Config::disableProcessTimeout",
             "phpunit -c phpunit-integration-legacy.xml"

--- a/eZ/Bundle/EzPublishCoreBundle/Command/UpdateTimestampsToUTCCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/UpdateTimestampsToUTCCommand.php
@@ -256,9 +256,9 @@ EOT
                 '',
                 sprintf('Done: %d', $this->done),
             ]);
-
-            return 0;
         }
+
+        return 0;
     }
 
     /**

--- a/eZ/Bundle/EzPublishIOBundle/Command/MigrateFilesCommand.php
+++ b/eZ/Bundle/EzPublishIOBundle/Command/MigrateFilesCommand.php
@@ -255,7 +255,7 @@ EOT
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      */
     protected function migrateFiles(
-        $totalFileCount = null,
+        $totalFileCount,
         $bulkCount,
         $dryRun,
         OutputInterface $output

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIterator/LegacyStorageFileIterator.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIterator/LegacyStorageFileIterator.php
@@ -38,7 +38,7 @@ final class LegacyStorageFileIterator implements FileIteratorInterface
         return $this->item;
     }
 
-    public function next()
+    public function next(): void
     {
         $this->fetchRow();
     }
@@ -48,19 +48,19 @@ final class LegacyStorageFileIterator implements FileIteratorInterface
         return $this->cursor;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return $this->cursor < $this->count();
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->cursor = -1;
         $this->rowReader->init();
         $this->fetchRow();
     }
 
-    public function count()
+    public function count(): int
     {
         return $this->rowReader->getCount();
     }

--- a/eZ/Publish/Core/FieldType/Media/Type.php
+++ b/eZ/Publish/Core/FieldType/Media/Type.php
@@ -208,7 +208,7 @@ class Type extends BaseType
     /**
      * Converts a $Value to a hash.
      *
-     * @param \eZ\Publish\Core\FieldType\Media\Value $value
+     * @param \eZ\Publish\SPI\FieldType\Value $value
      *
      * @return mixed
      */

--- a/eZ/Publish/Core/FieldType/Media/Type.php
+++ b/eZ/Publish/Core/FieldType/Media/Type.php
@@ -10,7 +10,7 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentType;
 use eZ\Publish\Core\FieldType\BinaryBase\Type as BaseType;
 use eZ\Publish\Core\FieldType\ValidationError;
 use eZ\Publish\Core\FieldType\Value as BaseValue;
-use eZ\Publish\SPI\fieldType\Value as SPIValue;
+use eZ\Publish\SPI\FieldType\Value as SPIValue;
 use eZ\Publish\SPI\Persistence\Content\FieldValue;
 
 /**
@@ -208,7 +208,7 @@ class Type extends BaseType
     /**
      * Converts a $Value to a hash.
      *
-     * @param \eZ\Publish\SPI\FieldType\Value $value
+     * @param \eZ\Publish\Core\FieldType\Media\Value $value
      *
      * @return mixed
      */

--- a/eZ/Publish/SPI/Persistence/Filter/Content/LazyContentItemListIterator.php
+++ b/eZ/Publish/SPI/Persistence/Filter/Content/LazyContentItemListIterator.php
@@ -24,6 +24,7 @@ class LazyContentItemListIterator extends LazyListIterator
      *
      * @throws \Exception
      */
+    #[\ReturnTypeWillChange]
     public function getIterator(): iterable
     {
         yield from parent::getIterator();

--- a/eZ/Publish/SPI/Persistence/Filter/LazyListIterator.php
+++ b/eZ/Publish/SPI/Persistence/Filter/LazyListIterator.php
@@ -48,6 +48,7 @@ abstract class LazyListIterator implements IteratorAggregate
         return $this->totalCount;
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator(): iterable
     {
         if (0 === $this->totalCount) {

--- a/eZ/Publish/SPI/Persistence/Filter/Location/LazyLocationListIterator.php
+++ b/eZ/Publish/SPI/Persistence/Filter/Location/LazyLocationListIterator.php
@@ -24,6 +24,7 @@ class LazyLocationListIterator extends LazyListIterator
      *
      * @throws \Exception
      */
+    #[\ReturnTypeWillChange]
     public function getIterator(): iterable
     {
         yield from parent::getIterator();

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,537 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Access to undefined constant static\\(eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\DependencyInjection\\\\Compiler\\\\ViewManagerPass\\)\\:\\:VIEW_PROVIDER_IDENTIFIER\\.$#"
+			count: 2
+			path: eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewManagerPass.php
+
+		-
+			message: "#^Access to undefined constant static\\(eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\DependencyInjection\\\\Compiler\\\\ViewManagerPass\\)\\:\\:VIEW_TYPE\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Compiler/ViewManagerPass.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\DependencyInjection\\\\Configuration\\\\ConfigResolver\\:\\:logTooEarlyLoadedListIfNeeded\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/ConfigResolver.php
+
+		-
+			message: "#^Access to undefined constant static\\(eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\DependencyInjection\\\\Configuration\\\\Parser\\\\Templates\\)\\:\\:INFO\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Templates.php
+
+		-
+			message: "#^Access to undefined constant static\\(eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\DependencyInjection\\\\Configuration\\\\Parser\\\\Templates\\)\\:\\:INFO_TEMPLATE_KEY\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Templates.php
+
+		-
+			message: "#^Access to undefined constant static\\(eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\DependencyInjection\\\\Configuration\\\\Parser\\\\Templates\\)\\:\\:NODE_KEY\\.$#"
+			count: 5
+			path: eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/Templates.php
+
+		-
+			message: "#^Access to undefined constant static\\(eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\DependencyInjection\\\\Configuration\\\\Parser\\\\View\\)\\:\\:INFO\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/View.php
+
+		-
+			message: "#^Access to undefined constant static\\(eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\DependencyInjection\\\\Configuration\\\\Parser\\\\View\\)\\:\\:NODE_KEY\\.$#"
+			count: 2
+			path: eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Configuration/Parser/View.php
+
+		-
+			message: "#^Parameter \\$content of method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Features\\\\Context\\\\BasicContentContext\\:\\:publishDraft\\(\\) has invalid type eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Features\\\\Context\\\\Content\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Features/Context/BasicContentContext.php
+
+		-
+			message: "#^Call to an undefined method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Features\\\\Context\\\\ContentTypeContext\\:\\:processSettings\\(\\)\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentTypeContext.php
+
+		-
+			message: "#^Call to an undefined method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Features\\\\Context\\\\ContentTypeContext\\:\\:processValidator\\(\\)\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Features/Context/ContentTypeContext.php
+
+		-
+			message: "#^Access to an undefined property eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Features\\\\Context\\\\QueryControllerContext\\:\\:\\$repository\\.$#"
+			count: 7
+			path: eZ/Bundle/EzPublishCoreBundle/Features/Context/QueryControllerContext.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Features\\\\Context\\\\UserContext\\:\\:ensureUserExists\\(\\) invoked with 2 parameters, 3\\-4 required\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Features\\\\Context\\\\UserContext\\:\\:iHaveUser\\(\\) should return eZ\\\\Publish\\\\API\\\\Repository\\\\Values\\\\User\\\\User but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Features\\\\Context\\\\UserContext\\:\\:iHaveUserInGroup\\(\\) should return eZ\\\\Publish\\\\API\\\\Repository\\\\Values\\\\User\\\\User but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Features\\\\Context\\\\UserContext\\:\\:iHaveUserWithUsernameEmailAndPassword\\(\\) should return eZ\\\\Publish\\\\API\\\\Repository\\\\Values\\\\User\\\\User but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
+
+		-
+			message: "#^Access to an undefined property eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Tests\\\\DependencyInjection\\\\Configuration\\\\Parser\\\\LanguagesTest\\:\\:\\$minimalConfig\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Configuration/Parser/LanguagesTest.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Tests\\\\DependencyInjection\\\\Stub\\\\QueryTypeBundle\\\\QueryType\\\\TestQueryType\\:\\:getQuery\\(\\) should return eZ\\\\Publish\\\\API\\\\Repository\\\\Values\\\\Content\\\\Query but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/QueryTypeBundle/QueryType/TestQueryType.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Tests\\\\DependencyInjection\\\\Stub\\\\QueryTypeBundle\\\\QueryType\\\\TestQueryType\\:\\:getSupportedParameters\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Stub/QueryTypeBundle/QueryType/TestQueryType.php
+
+		-
+			message: "#^Access to an undefined property eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Tests\\\\EventListener\\\\RoutingListenerTest\\:\\:\\$container\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/RoutingListenerTest.php
+
+		-
+			message: "#^Access to an undefined property eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Tests\\\\EventListener\\\\SessionSetDynamicNameListenerTest\\:\\:\\$session\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionSetDynamicNameListenerTest.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Tests\\\\EventListener\\\\Stubs\\\\ViewManager\\:\\:renderContent\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/ViewManager.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Tests\\\\EventListener\\\\Stubs\\\\ViewManager\\:\\:renderContentView\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/ViewManager.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Tests\\\\EventListener\\\\Stubs\\\\ViewManager\\:\\:renderLocation\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/ViewManager.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Tests\\\\EventListener\\\\Stubs\\\\ViewProvider\\:\\:getView\\(\\) should return eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\View\\\\View but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/Stubs/ViewProvider.php
+
+		-
+			message: "#^Access to an undefined property eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Tests\\\\Fragment\\\\FragmentRendererBaseTest\\:\\:\\$innerRenderer\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Tests/Fragment/FragmentRendererBaseTest.php
+
+		-
+			message: "#^Access to an undefined property eZ\\\\Bundle\\\\EzPublishCoreBundle\\\\Tests\\\\Routing\\\\UrlAliasRouterTest\\:\\:\\$container\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishCoreBundle/Tests/Routing/UrlAliasRouterTest.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishIOBundle\\\\BinaryStreamResponse\\:\\:sendContent\\(\\) should return \\$this\\(eZ\\\\Bundle\\\\EzPublishIOBundle\\\\BinaryStreamResponse\\) but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishIOBundle/BinaryStreamResponse.php
+
+		-
+			message: "#^Method eZ\\\\Bundle\\\\EzPublishIOBundle\\\\BinaryStreamResponse\\:\\:setContent\\(\\) should return \\$this\\(eZ\\\\Bundle\\\\EzPublishIOBundle\\\\BinaryStreamResponse\\) but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishIOBundle/BinaryStreamResponse.php
+
+		-
+			message: "#^Instantiated class eZ\\\\Bundle\\\\EzPublishIOBundle\\\\Tests\\\\DependencyInjection\\\\ConfigurationFactory\\\\MetadataHandler\\\\Flysystem not found\\.$#"
+			count: 1
+			path: eZ/Bundle/EzPublishIOBundle/Tests/DependencyInjection/ConfigurationFactory/MetadataHandler/FlysystemTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\ContentServiceTest\\:\\:testCreateContentAndPublishWithPrivilegedAnonymousUser\\(\\) should return eZ\\\\Publish\\\\API\\\\Repository\\\\Values\\\\Content\\\\Content but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/ContentServiceTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\AuthorIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/AuthorIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\BinaryFileIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/BinaryFileIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\CheckboxIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/CheckboxIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\CountryIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/CountryIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\DateAndTimeIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/DateAndTimeIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\EmailAddressIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/EmailAddressIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\FloatIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/FloatIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\ISBNIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/ISBNIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\ImageIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/ImageIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\IntegerIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/IntegerIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\KeywordIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/KeywordIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\MapLocationIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/MapLocationIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\MediaIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/MediaIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\RelationIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/RelationIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\RelationListIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/RelationListIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\SelectionIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/SelectionIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\TextBlockIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/TextBlockIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\TextLineIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/TextLineIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\TimeIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/TimeIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\UrlIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/UrlIntegrationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\FieldType\\\\UserIntegrationTest\\:\\:assertUpdatedFieldDataLoadedCorrect\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/FieldType/UserIntegrationTest.php
+
+		-
+			message: "#^Class EzSystems\\\\EzPlatformSolrSearchEngine\\\\Tests\\\\SetupFactory\\\\LegacySetupFactory not found\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/Regression/EZP20018LanguageTest.php
+
+		-
+			message: "#^Instantiated class eZ\\\\Publish\\\\Core\\\\FieldType\\\\RichText\\\\Value not found\\.$#"
+			count: 3
+			path: eZ/Publish/API/Repository/Tests/SearchService/SearchServiceFullTextEmbedTest.php
+
+		-
+			message: "#^Class EzSystems\\\\EzPlatformSolrSearchEngine\\\\Tests\\\\SetupFactory\\\\LegacySetupFactory not found\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/SearchServiceLocationTest.php
+
+		-
+			message: "#^Class EzSystems\\\\EzPlatformSolrSearchEngine\\\\Tests\\\\SetupFactory\\\\LegacySetupFactory not found\\.$#"
+			count: 5
+			path: eZ/Publish/API/Repository/Tests/SearchServiceTest.php
+
+		-
+			message: "#^Class EzSystems\\\\EzPlatformSolrSearchEngine\\\\Tests\\\\SetupFactory\\\\LegacySetupFactory not found\\.$#"
+			count: 3
+			path: eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
+
+		-
+			message: "#^Undefined variable\\: \\$loader$#"
+			count: 3
+			path: eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\URLWildcardServiceAuthorizationTest\\:\\:testCreateThrowsUnauthorizedException\\(\\) should return eZ\\\\Publish\\\\API\\\\Repository\\\\Values\\\\Content\\\\URLWildcard but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/URLWildcardServiceAuthorizationTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\URLWildcardServiceTest\\:\\:testTranslateThrowsNotFoundExceptionWhenNotAliasOrWildcardMatches\\(\\) should return eZ\\\\Publish\\\\API\\\\Repository\\\\Values\\\\Content\\\\URLAlias but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/URLWildcardServiceTest.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\UserServiceTest\\:\\:testUpdateUserNoPassword\\(\\) should return eZ\\\\Publish\\\\API\\\\Repository\\\\Values\\\\User\\\\User but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/UserServiceTest.php
+
+		-
+			message: "#^Instantiated class eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\RuntimeException not found\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Tests/_fixtures/generate-fixtures.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: eZ/Publish/API/Repository/Values/ValueObject.php
+
+		-
+			message: "#^Access to an undefined property eZ\\\\Publish\\\\Core\\\\Base\\\\Exceptions\\\\LimitationValidationException\\:\\:\\$validationErrors\\.$#"
+			count: 1
+			path: eZ/Publish/Core/Base/Exceptions/LimitationValidationException.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\Base\\\\Tests\\\\Container\\\\Compiler\\\\Stubs\\\\GatewayBasedStorageHandler\\:\\:deleteFieldData\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/Base/Tests/Container/Compiler/Stubs/GatewayBasedStorageHandler.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\Base\\\\Tests\\\\Container\\\\Compiler\\\\Stubs\\\\GatewayBasedStorageHandler\\:\\:getIndexData\\(\\) should return array\\<eZ\\\\Publish\\\\SPI\\\\Search\\\\Field\\> but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/Base/Tests/Container/Compiler/Stubs/GatewayBasedStorageHandler.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\Base\\\\Tests\\\\Container\\\\Compiler\\\\Stubs\\\\GatewayBasedStorageHandler\\:\\:hasFieldData\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/Base/Tests/Container/Compiler/Stubs/GatewayBasedStorageHandler.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\FieldType\\\\BinaryBase\\\\BinaryBaseStorage\\:\\:deleteFieldData\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\FieldType\\\\BinaryBase\\\\BinaryBaseStorage\\:\\:getIndexData\\(\\) should return array\\<eZ\\\\Publish\\\\SPI\\\\Search\\\\Field\\> but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/BinaryBase/BinaryBaseStorage.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 2
+			path: eZ/Publish/Core/FieldType/Date/Value.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 2
+			path: eZ/Publish/Core/FieldType/DateAndTime/Value.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\FieldType\\\\Image\\\\ImageStorage\\:\\:deleteFieldData\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/Image/ImageStorage.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/Image/Value.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\FieldType\\\\MapLocation\\\\MapLocationStorage\\:\\:deleteFieldData\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\FieldType\\\\MapLocation\\\\MapLocationStorage\\\\Gateway\\\\DoctrineStorage\\:\\:getFieldData\\(\\) should return array but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway/DoctrineStorage.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\FieldType\\\\MapLocation\\\\MapLocationStorage\\\\Gateway\\\\DoctrineStorage\\:\\:updateFieldData\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway/DoctrineStorage.php
+
+		-
+			message: "#^Interface eZ\\\\Publish\\\\SPI\\\\FieldType\\\\Value referenced with incorrect case\\: eZ\\\\Publish\\\\SPI\\\\fieldType\\\\Value\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/Media/Type.php
+
+		-
+			message: "#^Class eZ\\\\Publish\\\\Core\\\\FieldType\\\\ISBN\\\\Type does not have a constructor and must be instantiated without any parameters\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/Tests/ISBNTest.php
+
+		-
+			message: "#^Access to an undefined property eZ\\\\Publish\\\\Core\\\\FieldType\\\\Tests\\\\ImageTest\\:\\:\\$mimeTypeDetectorMock\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/Tests/ImageTest.php
+
+		-
+			message: "#^Class eZ\\\\Publish\\\\SPI\\\\FieldType\\\\BinaryBase\\\\MimeTypeDetector not found\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/Tests/ImageTest.php
+
+		-
+			message: "#^Access to an undefined property eZ\\\\Publish\\\\Core\\\\FieldType\\\\Tests\\\\Url\\\\Gateway\\\\DoctrineStorageTest\\:\\:\\$storageGateway\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/Tests/Url/Gateway/DoctrineStorageTest.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/Time/Value.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\FieldType\\\\Url\\\\UrlStorage\\:\\:deleteFieldData\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/Url/UrlStorage.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\FieldType\\\\Url\\\\UrlStorage\\:\\:getIndexData\\(\\) should return array\\<eZ\\\\Publish\\\\SPI\\\\Search\\\\Field\\> but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/Url/UrlStorage.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\FieldType\\\\User\\\\UserStorage\\:\\:getIndexData\\(\\) should return array\\<eZ\\\\Publish\\\\SPI\\\\Search\\\\Field\\> but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/FieldType/User/UserStorage.php
+
+		-
+			message: "#^Access to an undefined property eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Content\\\\PreviewController\\:\\:\\$locationProvider\\.$#"
+			count: 2
+			path: eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\Matcher\\\\ContentBased\\\\Id\\\\LocationRemote\\:\\:matchContentInfo\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/LocationRemote.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\Matcher\\\\ContentBased\\\\Id\\\\LocationRemote\\:\\:matchLocation\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/LocationRemote.php
+
+		-
+			message: "#^Access to an undefined property eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\Matcher\\\\Tests\\\\AbstractMatcherFactoryTest\\:\\:\\$matcherFactoryClass\\.$#"
+			count: 5
+			path: eZ/Publish/Core/MVC/Symfony/Matcher/Tests/AbstractMatcherFactoryTest.php
+
+		-
+			message: "#^Class eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\View\\\\Provider\\\\Location\\\\Configured not found\\.$#"
+			count: 1
+			path: eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBased/BaseTest.php
+
+		-
+			message: "#^Access to an undefined property eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\Matcher\\\\Tests\\\\ContentBasedMatcherFactoryTest\\:\\:\\$matcherFactoryClass\\.$#"
+			count: 1
+			path: eZ/Publish/Core/MVC/Symfony/Matcher/Tests/ContentBasedMatcherFactoryTest.php
+
+		-
+			message: "#^Unsafe usage of new static\\(\\)\\.$#"
+			count: 1
+			path: eZ/Publish/Core/MVC/Symfony/Routing/SimplifiedRequest.php
+
+		-
+			message: "#^Access to undefined constant static\\(eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\SiteAccess\\\\Matcher\\\\Compound\\)\\:\\:NAME\\.$#"
+			count: 1
+			path: eZ/Publish/Core/MVC/Symfony/SiteAccess/Matcher/Compound.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\Templating\\\\GlobalHelper\\:\\:getRequestedUriString\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/MVC/Symfony/Templating/GlobalHelper.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\Templating\\\\GlobalHelper\\:\\:getViewParametersString\\(\\) should return string but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/MVC/Symfony/Templating/GlobalHelper.php
+
+		-
+			message: "#^Undefined variable\\: \\$ret$#"
+			count: 1
+			path: eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/FileSystemTwigIntegrationTestCase.php
+
+		-
+			message: "#^Class eZ\\\\Publish\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\FieldValue\\\\Converter\\\\SelectionConverter constructor invoked with 0 parameters, 1 required\\.$#"
+			count: 1
+			path: eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/SelectionConverter.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\Handler\\:\\:deleteContent\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\Handler\\:\\:deleteVersion\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\Location\\\\Handler\\:\\:move\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\Location\\\\Handler\\:\\:removeSubtree\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\Location\\\\Handler\\:\\:swap\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\TreeHandler\\:\\:removeSubtree\\(\\) should return bool but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/Persistence/Legacy/Content/TreeHandler.php
+
+		-
+			message: "#^Method eZ\\\\Publish\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\Type\\\\Handler\\:\\:addFieldDefinition\\(\\) should return eZ\\\\Publish\\\\SPI\\\\Persistence\\\\Content\\\\Type\\\\FieldDefinition but return statement is missing\\.$#"
+			count: 1
+			path: eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
+
+		-
+			message: "#^Undefined variable\\: \\$loader$#"
+			count: 2
+			path: eZ/Publish/Core/Persistence/Legacy/Tests/HandlerTest.php
+
+		-
+			message: "#^Class eZ\\\\Publish\\\\SPI\\\\Persistence\\\\Content\\\\UrlAlias referenced with incorrect case\\: eZ\\\\Publish\\\\SPI\\\\Persistence\\\\Content\\\\URLAlias\\.$#"
+			count: 2
+			path: eZ/Publish/Core/Repository/URLAliasService.php
+
+		-
+			message: "#^Class Symfony\\\\Component\\\\Validator\\\\ConstraintViolation constructor invoked with 1 parameter, 6\\-10 required\\.$#"
+			count: 1
+			path: eZ/Publish/SPI/FieldType/Generic/Tests/GenericTest.php
+

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -381,11 +381,6 @@ parameters:
 			path: eZ/Publish/Core/FieldType/MapLocation/MapLocationStorage/Gateway/DoctrineStorage.php
 
 		-
-			message: "#^Interface eZ\\\\Publish\\\\SPI\\\\FieldType\\\\Value referenced with incorrect case\\: eZ\\\\Publish\\\\SPI\\\\fieldType\\\\Value\\.$#"
-			count: 1
-			path: eZ/Publish/Core/FieldType/Media/Type.php
-
-		-
 			message: "#^Class eZ\\\\Publish\\\\Core\\\\FieldType\\\\ISBN\\\\Type does not have a constructor and must be instantiated without any parameters\\.$#"
 			count: 1
 			path: eZ/Publish/Core/FieldType/Tests/ISBNTest.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -10,3 +10,4 @@ parameters:
     excludePaths:
         analyse:
             - tests/integration/Core/Repository/var
+            - eZ/Publish/Core/Search/Legacy/Tests/_fixtures/full_dump.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,12 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: 0
+    paths:
+        - eZ
+        - src
+        - tests
+    excludePaths:
+        analyse:
+            - tests/integration/Core/Repository/var


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

## NOTE: Temporarily set `fix-php8` as base, since it already includes fixes for some errors detected by PHPStan.

This PR introduces static analysis on the lowest possible level, with multiple low-hanging errors put into baseline to be fixed in the near future.

As a noteworthy mention, since 0.12 PHPStan version some best practices changed. Now PHPStan loads either `phpstan.neon` or `phpstan.neon.dist` configuration files (in that order) when performing `analyze` (see https://phpstan.org/config-reference#config-file).
Since this allows user-customization, this practice is followed, and configuration file option is no longer used in composer script declaration.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage.~ _No behavior changes_
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
