### PR TITLE
IBX-1489: Fixed mismatch in new namespace RepositoryInstaller

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,7 +104,7 @@
             "Ibexa\\Tests\\Integration\\Core\\": "tests/integration/Core",
             "Ibexa\\Tests\\Integration\\Debug\\": "tests/integration/Debug",
             "Ibexa\\Tests\\Integration\\IO\\": "tests/integration/IO",
-            "Ibexa\\Tests\\Integration\\Installer\\": "tests/integration/Installer",
+            "Ibexa\\Tests\\Integration\\RepositoryInstaller\\": "tests/integration/RepositoryInstaller",
             "Ibexa\\Tests\\Integration\\LegacySearchEngine\\": "tests/integration/LegacySearchEngine",
             "Ibexa\\Tests\\Core\\": "tests/lib"
         }

--- a/tests/integration/RepositoryInstaller/Installer/CoreInstallerTest.php
+++ b/tests/integration/RepositoryInstaller/Installer/CoreInstallerTest.php
@@ -4,10 +4,10 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace Ibexa\Tests\Integration\Installer\Installer;
+namespace Ibexa\Tests\Integration\Installer\RepositoryInstaller;
 
 use EzSystems\PlatformInstallerBundle\Installer\CoreInstaller;
-use Ibexa\Tests\Integration\Installer\TestCase;
+use Ibexa\Tests\Integration\RepositoryInstaller\TestCase;
 use Symfony\Component\Console\Output\NullOutput;
 
 final class CoreInstallerTest extends TestCase

--- a/tests/integration/RepositoryInstaller/TestCase.php
+++ b/tests/integration/RepositoryInstaller/TestCase.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Integration\Installer;
+namespace Ibexa\Tests\Integration\RepositoryInstaller;
 
 use Ibexa\Contracts\Core\Test\IbexaKernelTestCase;
 

--- a/tests/integration/RepositoryInstaller/TestKernel.php
+++ b/tests/integration/RepositoryInstaller/TestKernel.php
@@ -6,7 +6,7 @@
  */
 declare(strict_types=1);
 
-namespace Ibexa\Tests\Integration\Installer;
+namespace Ibexa\Tests\Integration\RepositoryInstaller;
 
 use EzSystems\DoctrineSchemaBundle\DoctrineSchemaBundle;
 use EzSystems\PlatformInstallerBundle\EzSystemsPlatformInstallerBundle;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1489](https://issues.ibexa.co/browse/IBX-1489)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Backports changes related to `Installer` namespace from https://github.com/ibexa/core/pull/34.

Fixes mismatch between new namespace and the one declared in PRs.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
