### PR TITLE
IBX-2264: Handled missing thumbnail images

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
@@ -100,7 +100,7 @@ class ImageThumbnailStrategy implements FieldTypeBasedThumbnailStrategy, LoggerA
         ]);
     }
 
-    private function generateContentDetailsMessage(?APIVersionInfo $versionInfo)
+    private function generateContentDetailsMessage(?APIVersionInfo $versionInfo): string
     {
         return $versionInfo !== null
             ? sprintf('Content: %d, Version No: %d', $versionInfo->getContentInfo()->id, $versionInfo->versionNo)

--- a/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
@@ -61,34 +61,26 @@ class ImageThumbnailStrategy implements FieldTypeBasedThumbnailStrategy, LoggerA
                 $this->variationName
             );
         } catch (SourceImageNotFoundException $e) {
-            $contentDetails = isset($versionInfo->contentInfo) && isset($versionInfo->versionNo)
-                ? sprintf(' Content: %d, Version No: %d', $versionInfo->contentInfo->id, $versionInfo->versionNo)
-                : '';
-
             $this->logger->warning(
                 sprintf(
-                    'Thumbnail source image generated for %s field and %s variation could not be found (%s).',
+                    'Thumbnail source image generated for %s field and %s variation could not be found (%s). %s',
                     $field->fieldTypeIdentifier,
                     $this->variationName,
-                    $e->getMessage()
+                    $e->getMessage(),
+                    $this->generateContentDetailsMessage($versionInfo)
                 )
-                . $contentDetails
             );
 
             return null;
         } catch (Exception $e) {
-            $contentDetails = isset($versionInfo->contentInfo) && isset($versionInfo->versionNo)
-                ? sprintf(' Content: %d, Version No: %d', $versionInfo->contentInfo->id, $versionInfo->versionNo)
-                : '';
-
             $this->logger->warning(
                 sprintf(
-                    'Thumbnail could not be generated for %s field and %s variation due to %s.',
+                    'Thumbnail could not be generated for %s field and %s variation due to %s. %s',
                     $field->fieldTypeIdentifier,
                     $this->variationName,
-                    $e->getMessage()
+                    $e->getMessage(),
+                    $this->generateContentDetailsMessage($versionInfo)
                 )
-                . $contentDetails
             );
 
             return null;
@@ -100,5 +92,12 @@ class ImageThumbnailStrategy implements FieldTypeBasedThumbnailStrategy, LoggerA
             'height' => $variation->height,
             'mimeType' => $variation->mimeType,
         ]);
+    }
+
+    private function generateContentDetailsMessage(?APIVersionInfo $versionInfo)
+    {
+        return $versionInfo !== null
+            ? sprintf(' Content: %d, Version No: %d', $versionInfo->getContentInfo()->id, $versionInfo->versionNo)
+            : '';
     }
 }

--- a/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
@@ -97,7 +97,7 @@ class ImageThumbnailStrategy implements FieldTypeBasedThumbnailStrategy, LoggerA
     private function generateContentDetailsMessage(?APIVersionInfo $versionInfo)
     {
         return $versionInfo !== null
-            ? sprintf(' Content: %d, Version No: %d', $versionInfo->getContentInfo()->id, $versionInfo->versionNo)
+            ? sprintf('Content: %d, Version No: %d', $versionInfo->getContentInfo()->id, $versionInfo->versionNo)
             : '';
     }
 }

--- a/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
@@ -51,7 +51,7 @@ class ImageThumbnailStrategy implements FieldTypeBasedThumbnailStrategy
                 $this->variationName
             );
         } catch (\Exception $e) {
-            return new Thumbnail();
+            return null;
         }
 
         return new Thumbnail([

--- a/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
@@ -43,12 +43,16 @@ class ImageThumbnailStrategy implements FieldTypeBasedThumbnailStrategy
 
     public function getThumbnail(Field $field, ?APIVersionInfo $versionInfo = null): ?Thumbnail
     {
-        /** @var \eZ\Publish\SPI\Variation\Values\ImageVariation $variation */
-        $variation = $this->variationHandler->getVariation(
-            $field,
-            $versionInfo ?? new VersionInfo(),
-            $this->variationName
-        );
+        try {
+            /** @var \eZ\Publish\SPI\Variation\Values\ImageVariation $variation */
+            $variation = $this->variationHandler->getVariation(
+                $field,
+                $versionInfo ?? new VersionInfo(),
+                $this->variationName
+            );
+        } catch (\Exception $e) {
+            return new Thumbnail();
+        }
 
         return new Thumbnail([
             'resource' => $variation->uri,

--- a/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageThumbnailStrategy.php
@@ -43,7 +43,7 @@ class ImageThumbnailStrategy implements FieldTypeBasedThumbnailStrategy, LoggerA
         $this->fieldTypeIdentifier = $fieldTypeIdentifier;
         $this->variationHandler = $variationHandler;
         $this->variationName = $variationName;
-        $this->logger = $logger ?: new NullLogger();
+        $this->logger = $logger ?? new NullLogger();
     }
 
     public function getFieldTypeIdentifier(): string
@@ -68,7 +68,10 @@ class ImageThumbnailStrategy implements FieldTypeBasedThumbnailStrategy, LoggerA
                     $this->variationName,
                     $e->getMessage(),
                     $this->generateContentDetailsMessage($versionInfo)
-                )
+                ),
+                [
+                    'exception' => $e,
+                ]
             );
 
             return null;
@@ -80,7 +83,10 @@ class ImageThumbnailStrategy implements FieldTypeBasedThumbnailStrategy, LoggerA
                     $this->variationName,
                     $e->getMessage(),
                     $this->generateContentDetailsMessage($versionInfo)
-                )
+                ),
+                [
+                    'exception' => $e,
+                ]
             );
 
             return null;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2264](https://issues.ibexa.co/browse/IBX-2264)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

As the title states.

Required `ezplatform-rest` PR: https://github.com/ezsystems/ezplatform-rest/pull/91

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).

The related bundles fixes will be listed here:
