### PR TITLE
IBX-2839: Fix pagination with ez_render_content_query()

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/templating.yml
@@ -152,6 +152,7 @@ services:
     eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\QueryRenderingExtension:
         arguments:
             - '@fragment.handler'
+            - '@request_stack'
         tags:
             - { name: twig.extension }
 

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/QueryRenderingExtensionTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/QueryRenderingExtensionTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Tests\Twig\Extension;
 
 use eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension\QueryRenderingExtension;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 
 final class QueryRenderingExtensionTest extends FileSystemTwigIntegrationTestCase
@@ -22,8 +24,18 @@ final class QueryRenderingExtensionTest extends FileSystemTwigIntegrationTestCas
                 return var_export($args, true);
             });
 
+        $currentRequest = $this->createMock(Request::class);
+        $currentRequest
+            ->method('get')
+            ->willReturn(1);
+
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack
+            ->method('getCurrentRequest')
+            ->willReturn($currentRequest);
+
         return [
-            new QueryRenderingExtension($fragmentHandler),
+            new QueryRenderingExtension($fragmentHandler, $requestStack),
         ];
     }
 

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/query_rendering_functions/ez_render_content_query.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/query_rendering_functions/ez_render_content_query.test
@@ -27,6 +27,7 @@ array (
     ),
      'query' => 
     array (
+      'page' => 1,
     ),
   )),
   1 => 'inline',

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/query_rendering_functions/ez_render_content_query_esi.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/query_rendering_functions/ez_render_content_query_esi.test
@@ -27,6 +27,7 @@ array (
     ),
      'query' => 
     array (
+      'page' => 1,
     ),
   )),
   1 => 'esi',

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/query_rendering_functions/ez_render_content_query_with_pagination.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/query_rendering_functions/ez_render_content_query_with_pagination.test
@@ -1,9 +1,14 @@
 --TEST--
-"ez_render_location_query_esi" function
+"ez_render_content_query_b" function
 --TEMPLATE--
-{{ ez_render_location_query_esi({
+{{ ez_render_content_query({
     'query': {
         'query_type': 'LatestBlogPost',
+    },
+   'pagination': {
+        'enabled': true,
+        'limit': 5,
+        'page_param' : 'current_page'
     },
     'template': 'latest_blog_post.html.twig',
 }) }}
@@ -22,15 +27,21 @@ array (
         array (
           'query_type' => 'LatestBlogPost',
         ),
+        'pagination' => 
+        array (
+          'enabled' => true,
+          'limit' => 5,
+          'page_param' => 'current_page',
+        ),
         'template' => 'latest_blog_post.html.twig',
       ),
     ),
      'query' => 
     array (
-      'page' => 1,
+      'current_page' => 1,
     ),
   )),
-  1 => 'esi',
+  1 => 'inline',
   2 => 
   array (
   ),

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/query_rendering_functions/ez_render_location_query.test
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Tests/Twig/Extension/_fixtures/query_rendering_functions/ez_render_location_query.test
@@ -27,6 +27,7 @@ array (
     ),
      'query' => 
     array (
+      'page' => 1,
     ),
   )),
   1 => 'inline',

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/QueryRenderingExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/QueryRenderingExtension.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\MVC\Symfony\Templating\Twig\Extension;
 
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Controller\ControllerReference;
 use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 use Twig\Extension\AbstractExtension;
@@ -21,9 +22,13 @@ class QueryRenderingExtension extends AbstractExtension
     /** @var \Symfony\Component\HttpKernel\Fragment\FragmentHandler */
     private $fragmentHandler;
 
-    public function __construct(FragmentHandler $fragmentHandler)
+    /** @var \Symfony\Component\HttpFoundation\RequestStack */
+    private $requestStack;
+
+    public function __construct(FragmentHandler $fragmentHandler, RequestStack $requestStack)
     {
         $this->fragmentHandler = $fragmentHandler;
+        $this->requestStack = $requestStack;
     }
 
     public function getFunctions(): array
@@ -57,9 +62,15 @@ class QueryRenderingExtension extends AbstractExtension
 
     private function createControllerReference(array $options): ControllerReference
     {
-        return new ControllerReference('ez_query_render::renderQuery', [
-            'options' => $options,
-        ]);
+        $pageParam = isset($options['pagination']['page_param']) ? $options['pagination']['page_param'] : 'page';
+
+        return new ControllerReference(
+            'ez_query_render::renderQuery',
+            [
+                'options' => $options,
+            ],
+            [$pageParam => $this->requestStack->getCurrentRequest()->get($pageParam)],
+        );
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/QueryRenderingExtension.php
+++ b/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/QueryRenderingExtension.php
@@ -62,7 +62,7 @@ class QueryRenderingExtension extends AbstractExtension
 
     private function createControllerReference(array $options): ControllerReference
     {
-        $pageParam = isset($options['pagination']['page_param']) ? $options['pagination']['page_param'] : 'page';
+        $pageParam = $options['pagination']['page_param'] ?? 'page';
 
         return new ControllerReference(
             'ez_query_render::renderQuery',


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2839](https://issues.ibexa.co/browse/IBX-2839)
| **Type**                                   | feature
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

The problem is that setting the page_param parameter in a template won't work:
```
{{ ez_render_content_query({
   'query': {
       'query_type': 'SearchWithLimit',
       'assign_results_to': 'productItems'
   },
   'pagination': {
        'enabled': true,
        'limit': 5,
        'page_param' : 'current_page'
    },
   'template': '@ezdesign/full/SearchWithLimitQueryType.html.twig',
  })
}}
```
Specifying a GET parameter named current_page won't affect the query result :
http://localhost:8080/tests/cs-9997-querytype-and-limit?current_page=2


This is because the twig function will issue a subrequest and the GET variable specified by the `page_param` parameter won't be passed on to the subrequest :

https://github.com/ezsystems/ezplatform-kernel/blob/v1.3.17/eZ/Publish/Core/MVC/Symfony/Templating/Twig/Extension/QueryRenderingExtension.php#L37-L39

In this PR I just pass on the `page_param` to the subrequest


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
