### PR TITLE
Fixed MemoryAdapter class not found in dependent packages

### DIFF
--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -20,6 +20,7 @@ use FOS\JsRoutingBundle\FOSJsRoutingBundle;
 use JMS\TranslationBundle\JMSTranslationBundle;
 use League\Flysystem\Memory\MemoryAdapter;
 use Liip\ImagineBundle\LiipImagineBundle;
+use LogicException;
 use Psr\Log\NullLogger;
 use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
 use Symfony\Bundle\SecurityBundle\SecurityBundle;
@@ -200,6 +201,14 @@ class IbexaTestKernel extends Kernel
 
     private static function prepareIOServices(ContainerBuilder $container): void
     {
+        if (!class_exists(MemoryAdapter::class)) {
+            throw new LogicException(sprintf(
+                'Missing %s class. Ensure that %s package is installed as a dev dependency',
+                MemoryAdapter::class,
+                'league/flysystem-memory',
+            ));
+        }
+
         $container->setDefinition(LocalAdapter::class, new Definition(MemoryAdapter::class));
     }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Dependent packages that make use of `IbexaTestKernel` now have their `LocalAdapter` automatically replaced with an in-memory implementation (`MemoryAdapter`). However, this class is part of `league/flysystem-memory`, not the Flysystem itself.

To prevent confusing error messages, I propose we introduce a check before performing the replacement, and ask that this dependency be installed as a dev requirement.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
