### PR TITLE
Fixed `Language::$id` phpdoc being not accurate

### DIFF
--- a/eZ/Publish/SPI/Persistence/Content/Language.php
+++ b/eZ/Publish/SPI/Persistence/Content/Language.php
@@ -16,7 +16,7 @@ class Language extends ValueObject
     /**
      * Language ID.
      *
-     * @var mixed
+     * @var int
      */
     public $id;
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Changes PHPDoc for SPI Language to be more accurate.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
