### PR TITLE
Exposed `getSchemaFiles` & `getFixtures` methods in IbexaTestKernel

### DIFF
--- a/src/contracts/Test/IbexaKernelTestCase.php
+++ b/src/contracts/Test/IbexaKernelTestCase.php
@@ -55,11 +55,11 @@ abstract class IbexaKernelTestCase extends KernelTestCase
     }
 
     /**
-     * @return array<string>
+     * @return iterable<string>
      */
     protected static function getSchemaFiles(): iterable
     {
-        yield self::$kernel->locateResource('@EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml');
+        yield from self::$kernel->getSchemaFiles();
     }
 
     final protected static function loadFixtures(): void
@@ -82,7 +82,7 @@ abstract class IbexaKernelTestCase extends KernelTestCase
      */
     protected static function getFixtures(): iterable
     {
-        yield new YamlFixture(dirname(__DIR__, 3) . '/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/data/test_data.yaml');
+        yield from self::$kernel->getFixtures();
     }
 
     /**

--- a/src/contracts/Test/IbexaKernelTestCase.php
+++ b/src/contracts/Test/IbexaKernelTestCase.php
@@ -23,7 +23,6 @@ use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
 use eZ\Publish\SPI\Persistence\TransactionHandler;
 use eZ\Publish\SPI\Tests\Persistence\FixtureImporter;
-use eZ\Publish\SPI\Tests\Persistence\YamlFixture;
 use LogicException;
 use RuntimeException;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;

--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -14,6 +14,7 @@ use eZ\Bundle\EzPublishCoreBundle\EzPublishCoreBundle;
 use eZ\Bundle\EzPublishLegacySearchEngineBundle\EzPublishLegacySearchEngineBundle;
 use eZ\Publish\API\Repository;
 use eZ\Publish\SPI\Persistence\TransactionHandler;
+use eZ\Publish\SPI\Tests\Persistence\YamlFixture;
 use FOS\JsRoutingBundle\FOSJsRoutingBundle;
 use JMS\TranslationBundle\JMSTranslationBundle;
 use Liip\ImagineBundle\LiipImagineBundle;
@@ -95,6 +96,22 @@ class IbexaTestKernel extends Kernel
     public static function getAliasServiceId(string $id): string
     {
         return 'test.' . $id;
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    public function getSchemaFiles(): iterable
+    {
+        yield $this->locateResource('@EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml');
+    }
+
+    /**
+     * @return iterable<\eZ\Publish\SPI\Tests\Persistence\Fixture>
+     */
+    public function getFixtures(): iterable
+    {
+        yield new YamlFixture(dirname(__DIR__, 3) . '/eZ/Publish/API/Repository/Tests/_fixtures/Legacy/data/test_data.yaml');
     }
 
     public function getCacheDir(): string


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR is extracted from #242.

It exposes `getSchemaFiles` and `getFixtures` as methods in `IbexaTestKernel`, so that bootstrapping scripts can make use of these.

Previously the only location these were available were `IbexaKernelTestCase`, which meant that they were only accessible during test execution itself.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
