### PR TITLE
Fixed incorrect phpdoc for ContentFieldValidationException

### DIFF
--- a/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
@@ -26,7 +26,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
      *  $fieldErrors["43"]["eng-GB"]->getTranslatableMessage();
      * </code>
      *
-     * @var \eZ\Publish\Core\FieldType\ValidationError[]
+     * @var array<array-key, array<string, \eZ\Publish\Core\FieldType\ValidationError>>
      */
     protected $errors;
 
@@ -35,7 +35,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
      *
      * Also sets the given $fieldErrors to the internal property, retrievable by getFieldErrors()
      *
-     * @param \eZ\Publish\Core\FieldType\ValidationError[] $errors
+     * @param array<array-key, array<string, \eZ\Publish\Core\FieldType\ValidationError>> $errors
      */
     public function __construct(array $errors)
     {
@@ -47,7 +47,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
     /**
      * Returns an array of field validation error messages.
      *
-     * @return \eZ\Publish\Core\FieldType\ValidationError[]
+     * @return array<array-key, array<string, \eZ\Publish\Core\FieldType\ValidationError>>
      */
     public function getFieldErrors()
     {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Fixes incorrect phpdoc annotation regarding validation errors.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
