### PR TITLE
IBX-1809: Allowed override of test Kernel via environment

### DIFF
--- a/phpunit-integration-legacy-solr.xml
+++ b/phpunit-integration-legacy-solr.xml
@@ -18,7 +18,7 @@
         <env name="CORES_SETUP" value="dedicated" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
         <ini name="error_reporting" value="-1" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+        <env name="KERNEL_CLASS" value="Ibexa\Contracts\Core\Test\IbexaTestKernel"/>
     </php>
     <testsuites>
         <testsuite name="eZ\Publish\API\Repository">

--- a/phpunit-integration-legacy.xml
+++ b/phpunit-integration-legacy.xml
@@ -17,6 +17,7 @@
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
         <ini name="error_reporting" value="-1" />
         <env name="DATABASE_URL" value="sqlite://:memory:" />
+        <env name="KERNEL_CLASS" value="Ibexa\Contracts\Core\Test\IbexaTestKernel"/>
     </php>
     <testsuites>
         <testsuite name="eZ\Publish\API\Repository">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,6 +12,7 @@
   <php>
     <ini name="error_reporting" value="-1" />
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
+    <env name="KERNEL_CLASS" value="Ibexa\Contracts\Core\Test\IbexaTestKernel"/>
   </php>
   <testsuites>
     <testsuite name="eZ\Publish\Core\Base">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,6 @@
   <php>
     <ini name="error_reporting" value="-1" />
     <env name="SYMFONY_DEPRECATIONS_HELPER" value="disabled"/>
-    <env name="KERNEL_CLASS" value="Ibexa\Contracts\Core\Test\IbexaTestKernel"/>
   </php>
   <testsuites>
     <testsuite name="eZ\Publish\Core\Base">

--- a/src/contracts/Test/IbexaKernelTestCase.php
+++ b/src/contracts/Test/IbexaKernelTestCase.php
@@ -41,13 +41,6 @@ abstract class IbexaKernelTestCase extends KernelTestCase
         try {
             return parent::getKernelClass();
         } catch (LogicException $e) {
-            @trigger_error(sprintf(
-                'You should set the KERNEL_CLASS environment variable to the fully-qualified class name of your '
-                . 'Kernel in phpunit.xml / phpunit.xml.dist or override the "%1$s::createKernel()" or '
-                . '"%1$s::getKernelClass()" method.',
-                static::class
-            ), E_USER_DEPRECATED);
-
             return IbexaTestKernel::class;
         }
     }

--- a/src/contracts/Test/IbexaKernelTestCase.php
+++ b/src/contracts/Test/IbexaKernelTestCase.php
@@ -41,7 +41,7 @@ abstract class IbexaKernelTestCase extends KernelTestCase
         try {
             return parent::getKernelClass();
         } catch (LogicException $e) {
-            trigger_error(sprintf(
+            @trigger_error(sprintf(
                 'You should set the KERNEL_CLASS environment variable to the fully-qualified class name of your '
                 . 'Kernel in phpunit.xml / phpunit.xml.dist or override the "%1$s::createKernel()" or '
                 . '"%1$s::getKernelClass()" method.',


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1809](https://issues.ibexa.co/browse/IBX-1809)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR allows developers to change the base Kernel class used in their tests without adding the `getKernelClass()` method.
In practice this allows exposition & re-use of any abstract test classes without creating intermediary classes just to overwrite the Kernel class, or overwriting the method in all descendants.

Additionally, methods to switch user context are added, because they repeat in every package that needs to take user into account.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
