### PR TITLE
IBX-2041: Made LocalAdapter lazy loaded to fix commands having wrong adapter set

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -99,6 +99,7 @@ services:
     # Inject the siteaccess config into a few io services
     ezpublish.core.io.flysystem.default_adapter:
         class: eZ\Publish\Core\IO\Adapter\LocalAdapter
+        lazy: true
         arguments:
             - '@eZ\Publish\Core\IO\IOConfigProvider'
             - '@ezpublish.config.resolver'

--- a/eZ/Publish/Core/IO/Adapter/LocalAdapter.php
+++ b/eZ/Publish/Core/IO/Adapter/LocalAdapter.php
@@ -18,7 +18,7 @@ use LogicException;
 /**
  * @internal
  */
-final class LocalAdapter extends Local implements ConfigScopeChangeSubscriber
+class LocalAdapter extends Local implements ConfigScopeChangeSubscriber
 {
     /** @var \eZ\Publish\Core\IO\IOConfigProvider */
     private $ioConfigProvider;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2041](https://issues.ibexa.co/browse/IBX-2041)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

As the title states. Without this change, all of the console commands that use different `--siteaccess` option other than `default` have wrongly set Site Access because the `ConsoleListener` which changes Site Access is executed **after** the services are set.

Not sure if the solution is proper but it fixes the issue with all of the commands.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
