### PR TITLE
IBX-2663: Implemented `--no-hash` option in `normalize-paths` command

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -78,7 +78,7 @@ EOT;
                 self::SKIP_HASHING_COMMAND_PARAMETER,
                 null,
                 InputOption::VALUE_NONE,
-                'Skip filenames hashing'
+                'Skip filename hashing'
             )
             ->setHelp(
                 <<<EOT
@@ -102,8 +102,8 @@ EOT
 
         $this->skipHashing = $input->getOption(self::SKIP_HASHING_COMMAND_PARAMETER);
         $this->skipHashing
-            ? $io->caution('Images\' filenames will not be hashed.')
-            : $io->caution('Images\' filenames will be hashed with format {hash}-{sanitized name}.');
+            ? $io->caution('Image filenames will not be hashed.')
+            : $io->caution('Image filenames will be hashed with format {hash}-{sanitized name}.');
 
         $imagePathsToNormalize = $this->getImagePathsToNormalize($io);
 

--- a/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/NormalizeImagesPathsCommand.php
@@ -102,8 +102,8 @@ EOT
 
         $this->skipHashing = $input->getOption(self::SKIP_HASHING_COMMAND_PARAMETER);
         $this->skipHashing
-            ? $io->caution('Images\'s filenames will not be hashed.')
-            : $io->caution('Images\'s filenames will be hashed with format {hash}-{sanitized name}.');
+            ? $io->caution('Images\' filenames will not be hashed.')
+            : $io->caution('Images\' filenames will be hashed with format {hash}-{sanitized name}.');
 
         $imagePathsToNormalize = $this->getImagePathsToNormalize($io);
 

--- a/eZ/Publish/Core/IO/FilePathNormalizer/Flysystem.php
+++ b/eZ/Publish/Core/IO/FilePathNormalizer/Flysystem.php
@@ -29,7 +29,7 @@ final class Flysystem implements FilePathNormalizerInterface
         $fileName = pathinfo($filePath, PATHINFO_BASENAME);
         $directory = pathinfo($filePath, PATHINFO_DIRNAME);
 
-        $fileName = $this->slugConverter->convert($fileName);
+        $fileName = $this->slugConverter->convert($fileName, '_1', 'urlalias');
 
         $hash = $doHash
             ? (preg_match(self::HASH_PATTERN, $fileName) ? '' : bin2hex(random_bytes(6)) . '-')

--- a/eZ/Publish/Core/IO/FilePathNormalizer/Flysystem.php
+++ b/eZ/Publish/Core/IO/FilePathNormalizer/Flysystem.php
@@ -24,14 +24,16 @@ final class Flysystem implements FilePathNormalizerInterface
         $this->slugConverter = $slugConverter;
     }
 
-    public function normalizePath(string $filePath): string
+    public function normalizePath(string $filePath, bool $doHash = true): string
     {
         $fileName = pathinfo($filePath, PATHINFO_BASENAME);
         $directory = pathinfo($filePath, PATHINFO_DIRNAME);
 
         $fileName = $this->slugConverter->convert($fileName);
 
-        $hash = preg_match(self::HASH_PATTERN, $fileName) ? '' : bin2hex(random_bytes(6)) . '-';
+        $hash = $doHash
+            ? (preg_match(self::HASH_PATTERN, $fileName) ? '' : bin2hex(random_bytes(6)) . '-')
+            : '';
 
         $filePath = $directory . \DIRECTORY_SEPARATOR . $hash . $fileName;
 

--- a/eZ/Publish/Core/IO/FilePathNormalizerInterface.php
+++ b/eZ/Publish/Core/IO/FilePathNormalizerInterface.php
@@ -13,5 +13,5 @@ namespace eZ\Publish\Core\IO;
  */
 interface FilePathNormalizerInterface
 {
-    public function normalizePath(string $filePath): string;
+    public function normalizePath(string $filePath, bool $doHash = true): string;
 }

--- a/eZ/Publish/Core/IO/Tests/FilePathNormalizer/FlysystemTest.php
+++ b/eZ/Publish/Core/IO/Tests/FilePathNormalizer/FlysystemTest.php
@@ -33,7 +33,8 @@ final class FlysystemTest extends TestCase
         string $originalPath,
         string $fileName,
         string $sluggedFileName,
-        string $regex
+        string $regex,
+        bool $doHash
     ): void {
         $this->slugConverter
             ->expects(self::once())
@@ -41,7 +42,7 @@ final class FlysystemTest extends TestCase
             ->with($fileName)
             ->willReturn($sluggedFileName);
 
-        $normalizedPath = $this->filePathNormalizer->normalizePath($originalPath);
+        $normalizedPath = $this->filePathNormalizer->normalizePath($originalPath, $doHash);
 
         self::assertStringEndsWith($sluggedFileName, $normalizedPath);
         self::assertRegExp($regex, $normalizedPath);
@@ -57,30 +58,56 @@ final class FlysystemTest extends TestCase
                 'image.jpg',
                 'image.jpg',
                 $defaultPattern . 'image.jpg/',
+                true,
             ],
             'Spaces in the filename' => [
                 '4/3/2/234/1/image with spaces.jpg',
                 'image with spaces.jpg',
                 'image-with-spaces.jpg',
                 $defaultPattern . 'image-with-spaces.jpg/',
+                true,
             ],
             'Encoded spaces in the name' => [
                 '4/3/2/234/1/image%20+no+spaces.jpg',
                 'image%20+no+spaces.jpg',
                 'image-20-nospaces.jpg',
                 $defaultPattern . 'image-20-nospaces.jpg/',
+                true,
             ],
             'Special chars in the name' => [
                 '4/3/2/234/1/image%20+no+spaces?.jpg',
                 'image%20+no+spaces?.jpg',
                 'image-20-nospaces.jpg',
                 $defaultPattern . 'image-20-nospaces.jpg/',
+                true,
             ],
             'Already hashed name' => [
                 '4/3/2/234/1/14ff44718877-hashed.jpg',
                 '14ff44718877-hashed.jpg',
                 '14ff44718877-hashed.jpg',
                 '/^4\/3\/2\/234\/1\/14ff44718877-hashed.jpg$/',
+                true,
+            ],
+            'No special chars and no hashing' => [
+                '4/3/2/234/1/image.jpg',
+                'image.jpg',
+                'image.jpg',
+                '/\/image.jpg/',
+                false,
+            ],
+            'Special chars and no hashing' => [
+                '4/3/2/234/1/image%20+no+spaces.jpg',
+                'image%20+no+spaces.jpg',
+                'image-20-nospaces.jpg',
+                '/\/image-20-nospaces.jpg/',
+                false,
+            ],
+            'Already hashed name and no hashing' => [
+                '4/3/2/234/1/14ff44718877-hashed.jpg',
+                '14ff44718877-hashed.jpg',
+                '14ff44718877-hashed.jpg',
+                '/^4\/3\/2\/234\/1\/14ff44718877-hashed.jpg$/',
+                false,
             ],
         ];
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2663](https://issues.ibexa.co/browse/IBX-2663)
| **Type**                                   | feature
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This might be handy for installations with a huge amount of images. Using the mentioned option will touch only the portion of images (images with special chars etc.) and will skip hashing the images with {hash}-{filename}.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
