### PR TITLE
IBX-2295: Fixed SiteAccess-aware ConfigScopeChangeSubscriber

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/ConfigScopeListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/ConfigScopeListener.php
@@ -11,9 +11,10 @@ use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessAware;
 use eZ\Publish\Core\MVC\Symfony\View\ViewManagerInterface;
+use eZ\Publish\SPI\MVC\EventSubscriber\ConfigScopeChangeSubscriber;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
-class ConfigScopeListener implements EventSubscriberInterface
+class ConfigScopeListener implements EventSubscriberInterface, ConfigScopeChangeSubscriber
 {
     /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
     private $configResolvers;
@@ -40,7 +41,7 @@ class ConfigScopeListener implements EventSubscriberInterface
         ];
     }
 
-    public function onConfigScopeChange(ScopeChangeEvent $event)
+    public function onConfigScopeChange(ScopeChangeEvent $event): void
     {
         $siteAccess = $event->getSiteAccess();
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/fieldtype_services.yml
@@ -79,6 +79,7 @@ services:
     ezpublish.fieldType.ezimage.io_service.draft.config_scope_change_aware:
         class: eZ\Publish\Core\IO\ConfigScopeChangeAwareIOService
         decorates: ezpublish.fieldType.ezimage.io_service.draft
+        autoconfigure: true
         lazy: true
         arguments:
             $configResolver: '@ezpublish.config.resolver'

--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -99,6 +99,7 @@ services:
     # Inject the siteaccess config into a few io services
     ezpublish.core.io.flysystem.default_adapter:
         class: eZ\Publish\Core\IO\Adapter\LocalAdapter
+        autoconfigure: true
         arguments:
             - '@eZ\Publish\Core\IO\IOConfigProvider'
             - '@ezpublish.config.resolver'

--- a/eZ/Publish/Core/IO/Adapter/LocalAdapter.php
+++ b/eZ/Publish/Core/IO/Adapter/LocalAdapter.php
@@ -10,7 +10,7 @@ namespace eZ\Publish\Core\IO\Adapter;
 
 use eZ\Publish\Core\IO\IOConfigProvider;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\SPI\MVC\EventSubscriber\ConfigScopeChangeSubscriber;
 use League\Flysystem\Adapter\Local;
 use LogicException;
@@ -46,7 +46,7 @@ final class LocalAdapter extends Local implements ConfigScopeChangeSubscriber
      * Reconfigure Adapter due to SiteAccess change which implies
      * root dir and permissions could be different for new SiteAccess.
      */
-    public function onConfigScopeChange(SiteAccess $siteAccess): void
+    public function onConfigScopeChange(ScopeChangeEvent $event): void
     {
         $root = $this->ioConfigProvider->getRootDir();
         $root = is_link($root) ? realpath($root) : $root;

--- a/eZ/Publish/Core/IO/ConfigScopeChangeAwareIOService.php
+++ b/eZ/Publish/Core/IO/ConfigScopeChangeAwareIOService.php
@@ -11,7 +11,7 @@ namespace eZ\Publish\Core\IO;
 use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\IO\Values\BinaryFileCreateStruct;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use eZ\Publish\SPI\MVC\EventSubscriber\ConfigScopeChangeSubscriber;
 
 class ConfigScopeChangeAwareIOService implements IOServiceInterface, ConfigScopeChangeSubscriber
@@ -113,7 +113,7 @@ class ConfigScopeChangeAwareIOService implements IOServiceInterface, ConfigScope
         $this->innerIOService->deleteDirectory($path);
     }
 
-    public function onConfigScopeChange(SiteAccess $siteAccess): void
+    public function onConfigScopeChange(ScopeChangeEvent $event): void
     {
         $this->setPrefix($this->configResolver->getParameter($this->prefixParameterName));
     }

--- a/eZ/Publish/Core/IO/Tests/ConfigScopeChangeAwareIOServiceTest.php
+++ b/eZ/Publish/Core/IO/Tests/ConfigScopeChangeAwareIOServiceTest.php
@@ -13,7 +13,7 @@ use eZ\Publish\Core\IO\IOServiceInterface;
 use eZ\Publish\Core\IO\Values\BinaryFile;
 use eZ\Publish\Core\IO\Values\BinaryFileCreateStruct;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
-use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 use PHPUnit\Framework\TestCase;
 
 final class ConfigScopeChangeAwareIOServiceTest extends TestCase
@@ -309,12 +309,12 @@ final class ConfigScopeChangeAwareIOServiceTest extends TestCase
 
     public function testOnConfigScopeChange(): void
     {
-        $siteAccess = $this->createMock(SiteAccess::class);
+        $event = $this->createMock(ScopeChangeEvent::class);
         $this->innerIOService
             ->expects($this->once())
             ->method('setPrefix')
             ->with(self::PREFIX);
 
-        $this->ioService->onConfigScopeChange($siteAccess);
+        $this->ioService->onConfigScopeChange($event);
     }
 }

--- a/eZ/Publish/SPI/MVC/EventSubscriber/ConfigScopeChangeSubscriber.php
+++ b/eZ/Publish/SPI/MVC/EventSubscriber/ConfigScopeChangeSubscriber.php
@@ -8,12 +8,12 @@ declare(strict_types=1);
 
 namespace eZ\Publish\SPI\MVC\EventSubscriber;
 
-use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\Event\ScopeChangeEvent;
 
 /**
  * Lets implementing class react to config scope changes.
  */
 interface ConfigScopeChangeSubscriber
 {
-    public function onConfigScopeChange(SiteAccess $siteAccess): void;
+    public function onConfigScopeChange(ScopeChangeEvent $event): void;
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2295](https://issues.ibexa.co/browse/IBX-2295)
| **Fixes also**                          | [IBX-2041](https://issues.ibexa.co/browse/IBX-2041)
| **Alternative to**                     | #283
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | **yes**

For `ConfigScopeChangeSubscriber` to work its `onConfigScopeChange` method needs to accept `ScopeChangeEvent` instead of `SiteAccess`. This looks like a left-over from when we dropped direct support of Dynamic Settings in 3.0 due to Symfony changes.

This is a BC break, but I would suggest making this fix in this way, so whoever relies on that SPI directly, knows that he needs to fix his code.

## TODO
- [x] Wait for CI

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually (on OSS only).
- ~Provided automated test coverage~ // already exists
- [x] Checked that target branch is set correctly
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
