### PR TITLE
Moved php-cs-fixer to another job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,31 @@ on:
     pull_request: ~
 
 jobs:
+    cs_fix:
+        name: Run code style check
+        runs-on: "ubuntu-20.04"
+        strategy:
+            matrix:
+                php:
+                    - '8.0'
+        steps:
+            - uses: actions/checkout@v2
+
+            - name: Setup PHP Action
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ matrix.php }}
+                  coverage: none
+                  extensions: 'pdo_sqlite, gd'
+                  tools: cs2pr
+
+            - uses: "ramsey/composer-install@v1"
+              with:
+                  dependency-versions: "highest"
+
+            - name: Run code style check
+              run: composer run-script check-cs -- --format=checkstyle | cs2pr
+
     tests:
         name: Unit tests & SQLite integration tests
         runs-on: "ubuntu-20.04"
@@ -16,17 +41,11 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                experimental: [ false ]
                 php:
                     - '7.3'
                     - '7.4'
-                composer_options: [ "" ]
-                include:
-                    -   php: '8.0'
-                        composer_options: "--ignore-platform-req php"
-                    -   php: '8.1'
-                        composer_options: "--ignore-platform-req php"
-                        skip_code_style: true
+                    - '8.0'
+                    - '8.1'
 
         steps:
             - uses: actions/checkout@v2
@@ -42,17 +61,12 @@ jobs:
             - uses: "ramsey/composer-install@v1"
               with:
                   dependency-versions: "highest"
-                  composer-options: "${{ matrix.composer_options }}"
 
             - name: Setup problem matchers for PHPUnit
               run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
             - name: Run PHPStan analysis
               run: composer run-script phpstan
-
-            - name: Run code style check
-              if: matrix.skip_code_style != true
-              run: composer run-script check-cs -- --format=checkstyle | cs2pr
 
             - name: Run unit test suite
               run: composer run-script unit
@@ -86,12 +100,8 @@ jobs:
                 php:
                     - '7.3'
                     - '7.4'
-                composer_options: [ "" ]
-                include:
-                    -   php: '8.0'
-                        composer_options: "--ignore-platform-req php"
-                    -   php: '8.1'
-                        composer_options: "--ignore-platform-req php"
+                    - '8.0'
+                    - '8.1'
 
         steps:
             -   uses: actions/checkout@v2
@@ -107,7 +117,6 @@ jobs:
             -   uses: "ramsey/composer-install@v1"
                 with:
                     dependency-versions: "highest"
-                    composer-options: "${{ matrix.composer_options }}"
 
             -   name: Setup problem matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
@@ -146,12 +155,8 @@ jobs:
             matrix:
                 php:
                     - '7.4'
-                composer_options: [ "" ]
-                include:
-                    -   php: '8.0'
-                        composer_options: "--ignore-platform-req php"
-                    -   php: '8.1'
-                        composer_options: "--ignore-platform-req php"
+                    - '8.0'
+                    - '8.1'
 
         steps:
             -   uses: actions/checkout@v2
@@ -167,7 +172,6 @@ jobs:
             -   uses: "ramsey/composer-install@v1"
                 with:
                     dependency-versions: "highest"
-                    composer-options: "${{ matrix.composer_options }}"
 
             -   name: Setup problem matchers for PHPUnit
                 run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1489](https://issues.ibexa.co/browse/IBX-1489)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

To avoid running cs-fixer on every supported PHP version, I moved it to another job, as in https://github.com/ibexa/post-install/pull/27. Besides, I dropped `experimental` and run the installation on PHP 8+ without `--ignore-platform-reqs` flag. Depends on https://github.com/ezsystems/doctrine-dbal-schema/pull/26.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
