### PR TITLE
IBX-1090: Fixed calculations and displaying of ezdate FT, as it should always be represented in UTC

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/content_fields.html.twig
@@ -80,7 +80,7 @@
 {% block ezdate_field %}
 {% apply spaceless %}
     {% if not ez_field_is_empty( content, field ) %}
-        {% set field_value = field.value.date|format_date( 'short', locale=parameters.locale ) %}
+        {% set field_value = field.value.date|format_date( 'short', locale=parameters.locale, timezone='UTC' ) %}
         {{ block( 'simple_block_field' ) }}
     {% endif %}
 {% endapply %}

--- a/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
@@ -117,9 +117,7 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
      */
     public function getValidCreationFieldData()
     {
-        $dateTime = $this->getValueOneDate();
-
-        return DateValue::fromTimestamp($dateTime->getTimestamp());
+        return DateValue::fromTimestamp(86400);
     }
 
     /**
@@ -147,10 +145,8 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
             $field->value
         );
 
-        $dateTime = $this->getValueOneDate();
-
         $expectedData = [
-            'date' => $dateTime,
+            'date' => new DateTime('@86400'),
         ];
 
         $this->assertPropertiesCorrect(
@@ -197,9 +193,7 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
      */
     public function getValidUpdateFieldData()
     {
-        $dateTime = $this->getValueOneDate();
-
-        return DateValue::fromTimestamp($dateTime->getTimestamp());
+        return DateValue::fromTimestamp(86400);
     }
 
     /**
@@ -217,10 +211,8 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
             $field->value
         );
 
-        $dateTime = $this->getValueOneDate();
-
         $expectedData = [
-            'date' => $dateTime,
+            'date' => new DateTime('@86400'),
         ];
         $this->assertPropertiesCorrect(
             $expectedData,
@@ -289,9 +281,8 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
      */
     public function provideToHashData()
     {
-        $timestamp = 186400;
-        $dateTime = new DateTime();
-        $dateTime->setTimestamp($timestamp);
+        $timestamp = 186401;
+        $dateTime = new DateTime("@{$timestamp}");
 
         return [
             [
@@ -334,7 +325,7 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
         return [
             [
                 [
-                    'timestamp' => $dateTime->getTimestamp(),
+                    'timestamp' => $timestamp,
                     'rfc850' => ($rfc850 = $dateTime->format(DateTime::RFC850)),
                 ],
                 DateValue::fromString($rfc850),
@@ -344,7 +335,7 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
                     'timestamp' => $dateTime->getTimestamp(),
                     'rfc850' => null,
                 ],
-                DateValue::fromTimestamp($dateTime->getTimestamp()),
+                DateValue::fromTimestamp($timestamp),
             ],
         ];
     }
@@ -367,16 +358,12 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
 
     protected function getValidSearchValueOne()
     {
-        $dateTime = $this->getValueOneDate();
-
-        return $dateTime->getTimestamp();
+        return 86400;
     }
 
     protected function getValidSearchValueTwo()
     {
-        $dateTime = new DateTime('1970-01-03');
-
-        return $dateTime->getTimestamp();
+        return 172800;
     }
 
     protected function getSearchTargetValueOne()
@@ -397,10 +384,5 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
         }
 
         return '1970-01-03T00:00:00Z';
-    }
-
-    protected function getValueOneDate(): DateTime
-    {
-        return new DateTime('1970-01-02');
     }
 }

--- a/eZ/Publish/Core/FieldType/Date/SearchField.php
+++ b/eZ/Publish/Core/FieldType/Date/SearchField.php
@@ -28,8 +28,7 @@ class SearchField implements Indexable
     public function getIndexData(Field $field, FieldDefinition $fieldDefinition)
     {
         if ($field->value->data !== null) {
-            $dateTime = new DateTime();
-            $dateTime->setTimestamp($field->value->data['timestamp']);
+            $dateTime = new DateTime("@{$field->value->data['timestamp']}");
 
             $value = $dateTime->format('Y-m-d\\Z');
         } else {

--- a/eZ/Publish/Core/FieldType/Date/Value.php
+++ b/eZ/Publish/Core/FieldType/Date/Value.php
@@ -13,6 +13,7 @@ use eZ\Publish\Core\FieldType\Value as BaseValue;
 
 /**
  * Value for Date field type.
+ * Date should always be represented in UTC.
  */
 class Value extends BaseValue
 {
@@ -74,10 +75,7 @@ class Value extends BaseValue
     public static function fromTimestamp($timestamp)
     {
         try {
-            $datetime = new DateTime();
-            $datetime->setTimestamp($timestamp);
-
-            return new static($datetime);
+            return new static(new DateTime("@{$timestamp}"));
         } catch (Exception $e) {
             throw new InvalidArgumentValue('$timestamp', $timestamp, __CLASS__, $e);
         }

--- a/eZ/Publish/Core/FieldType/Date/Value.php
+++ b/eZ/Publish/Core/FieldType/Date/Value.php
@@ -7,6 +7,7 @@
 namespace eZ\Publish\Core\FieldType\Date;
 
 use DateTime;
+use DateTimeZone;
 use Exception;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 use eZ\Publish\Core\FieldType\Value as BaseValue;
@@ -57,7 +58,7 @@ class Value extends BaseValue
     public static function fromString($dateString)
     {
         try {
-            return new static(new DateTime($dateString));
+            return new static(new DateTime($dateString, new DateTimeZone('UTC')));
         } catch (Exception $e) {
             throw new InvalidArgumentValue('$dateString', $dateString, __CLASS__, $e);
         }

--- a/eZ/Publish/Core/FieldType/Tests/DateTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/DateTest.php
@@ -145,11 +145,13 @@ class DateTest extends FieldTypeTest
             ],
             [
                 ($timestamp = 1346149200),
-                new DateValue((new DateTime())->setTimestamp($timestamp)),
+                new DateValue(
+                    new DateTime("@{$timestamp}")
+                ),
             ],
             [
                 DateValue::fromTimestamp($timestamp = 1372895999),
-                new DateValue((new DateTime())->setTimestamp($timestamp)),
+                new DateValue(new DateTime("@{$timestamp}")),
             ],
             [
                 ($dateTime = new DateTime()),
@@ -258,7 +260,7 @@ class DateTest extends FieldTypeTest
                 [
                     'timestamp' => ($timestamp = 1362614400),
                 ],
-                new DateValue($dateTime->setTimestamp($timestamp)),
+                new DateValue(new DateTime("@{$timestamp}")),
             ],
             [
                 [


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1090](https://issues.ibexa.co/browse/IBX-1090)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Reverted previous changes in this area, as date without meaningful time should always be represented in UTC.

https://github.com/ezsystems/ezplatform-admin-ui/pull/2033
~https://github.com/ezsystems/ezplatform-user/pull/111~

As in https://github.com/ezsystems/ezpublish-kernel/pull/2200 when using timestring, (i.e. `now`), UTC timezone instead of server one should be used.
https://github.com/ezsystems/ezplatform-kernel/pull/285/commits/2d0378255ee74770a9ae748f432fdfe66a939752


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
