### PR TITLE
Adjusted PHP CS fixer job naming

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
     pull_request: ~
 
 jobs:
-    cs_fix:
+    cs-fix:
         name: Run code style check
         runs-on: "ubuntu-20.04"
         strategy:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1489](https://issues.ibexa.co/browse/IBX-1489)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

The naming of the PHP-cs-fixer was adjusted to be consistent with other job names.

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
