### PR TITLE
Fixed integration tests failure after IO service changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
         "behat/behat": "^3.6.1",
         "jenner/simple_fork": "^1.2",
         "friends-of-behat/mink-extension": "^2.4",
+        "league/flysystem-memory": "^1.0",
         "ibexa/ci-scripts": "^0.1@dev",
         "ezsystems/ezplatform-code-style": "^2.0",
         "phpunit/phpunit": "^8.2",

--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -13,10 +13,12 @@ use Doctrine\DBAL\Connection;
 use eZ\Bundle\EzPublishCoreBundle\EzPublishCoreBundle;
 use eZ\Bundle\EzPublishLegacySearchEngineBundle\EzPublishLegacySearchEngineBundle;
 use eZ\Publish\API\Repository;
+use eZ\Publish\Core\IO\Adapter\LocalAdapter;
 use eZ\Publish\SPI\Persistence\TransactionHandler;
 use eZ\Publish\SPI\Tests\Persistence\YamlFixture;
 use FOS\JsRoutingBundle\FOSJsRoutingBundle;
 use JMS\TranslationBundle\JMSTranslationBundle;
+use League\Flysystem\Memory\MemoryAdapter;
 use Liip\ImagineBundle\LiipImagineBundle;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
@@ -150,6 +152,7 @@ class IbexaTestKernel extends Kernel
         $this->loadServices($loader);
 
         $loader->load(static function (ContainerBuilder $container): void {
+            self::prepareIOServices($container);
             self::createPublicAliasesForServicesUnderTest($container);
             self::setUpTestLogger($container);
         });
@@ -193,6 +196,11 @@ class IbexaTestKernel extends Kernel
     private static function getResourcesPath(): string
     {
         return dirname(__DIR__, 3) . '/eZ/Bundle/EzPublishCoreBundle/Tests/Resources';
+    }
+
+    private static function prepareIOServices(ContainerBuilder $container): void
+    {
+        $container->setDefinition(LocalAdapter::class, new Definition(MemoryAdapter::class));
     }
 
     private static function createPublicAliasesForServicesUnderTest(ContainerBuilder $container): void


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | bug (tests)
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Flysystem LocalAdapter ensures that a directory exists when it is constructed.
This PR replaces it with an in-memory implementation that is suitable for testing.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
