### PR TITLE
IBX-1090: DateTime for Date test should be in UTC

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/DateIntegrationTest.php
@@ -319,8 +319,8 @@ class DateIntegrationTest extends SearchBaseIntegrationTest
     {
         $timestamp = 123456;
 
-        $dateTime = new DateTime();
-        $dateTime->setTimestamp($timestamp)->setTime(0, 0, 0);
+        $dateTime = new DateTime("@{$timestamp}");
+        $dateTime->setTime(0, 0, 0);
 
         return [
             [


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1090](https://issues.ibexa.co/browse/IBX-1090)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

