### PR TITLE
IBX-1549: changed validation content to only one language

### DIFF
--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -638,7 +638,7 @@ class ContentService implements ContentServiceInterface
             throw new ContentFieldValidationException($errors);
         }
 
-        $spiLocationCreateStructs = $spiLocationCreateStructs = $this->buildSPILocationCreateStructs(
+        $spiLocationCreateStructs = $this->buildSPILocationCreateStructs(
             $locationCreateStructs,
             $contentCreateStruct->contentType
         );
@@ -1457,7 +1457,7 @@ class ContentService implements ContentServiceInterface
         $this->repository->beginTransaction();
         try {
             $this->copyTranslationsFromPublishedVersion($content->versionInfo, $translations);
-            $content = $this->internalPublishVersion($content->getVersionInfo(), null);
+            $content = $this->internalPublishVersion($content->getVersionInfo(), null, $translations);
             $this->repository->commit();
         } catch (Exception $e) {
             $this->repository->rollback();
@@ -1603,10 +1603,11 @@ class ContentService implements ContentServiceInterface
      *
      * @param \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo
      * @param int|null $publicationDate If null existing date is kept if there is one, otherwise current time is used.
+     * @param string[] $translations
      *
      * @return \eZ\Publish\API\Repository\Values\Content\Content
      */
-    protected function internalPublishVersion(APIVersionInfo $versionInfo, $publicationDate = null)
+    protected function internalPublishVersion(APIVersionInfo $versionInfo, $publicationDate = null, array $translations = Language::ALL)
     {
         if (!$versionInfo->isDraft()) {
             throw new BadStateException('$versionInfo', 'Only versions in draft status can be published.');
@@ -1625,6 +1626,7 @@ class ContentService implements ContentServiceInterface
                     null,
                     $versionInfo->versionNo
                 ),
+                'translations' => $translations,
             ]
         );
 

--- a/eZ/Publish/Core/Repository/Validator/VersionValidator.php
+++ b/eZ/Publish/Core/Repository/Validator/VersionValidator.php
@@ -68,7 +68,7 @@ final class VersionValidator implements ContentValidator
             );
 
             foreach ($languageCodes as $languageCode) {
-                $fieldValue = $content->getField($fieldDefinition->identifier)->value ?? $fieldDefinition->defaultValue;
+                $fieldValue = $content->getField($fieldDefinition->identifier, $languageCode)->value ?? $fieldDefinition->defaultValue;
                 $fieldValue = $fieldType->acceptValue($fieldValue);
 
                 if ($fieldType->isEmptyValue($fieldValue)) {

--- a/eZ/Publish/Core/Repository/Validator/VersionValidator.php
+++ b/eZ/Publish/Core/Repository/Validator/VersionValidator.php
@@ -54,7 +54,7 @@ final class VersionValidator implements ContentValidator
         $content = $context['content'];
 
         $contentType = $content->getContentType();
-        $languageCodes = $content->versionInfo->languageCodes;
+        $languageCode = $content->versionInfo->initialLanguageCode;
 
         $allFieldErrors = [];
 
@@ -67,27 +67,25 @@ final class VersionValidator implements ContentValidator
                 $fieldDefinition->fieldTypeIdentifier
             );
 
-            foreach ($languageCodes as $languageCode) {
-                $fieldValue = $content->getField($fieldDefinition->identifier)->value ?? $fieldDefinition->defaultValue;
-                $fieldValue = $fieldType->acceptValue($fieldValue);
+            $fieldValue = $content->getField($fieldDefinition->identifier, $languageCode)->value ?? $fieldDefinition->defaultValue;
+            $fieldValue = $fieldType->acceptValue($fieldValue);
 
-                if ($fieldType->isEmptyValue($fieldValue)) {
-                    if ($fieldDefinition->isRequired) {
-                        $allFieldErrors[$fieldDefinition->identifier][$languageCode] = new ValidationError(
-                            "Value for required field definition '%identifier%' with language '%languageCode%' is empty",
-                            null,
-                            ['%identifier%' => $fieldDefinition->identifier, '%languageCode%' => $languageCode],
-                            'empty'
-                        );
-                    }
-                } else {
-                    $fieldErrors = $fieldType->validate(
-                        $fieldDefinition,
-                        $fieldValue
+            if ($fieldType->isEmptyValue($fieldValue)) {
+                if ($fieldDefinition->isRequired) {
+                    $allFieldErrors[$fieldDefinition->identifier][$languageCode] = new ValidationError(
+                        "Value for required field definition '%identifier%' with language '%languageCode%' is empty",
+                        null,
+                        ['%identifier%' => $fieldDefinition->identifier, '%languageCode%' => $languageCode],
+                        'empty'
                     );
-                    if (!empty($fieldErrors)) {
-                        $allFieldErrors[$fieldDefinition->identifier][$languageCode] = $fieldErrors;
-                    }
+                }
+            } else {
+                $fieldErrors = $fieldType->validate(
+                    $fieldDefinition,
+                    $fieldValue
+                );
+                if (!empty($fieldErrors)) {
+                    $allFieldErrors[$fieldDefinition->identifier][$languageCode] = $fieldErrors;
                 }
             }
         }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1549](https://issues.ibexa.co/browse/IBX-1549), [IBX-1741](https://issues.ibexa.co/browse/IBX-1741) and [IBX-175](https://issues.ibexa.co/browse/IBX-175)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
