### PR TITLE
IBX-1489: Changed ProxyManager dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,6 @@
         "php-http/guzzle6-adapter": "^2.0",
         "nelmio/cors-bundle": "^2.0",
         "pagerfanta/pagerfanta": "^2.1",
-        "ocramius/proxy-manager": "^2.2",
         "doctrine/dbal": "^2.13.0",
         "doctrine/orm": "^2.7",
         "doctrine/doctrine-bundle": "^2.0",
@@ -54,6 +53,7 @@
         "twig/twig": "^3.0",
         "twig/extra-bundle": "^3.0",
         "friendsofsymfony/jsrouting-bundle": "^2.5",
+        "friendsofphp/proxy-manager-lts": "^1.0",
         "psr/event-dispatcher": "^1.0",
         "symfony/templating": "^5.3.0",
         "composer/package-versions-deprecated": "^1.11"


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1489](https://issues.ibexa.co/browse/IBX-1489)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | yes/no

`Ocramius/ProxyManager` is not yet ready for PHP `8.1`, ref: https://github.com/Ocramius/ProxyManager/pull/731. Therefore, some of our dependencies fail on installing kernel, ref: https://github.com/ezsystems/ezplatform-http-cache/runs/4560553221?check_suite_focus=true#step:4:30. In fact, **while installing kernel we rely on** https://github.com/FriendsOfPHP/proxy-manager-lts **anyway** due to usage of `proxy-manager-bridge`, ref: https://github.com/ezsystems/ezplatform-kernel/blob/1.3/composer.json#L70. 

Given the idea of `proxy-manager-lts` is being easier on PHP requirement (https://github.com/FriendsOfPHP/proxy-manager-lts/blob/1.x/composer.json#L29) relying on this dependency will resolve the issue. We might get back to Ocramius's package as soon as the support for PHP8.1 is provided, but this approach might backfire whenever there is a new version of PHP.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
