### PR TITLE
IBX-2825: Implemented `Location` target

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LanguageLimitationIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Limitation/PermissionResolver/LanguageLimitationIntegrationTest.php
@@ -139,7 +139,7 @@ class LanguageLimitationIntegrationTest extends BaseLimitationIntegrationTest
             'edit',
             $limitations,
             $contentInfo,
-            [$location]
+            [$location, $content->getVersionInfo()]
         );
     }
 

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -650,7 +650,7 @@ class LanguageLimitationTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testHideAndUnhideLocationAndContentWithLanguageLimitationAndDifferentContentTranslations(
+    public function testHideAndUnhideLocationWithLanguageLimitationAndDifferentContentTranslations(
         array $limitationValues,
         bool $containsAllTranslations
     ): void {
@@ -681,7 +681,38 @@ class LanguageLimitationTest extends BaseTest
                 $content->getVersionInfo()->languageCodes,
                 $revealedLocation->getContent()->getVersionInfo()->languageCodes
             );
+        } else {
+            self::expectException(UnauthorizedException::class);
 
+            $locationService->hideLocation($location);
+
+            self::expectException(UnauthorizedException::class);
+
+            $locationService->unhideLocation($location);
+        }
+    }
+
+    /**
+     * @dataProvider providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testHideAndRevealContentWithLanguageLimitationAndDifferentContentTranslations(
+        array $limitationValues,
+        bool $containsAllTranslations
+    ): void {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $content = $this->testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
+            $limitationValues,
+            $containsAllTranslations
+        );
+
+        if ($containsAllTranslations) {
             $contentService->hideContent($content->contentInfo);
 
             $content = $contentService->loadContent($content->id);
@@ -694,14 +725,6 @@ class LanguageLimitationTest extends BaseTest
 
             self::assertFalse($content->contentInfo->isHidden);
         } else {
-            self::expectException(UnauthorizedException::class);
-
-            $locationService->hideLocation($location);
-
-            self::expectException(UnauthorizedException::class);
-
-            $locationService->unhideLocation($location);
-
             self::expectException(UnauthorizedException::class);
 
             $contentService->hideContent($content->contentInfo);

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -721,6 +721,9 @@ class LanguageLimitationTest extends BaseTest
         return $content;
     }
 
+    /**
+     * @return iterable<array{array<string>, bool}>
+     */
     public function providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(): array
     {
         return [

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -494,99 +494,215 @@ class LanguageLimitationTest extends BaseTest
     }
 
     /**
+     * @dataProvider providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testCopyContentWithTranslationsDifferentThanLanguageLimitation(): void
-    {
+    public function testCopyContentWithLanguageLimitationAndDifferentContentTranslations(
+        array $limitationValues,
+        bool $containsAllTranslations
+    ): void {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
 
-        $content = $this->testPrepareDataForTestsWithTranslationsDifferentThanLanguageLimitation();
+        $content = $this->testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
+            $limitationValues,
+            $containsAllTranslations
+        );
 
         $locationCreateStruct = new LocationCreateStruct(['parentLocationId' => 2]);
 
-        self::expectException(UnauthorizedException::class);
+        if ($containsAllTranslations) {
+            $clonedContent = $contentService->copyContent($content->contentInfo, $locationCreateStruct);
 
-        $contentService->copyContent($content->contentInfo, $locationCreateStruct);
+            self::assertSame($content->getVersionInfo()->languageCodes, $clonedContent->getVersionInfo()->languageCodes);
+        } else {
+            self::expectException(UnauthorizedException::class);
+
+            $contentService->copyContent($content->contentInfo, $locationCreateStruct);
+        }
     }
 
     /**
+     * @dataProvider providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testCopySubtreeWithTranslationsDifferentThanLanguageLimitation(): void
-    {
+    public function testCopySubtreeWithLanguageLimitationAndDifferentContentTranslations(
+        array $limitationValues,
+        bool $containsAllTranslations
+    ): void {
         $repository = $this->getRepository();
         $locationService = $repository->getLocationService();
 
-        $content = $this->testPrepareDataForTestsWithTranslationsDifferentThanLanguageLimitation();
+        $content = $this->testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
+            $limitationValues,
+            $containsAllTranslations
+        );
 
         $contentLocation = $locationService->loadLocation($content->contentInfo->mainLocationId);
         $targetLocation = $locationService->loadLocation(2);
 
-        self::expectException(UnauthorizedException::class);
+        if ($containsAllTranslations) {
+            $location = $locationService->copySubtree($contentLocation, $targetLocation);
 
-        $locationService->copySubtree($contentLocation, $targetLocation);
+            self::assertSame(
+                $content->getVersionInfo()->languageCodes,
+                $location->getContent()->getVersionInfo()->languageCodes
+            );
+        } else {
+            self::expectException(UnauthorizedException::class);
+
+            $locationService->copySubtree($contentLocation, $targetLocation);
+        }
     }
 
     /**
+     * @dataProvider providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testMoveSubtreeWithTranslationsDifferentThanLanguageLimitation(): void
-    {
+    public function testMoveSubtreeWithLanguageLimitationAndDifferentContentTranslations(
+        array $limitationValues,
+        bool $containsAllTranslations
+    ): void {
         $repository = $this->getRepository();
         $locationService = $repository->getLocationService();
         $contentService = $repository->getContentService();
 
         $targetContent = $this->createMultilingualFolderDraft($contentService);
-        $content = $this->testPrepareDataForTestsWithTranslationsDifferentThanLanguageLimitation();
+        $content = $this->testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
+            $limitationValues,
+            $containsAllTranslations
+        );
 
         $contentLocation = $locationService->loadLocation($content->contentInfo->mainLocationId);
         $targetLocation = $locationService->loadLocation($targetContent->contentInfo->mainLocationId);
 
-        self::expectException(UnauthorizedException::class);
+        if ($containsAllTranslations) {
+            $locationService->moveSubtree($contentLocation, $targetLocation);
+            $targetLocation = $locationService->loadLocation($targetLocation->id);
 
-        $locationService->moveSubtree($contentLocation, $targetLocation);
+            self::assertSame(
+                $content->getVersionInfo()->languageCodes,
+                $targetLocation->getContent()->getVersionInfo()->languageCodes
+            );
+        } else {
+            self::expectException(UnauthorizedException::class);
+
+            $locationService->moveSubtree($contentLocation, $targetLocation);
+        }
     }
 
     /**
+     * @dataProvider providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testHideLocationWithTranslationsDifferentThanLanguageLimitation(): void
-    {
+    public function testHideLocationWithLanguageLimitationAndDifferentContentTranslations(
+        array $limitationValues,
+        bool $containsAllTranslations
+    ): void {
         $repository = $this->getRepository();
         $locationService = $repository->getLocationService();
 
-        $content = $this->testPrepareDataForTestsWithTranslationsDifferentThanLanguageLimitation();
+        $content = $this->testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
+            $limitationValues,
+            $containsAllTranslations
+        );
 
         $location = $locationService->loadLocation($content->contentInfo->mainLocationId);
 
-        self::expectException(UnauthorizedException::class);
+        if ($containsAllTranslations) {
+            $locationService->hideLocation($location);
+            $hiddenLocation = $locationService->loadLocation($location->id);
 
-        $locationService->hideLocation($location);
+            self::assertSame(
+                $content->getVersionInfo()->languageCodes,
+                $hiddenLocation->getContent()->getVersionInfo()->languageCodes
+            );
+        } else {
+            self::expectException(UnauthorizedException::class);
+
+            $locationService->hideLocation($location);
+        }
     }
 
     /**
+     * @dataProvider providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testHideAndUnhideLocationWithLanguageLimitationAndDifferentContentTranslations(
+        array $limitationValues,
+        bool $containsAllTranslations
+    ): void {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $content = $this->testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
+            $limitationValues,
+            $containsAllTranslations
+        );
+
+        $location = $locationService->loadLocation($content->contentInfo->mainLocationId);
+
+        if ($containsAllTranslations) {
+            $locationService->hideLocation($location);
+            $hiddenLocation = $locationService->loadLocation($location->id);
+
+            self::assertSame(
+                $content->getVersionInfo()->languageCodes,
+                $hiddenLocation->getContent()->getVersionInfo()->languageCodes
+            );
+
+            $locationService->unhideLocation($location);
+            $revealedLocation = $locationService->loadLocation($location->id);
+
+            self::assertSame(
+                $content->getVersionInfo()->languageCodes,
+                $revealedLocation->getContent()->getVersionInfo()->languageCodes
+            );
+        } else {
+            self::expectException(UnauthorizedException::class);
+
+            $locationService->hideLocation($location);
+
+            self::expectException(UnauthorizedException::class);
+
+            $locationService->unhideLocation($location);
+        }
+    }
+
+    /**
+     * @dataProvider providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations
+     *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      */
-    public function testPrepareDataForTestsWithTranslationsDifferentThanLanguageLimitation(): Content
-    {
+    public function testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
+        array $limitationValues,
+        bool $containsAllTranslations
+    ): Content {
         $repository = $this->getRepository();
         $contentService = $repository->getContentService();
         $permissionResolver = $repository->getPermissionResolver();
@@ -594,61 +710,23 @@ class LanguageLimitationTest extends BaseTest
         $draft = $this->createMultilingualFolderDraft($contentService);
         $content = $contentService->publishVersion($draft->getVersionInfo());
 
-        $limitationLanguages = [self::GER_DE];
-
-        // Validate that limitation value doesn't contain all version's languages
-        self::assertNotEmpty(array_diff($content->getVersionInfo()->languageCodes, $limitationLanguages));
+        $containsAllTranslations
+            ? self::assertEmpty(array_diff($content->getVersionInfo()->languageCodes, $limitationValues))
+            : self::assertNotEmpty(array_diff($content->getVersionInfo()->languageCodes, $limitationValues));
 
         $permissionResolver->setCurrentUserReference(
-            $this->createEditorUserWithLanguageLimitation($limitationLanguages)
+            $this->createEditorUserWithLanguageLimitation($limitationValues)
         );
 
         return $content;
     }
 
-    public function testCopyMoveHideAndUnhideContentWithLanguageLimitationsContainingAllTranslations(): void
+    public function providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(): array
     {
-        $repository = $this->getRepository();
-        $contentService = $repository->getContentService();
-        $locationService = $repository->getLocationService();
-        $permissionResolver = $repository->getPermissionResolver();
-
-        $draft = $this->createMultilingualFolderDraft($contentService);
-        $content = $contentService->publishVersion($draft->getVersionInfo());
-
-        $limitationLanguages = [self::GER_DE, self::ENG_US, self::ENG_GB];
-
-        // Validate that limitation value contains all version's languages
-        self::assertEmpty(array_diff($content->getVersionInfo()->languageCodes, $limitationLanguages));
-
-        $permissionResolver->setCurrentUserReference(
-            $this->createEditorUserWithLanguageLimitation($limitationLanguages)
-        );
-
-        // Copy
-        $locationCreateStruct = new LocationCreateStruct(['parentLocationId' => 2]);
-        $clonedContent = $contentService->copyContent($content->contentInfo, $locationCreateStruct);
-
-        self::assertSame($content->getVersionInfo()->languageCodes, $clonedContent->getVersionInfo()->languageCodes);
-
-        // Move
-        $targetContent = $this->createMultilingualFolderDraft($contentService);
-        $contentLocation = $locationService->loadLocation($content->contentInfo->mainLocationId);
-        $targetLocation = $locationService->loadLocation($targetContent->contentInfo->mainLocationId);
-
-        $locationService->moveSubtree($contentLocation, $targetLocation);
-
-        self::assertSame($content->getVersionInfo()->languageCodes, $targetContent->getVersionInfo()->languageCodes);
-
-        // Hide
-        $hiddenLocation = $locationService->hideLocation($targetLocation);
-        $hiddenLocationContent = $hiddenLocation->getContent();
-        self::assertSame($content->getVersionInfo()->languageCodes, $hiddenLocationContent->getVersionInfo()->languageCodes);
-
-        // Unhide
-        $revealedLocation = $locationService->unhideLocation($hiddenLocation);
-        $revealedLocationContent = $revealedLocation->getContent();
-        self::assertSame($content->getVersionInfo()->languageCodes, $revealedLocationContent->getVersionInfo()->languageCodes);
+        return [
+            [[self::GER_DE], false],
+            [[self::GER_DE, self::ENG_US, self::ENG_GB], true],
+        ];
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -650,12 +650,13 @@ class LanguageLimitationTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testHideAndUnhideLocationWithLanguageLimitationAndDifferentContentTranslations(
+    public function testHideAndUnhideLocationAndContentWithLanguageLimitationAndDifferentContentTranslations(
         array $limitationValues,
         bool $containsAllTranslations
     ): void {
         $repository = $this->getRepository();
         $locationService = $repository->getLocationService();
+        $contentService = $repository->getContentService();
 
         $content = $this->testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
             $limitationValues,
@@ -680,6 +681,18 @@ class LanguageLimitationTest extends BaseTest
                 $content->getVersionInfo()->languageCodes,
                 $revealedLocation->getContent()->getVersionInfo()->languageCodes
             );
+
+            $contentService->hideContent($content->contentInfo);
+
+            $content = $contentService->loadContent($content->id);
+
+            self::assertTrue($content->contentInfo->isHidden);
+
+            $contentService->revealContent($content->contentInfo);
+
+            $content = $contentService->loadContent($content->id);
+
+            self::assertFalse($content->contentInfo->isHidden);
         } else {
             self::expectException(UnauthorizedException::class);
 
@@ -688,6 +701,14 @@ class LanguageLimitationTest extends BaseTest
             self::expectException(UnauthorizedException::class);
 
             $locationService->unhideLocation($location);
+
+            self::expectException(UnauthorizedException::class);
+
+            $contentService->hideContent($content->contentInfo);
+
+            self::expectException(UnauthorizedException::class);
+
+            $contentService->revealContent($content->contentInfo);
         }
     }
 

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -650,6 +650,45 @@ class LanguageLimitationTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
+    public function testSwapLocationWithLanguageLimitationAndDifferentContentTranslations(
+        array $limitationValues,
+        bool $containsAllTranslations
+    ): void {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $content = $this->testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
+            $limitationValues,
+            $containsAllTranslations
+        );
+
+        $location = $locationService->loadLocation($content->contentInfo->mainLocationId);
+        $location2 = $locationService->loadLocation(2);
+
+        if ($containsAllTranslations) {
+            $locationService->swapLocation($location2, $location);
+
+            $location = $locationService->loadLocation($location2->id);
+
+            self::assertSame(
+                $content->getVersionInfo()->languageCodes,
+                $location->getContent()->getVersionInfo()->languageCodes
+            );
+        } else {
+            self::expectException(UnauthorizedException::class);
+
+            $locationService->swapLocation($location, $location2);
+        }
+    }
+
+    /**
+     * @dataProvider providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
     public function testHideAndUnhideLocationWithLanguageLimitationAndDifferentContentTranslations(
         array $limitationValues,
         bool $containsAllTranslations

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -513,7 +513,11 @@ class LanguageLimitationTest extends BaseTest
         $locationCreateStruct = new LocationCreateStruct(['parentLocationId' => 2]);
         $content = $contentService->copyContent($content->contentInfo, $locationCreateStruct);
 
-        self::assertInstanceOf(Content::class, $content);
+        self::assertNotSame(self::GER_DE, $content->getVersionInfo()->initialLanguageCode);
+
+        $clonedContent = $contentService->loadContent($content->id);
+
+        self::assertSame($content->getVersionInfo()->languageCodes, $clonedContent->getVersionInfo()->languageCodes);
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -613,43 +613,6 @@ class LanguageLimitationTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testHideLocationWithLanguageLimitationAndDifferentContentTranslations(
-        array $limitationValues,
-        bool $containsAllTranslations
-    ): void {
-        $repository = $this->getRepository();
-        $locationService = $repository->getLocationService();
-
-        $content = $this->testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
-            $limitationValues,
-            $containsAllTranslations
-        );
-
-        $location = $locationService->loadLocation($content->contentInfo->mainLocationId);
-
-        if ($containsAllTranslations) {
-            $locationService->hideLocation($location);
-            $hiddenLocation = $locationService->loadLocation($location->id);
-
-            self::assertSame(
-                $content->getVersionInfo()->languageCodes,
-                $hiddenLocation->getContent()->getVersionInfo()->languageCodes
-            );
-        } else {
-            self::expectException(UnauthorizedException::class);
-
-            $locationService->hideLocation($location);
-        }
-    }
-
-    /**
-     * @dataProvider providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations
-     *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     */
     public function testSwapLocationWithLanguageLimitationAndDifferentContentTranslations(
         array $limitationValues,
         bool $containsAllTranslations
@@ -689,7 +652,7 @@ class LanguageLimitationTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testHideAndUnhideLocationWithLanguageLimitationAndDifferentContentTranslations(
+    public function testHideLocationWithLanguageLimitationAndDifferentContentTranslations(
         array $limitationValues,
         bool $containsAllTranslations
     ): void {
@@ -711,7 +674,36 @@ class LanguageLimitationTest extends BaseTest
                 $content->getVersionInfo()->languageCodes,
                 $hiddenLocation->getContent()->getVersionInfo()->languageCodes
             );
+        } else {
+            self::expectException(UnauthorizedException::class);
 
+            $locationService->hideLocation($location);
+        }
+    }
+
+    /**
+     * @dataProvider providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testUnhideLocationWithLanguageLimitationAndDifferentContentTranslations(
+        array $limitationValues,
+        bool $containsAllTranslations
+    ): void {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $content = $this->testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
+            $limitationValues,
+            $containsAllTranslations
+        );
+
+        $location = $locationService->loadLocation($content->contentInfo->mainLocationId);
+
+        if ($containsAllTranslations) {
             $locationService->unhideLocation($location);
             $revealedLocation = $locationService->loadLocation($location->id);
 
@@ -720,10 +712,6 @@ class LanguageLimitationTest extends BaseTest
                 $revealedLocation->getContent()->getVersionInfo()->languageCodes
             );
         } else {
-            self::expectException(UnauthorizedException::class);
-
-            $locationService->hideLocation($location);
-
             self::expectException(UnauthorizedException::class);
 
             $locationService->unhideLocation($location);
@@ -738,7 +726,7 @@ class LanguageLimitationTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
-    public function testHideAndRevealContentWithLanguageLimitationAndDifferentContentTranslations(
+    public function testHideContentWithLanguageLimitationAndDifferentContentTranslations(
         array $limitationValues,
         bool $containsAllTranslations
     ): void {
@@ -756,17 +744,40 @@ class LanguageLimitationTest extends BaseTest
             $content = $contentService->loadContent($content->id);
 
             self::assertTrue($content->contentInfo->isHidden);
+        } else {
+            self::expectException(UnauthorizedException::class);
 
+            $contentService->hideContent($content->contentInfo);
+        }
+    }
+
+    /**
+     * @dataProvider providerForPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     */
+    public function testRevealContentWithLanguageLimitationAndDifferentContentTranslations(
+        array $limitationValues,
+        bool $containsAllTranslations
+    ): void {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+
+        $content = $this->testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
+            $limitationValues,
+            $containsAllTranslations
+        );
+
+        if ($containsAllTranslations) {
             $contentService->revealContent($content->contentInfo);
 
             $content = $contentService->loadContent($content->id);
 
             self::assertFalse($content->contentInfo->isHidden);
         } else {
-            self::expectException(UnauthorizedException::class);
-
-            $contentService->hideContent($content->contentInfo);
-
             self::expectException(UnauthorizedException::class);
 
             $contentService->revealContent($content->contentInfo);

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -520,7 +520,7 @@ class LanguageLimitationTest extends BaseTest
 
             self::assertSame($content->getVersionInfo()->languageCodes, $clonedContent->getVersionInfo()->languageCodes);
         } else {
-            self::expectException(UnauthorizedException::class);
+            $this->expectException(UnauthorizedException::class);
 
             $contentService->copyContent($content->contentInfo, $locationCreateStruct);
         }
@@ -558,7 +558,7 @@ class LanguageLimitationTest extends BaseTest
                 $location->getContent()->getVersionInfo()->languageCodes
             );
         } else {
-            self::expectException(UnauthorizedException::class);
+            $this->expectException(UnauthorizedException::class);
 
             $locationService->copySubtree($contentLocation, $targetLocation);
         }
@@ -599,7 +599,7 @@ class LanguageLimitationTest extends BaseTest
                 $targetLocation->getContent()->getVersionInfo()->languageCodes
             );
         } else {
-            self::expectException(UnauthorizedException::class);
+            $this->expectException(UnauthorizedException::class);
 
             $locationService->moveSubtree($contentLocation, $targetLocation);
         }
@@ -638,7 +638,7 @@ class LanguageLimitationTest extends BaseTest
                 $location->getContent()->getVersionInfo()->languageCodes
             );
         } else {
-            self::expectException(UnauthorizedException::class);
+            $this->expectException(UnauthorizedException::class);
 
             $locationService->swapLocation($location, $location2);
         }
@@ -675,7 +675,7 @@ class LanguageLimitationTest extends BaseTest
                 $hiddenLocation->getContent()->getVersionInfo()->languageCodes
             );
         } else {
-            self::expectException(UnauthorizedException::class);
+            $this->expectException(UnauthorizedException::class);
 
             $locationService->hideLocation($location);
         }
@@ -712,7 +712,7 @@ class LanguageLimitationTest extends BaseTest
                 $revealedLocation->getContent()->getVersionInfo()->languageCodes
             );
         } else {
-            self::expectException(UnauthorizedException::class);
+            $this->expectException(UnauthorizedException::class);
 
             $locationService->unhideLocation($location);
         }
@@ -745,7 +745,7 @@ class LanguageLimitationTest extends BaseTest
 
             self::assertTrue($content->contentInfo->isHidden);
         } else {
-            self::expectException(UnauthorizedException::class);
+            $this->expectException(UnauthorizedException::class);
 
             $contentService->hideContent($content->contentInfo);
         }
@@ -778,7 +778,7 @@ class LanguageLimitationTest extends BaseTest
 
             self::assertFalse($content->contentInfo->isHidden);
         } else {
-            self::expectException(UnauthorizedException::class);
+            $this->expectException(UnauthorizedException::class);
 
             $contentService->revealContent($content->contentInfo);
         }

--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -656,7 +656,6 @@ class LanguageLimitationTest extends BaseTest
     ): void {
         $repository = $this->getRepository();
         $locationService = $repository->getLocationService();
-        $contentService = $repository->getContentService();
 
         $content = $this->testPrepareDataForTestsWithLanguageLimitationAndDifferentContentTranslations(
             $limitationValues,

--- a/eZ/Publish/Core/Limitation/LanguageLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitationType.php
@@ -281,7 +281,7 @@ class LanguageLimitationType implements SPITargetAwareLimitationType
 
         return empty(array_diff($versionInfo->languageCodes, $value->limitationValues))
             ? self::ACCESS_GRANTED
-            : self::ACCESS_ABSTAIN;
+            : self::ACCESS_DENIED;
     }
 
     /**

--- a/eZ/Publish/Core/Limitation/LanguageLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitationType.php
@@ -275,6 +275,9 @@ class LanguageLimitationType implements SPITargetAwareLimitationType
         APILimitationValue $value
     ): ?bool {
         $versionInfo = $this->loadVersionInfo($location->getTargetContentInfo());
+        if ($versionInfo === null) {
+            return self::ACCESS_DENIED;
+        }
 
         return array_intersect($versionInfo->languageCodes, $value->limitationValues)
             ? self::ACCESS_GRANTED

--- a/eZ/Publish/Core/Limitation/LanguageLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitationType.php
@@ -157,7 +157,7 @@ class LanguageLimitationType implements SPITargetAwareLimitationType
         foreach ($targets as $target) {
             if ($target instanceof Target\Version) {
                 $accessVote = $this->evaluateVersionTarget($target, $value);
-            } elseif ($target instanceof Location) {
+            } elseif ($target instanceof Location && count($targets) === 1) {
                 $accessVote = self::ACCESS_GRANTED;
             } else {
                 continue;

--- a/eZ/Publish/Core/Limitation/LanguageLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitationType.php
@@ -274,7 +274,7 @@ class LanguageLimitationType implements SPITargetAwareLimitationType
         DestinationLocationTarget $location,
         APILimitationValue $value
     ): ?bool {
-        $versionInfo = $this->loadVersionInfo($location->targetContentInfo);
+        $versionInfo = $this->loadVersionInfo($location->getTargetContentInfo());
 
         return array_intersect($versionInfo->languageCodes, $value->limitationValues)
             ? self::ACCESS_GRANTED

--- a/eZ/Publish/Core/Limitation/LanguageLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitationType.php
@@ -279,7 +279,7 @@ class LanguageLimitationType implements SPITargetAwareLimitationType
             return self::ACCESS_DENIED;
         }
 
-        return !array_diff($versionInfo->languageCodes, $value->limitationValues)
+        return empty(array_diff($versionInfo->languageCodes, $value->limitationValues))
             ? self::ACCESS_GRANTED
             : self::ACCESS_ABSTAIN;
     }

--- a/eZ/Publish/Core/Limitation/LanguageLimitationType.php
+++ b/eZ/Publish/Core/Limitation/LanguageLimitationType.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\Exceptions\NotFoundException;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\ContentCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 use eZ\Publish\API\Repository\Values\Content\Query\CriterionInterface;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
@@ -152,13 +153,15 @@ class LanguageLimitationType implements SPITargetAwareLimitationType
             $targets = [];
         }
 
-        // the main focus here is an intent to update to a new Version
+        // the main focus here is an intent to update to a new Version and validate if target is Location by any chance
         foreach ($targets as $target) {
-            if (!$target instanceof Target\Version) {
+            if ($target instanceof Target\Version) {
+                $accessVote = $this->evaluateVersionTarget($target, $value);
+            } elseif ($target instanceof Location) {
+                $accessVote = self::ACCESS_GRANTED;
+            } else {
                 continue;
             }
-
-            $accessVote = $this->evaluateVersionTarget($target, $value);
 
             // continue evaluation of targets if there was no explicit grant/deny
             if ($accessVote === self::ACCESS_ABSTAIN) {

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -64,6 +64,7 @@ use eZ\Publish\SPI\Persistence\Filter\Content\Handler as ContentFilteringHandler
 use eZ\Publish\SPI\Persistence\Handler;
 use eZ\Publish\SPI\Repository\Validator\ContentValidator;
 use eZ\Publish\SPI\Repository\Values\Filter\FilteringCriterion;
+use Ibexa\Contracts\Core\Limitation\Target\DestinationLocation as DestinationLocationTarget;
 use function sprintf;
 
 /**
@@ -1813,7 +1814,16 @@ class ContentService implements ContentServiceInterface
         $destinationLocation = $this->repository->getLocationService()->loadLocation(
             $destinationLocationCreateStruct->parentLocationId
         );
-        if (!$this->permissionResolver->canUser('content', 'create', $contentInfo, [$destinationLocation])) {
+
+        $locationTarget = (new DestinationLocationTarget(
+            ['id' => $destinationLocation->id, 'targetContentInfo' => $contentInfo]
+        ));
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'create',
+            $contentInfo,
+            [$destinationLocation, $locationTarget],
+        )) {
             throw new UnauthorizedException(
                 'content',
                 'create',

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -2329,13 +2329,19 @@ class ContentService implements ContentServiceInterface
      *
      * Content hidden by this API can be revealed by revealContent API.
      *
-     * @see revealContent
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
     public function hideContent(ContentInfo $contentInfo): void
     {
-        if (!$this->permissionResolver->canUser('content', 'hide', $contentInfo)) {
+        $locationTarget = (new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo));
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'hide',
+            $contentInfo,
+            [$locationTarget]
+        )) {
             throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
         }
 
@@ -2363,13 +2369,19 @@ class ContentService implements ContentServiceInterface
      * Reveals Content hidden by hideContent API.
      * Locations which were hidden before hiding Content will remain hidden.
      *
-     * @see hideContent
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
     public function revealContent(ContentInfo $contentInfo): void
     {
-        if (!$this->permissionResolver->canUser('content', 'hide', $contentInfo)) {
+        $locationTarget = (new DestinationLocationTarget($contentInfo->mainLocationId, $contentInfo));
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'hide',
+            $contentInfo,
+            [$locationTarget]
+        )) {
             throw new UnauthorizedException('content', 'hide', ['contentId' => $contentInfo->id]);
         }
 

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1815,9 +1815,7 @@ class ContentService implements ContentServiceInterface
             $destinationLocationCreateStruct->parentLocationId
         );
 
-        $locationTarget = (new DestinationLocationTarget(
-            ['id' => $destinationLocation->id, 'targetContentInfo' => $contentInfo]
-        ));
+        $locationTarget = (new DestinationLocationTarget($destinationLocation->id, $contentInfo));
         if (!$this->permissionResolver->canUser(
             'content',
             'create',

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -44,6 +44,7 @@ use eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct;
 use eZ\Publish\SPI\Persistence\Filter\Location\Handler as LocationFilteringHandler;
 use eZ\Publish\SPI\Persistence\Handler;
 use eZ\Publish\SPI\Repository\Values\Filter\FilteringCriterion;
+use Ibexa\Contracts\Core\Limitation\Target\DestinationLocation as DestinationLocationTarget;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -461,7 +462,10 @@ class LocationService implements LocationServiceInterface
             throw new UnauthorizedException('content', 'manage_locations', ['contentId' => $contentInfo->id]);
         }
 
-        if (!$this->permissionResolver->canUser('content', 'create', $contentInfo, [$parentLocation])) {
+        $locationTarget = (new DestinationLocationTarget(
+            ['id' => $parentLocation->id, 'targetContentInfo' => $contentInfo]
+        ));
+        if (!$this->permissionResolver->canUser('content', 'create', $contentInfo, [$parentLocation, $locationTarget])) {
             throw new UnauthorizedException('content', 'create', ['locationId' => $parentLocation->id]);
         }
 

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -571,11 +571,24 @@ class LocationService implements LocationServiceInterface
     {
         $loadedLocation1 = $this->loadLocation($location1->id);
         $loadedLocation2 = $this->loadLocation($location2->id);
+        $locationTarget1 = (new DestinationLocationTarget($loadedLocation1->id, $loadedLocation1->contentInfo));
+        $locationTarget2 = (new DestinationLocationTarget($loadedLocation2->id, $loadedLocation2->contentInfo));
 
-        if (!$this->permissionResolver->canUser('content', 'edit', $loadedLocation1->getContentInfo(), [$loadedLocation1])) {
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'edit',
+            $loadedLocation1->getContentInfo(),
+            [$loadedLocation1, $locationTarget1]
+        )) {
             throw new UnauthorizedException('content', 'edit', ['locationId' => $loadedLocation1->id]);
         }
-        if (!$this->permissionResolver->canUser('content', 'edit', $loadedLocation2->getContentInfo(), [$loadedLocation2])) {
+
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'edit',
+            $loadedLocation2->getContentInfo(),
+            [$loadedLocation2, $locationTarget2]
+        )) {
             throw new UnauthorizedException('content', 'edit', ['locationId' => $loadedLocation2->id]);
         }
 

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -148,7 +148,13 @@ class LocationService implements LocationServiceInterface
         }
 
         // check create permission on target
-        if (!$this->permissionResolver->canUser('content', 'create', $loadedSubtree->getContentInfo(), [$loadedTargetLocation])) {
+        $locationTarget = (new DestinationLocationTarget($targetParentLocation->id, $loadedSubtree->contentInfo));
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'create',
+            $loadedSubtree->getContentInfo(),
+            [$loadedTargetLocation, $locationTarget]
+        )) {
             throw new UnauthorizedException('content', 'create', ['locationId' => $loadedTargetLocation->id]);
         }
 
@@ -633,7 +639,13 @@ class LocationService implements LocationServiceInterface
      */
     public function hideLocation(APILocation $location): APILocation
     {
-        if (!$this->permissionResolver->canUser('content', 'hide', $location->getContentInfo(), [$location])) {
+        $locationTarget = (new DestinationLocationTarget($location->id, $location->contentInfo));
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'hide',
+            $location->getContentInfo(),
+            [$location, $locationTarget]
+        )) {
             throw new UnauthorizedException('content', 'hide', ['locationId' => $location->id]);
         }
 
@@ -663,7 +675,13 @@ class LocationService implements LocationServiceInterface
      */
     public function unhideLocation(APILocation $location): APILocation
     {
-        if (!$this->permissionResolver->canUser('content', 'hide', $location->getContentInfo(), [$location])) {
+        $locationTarget = (new DestinationLocationTarget($location->id, $location->contentInfo));
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'hide',
+            $location->getContentInfo(),
+            [$location, $locationTarget]
+        )) {
             throw new UnauthorizedException('content', 'hide', ['locationId' => $location->id]);
         }
 
@@ -708,7 +726,13 @@ class LocationService implements LocationServiceInterface
         }
 
         // check create permission on target location
-        if (!$this->permissionResolver->canUser('content', 'create', $location->getContentInfo(), [$newParentLocation])) {
+        $locationTarget = (new DestinationLocationTarget($newParentLocation->id, $location->contentInfo));
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'create',
+            $location->getContentInfo(),
+            [$newParentLocation, $locationTarget]
+        )) {
             throw new UnauthorizedException('content', 'create', ['locationId' => $newParentLocation->id]);
         }
 

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -462,9 +462,7 @@ class LocationService implements LocationServiceInterface
             throw new UnauthorizedException('content', 'manage_locations', ['contentId' => $contentInfo->id]);
         }
 
-        $locationTarget = (new DestinationLocationTarget(
-            ['id' => $parentLocation->id, 'targetContentInfo' => $contentInfo]
-        ));
+        $locationTarget = (new DestinationLocationTarget($parentLocation->id, $contentInfo));
         if (!$this->permissionResolver->canUser('content', 'create', $contentInfo, [$parentLocation, $locationTarget])) {
             throw new UnauthorizedException('content', 'create', ['locationId' => $parentLocation->id]);
         }

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -966,7 +966,9 @@ class LocationService implements LocationServiceInterface
         );
         if ($contentReadCriterion === false) {
             throw new UnauthorizedException('content', 'read');
-        } elseif ($contentReadCriterion !== true) {
+        }
+
+        if ($contentReadCriterion !== true) {
             // Query if there are any content in subtree current user don't have access to
             $query = new Query(
                 [

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -445,21 +445,6 @@ class PermissionResolver implements PermissionResolverInterface
             return $isTargetAware ? [] : null;
         }
 
-        // BC: for TargetAware Limitations return only instances of Target, for others return only non-Target instances
-        $targets = array_filter(
-            $targets,
-            static function ($target) use ($isTargetAware) {
-                $isTarget = $target instanceof Target;
-
-                return $isTargetAware ? $isTarget : !$isTarget;
-            }
-        );
-
-        // BC: treat empty targets after filtering as if they were empty the whole time
-        if (!$isTargetAware && empty($targets)) {
-            return null;
-        }
-
         return $targets;
     }
 }

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -20,7 +20,6 @@ use eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue;
 use eZ\Publish\Core\MVC\ConfigResolverInterface;
 use eZ\Publish\Core\Repository\Mapper\RoleDomainMapper;
 use eZ\Publish\Core\Repository\Values\User\UserReference;
-use eZ\Publish\SPI\Limitation\Target;
 use eZ\Publish\SPI\Limitation\TargetAwareType;
 use eZ\Publish\SPI\Limitation\Type as LimitationType;
 use eZ\Publish\SPI\Persistence\User\Handler as UserHandler;

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5777,9 +5777,7 @@ class ContentTest extends BaseServiceMockTest
             ->with('sectionId')
             ->will(self::returnValue(42));
 
-        $destinationLocationTarget = (new DestinationLocation(
-            ['id' => $locationCreateStruct->parentLocationId, 'targetContentInfo' => $contentInfo]
-        ));
+        $destinationLocationTarget = (new DestinationLocation($locationCreateStruct->parentLocationId, $contentInfo));
         $permissionResolver
             ->method('canUser')
             ->with(

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5873,9 +5873,7 @@ class ContentTest extends BaseServiceMockTest
         $repositoryMock->expects($this->once())->method('beginTransaction');
         $repositoryMock->expects($this->once())->method('commit');
 
-        $destinationLocationTarget = (new DestinationLocation(
-            ['id' => $locationCreateStruct->parentLocationId, 'targetContentInfo' => $contentInfoMock]
-        ));
+        $destinationLocationTarget = (new DestinationLocation($locationCreateStruct->parentLocationId, $contentInfoMock));
         $permissionResolverMock
             ->method('canUser')
             ->withConsecutive(
@@ -6007,9 +6005,7 @@ class ContentTest extends BaseServiceMockTest
         $repositoryMock->expects($this->once())->method('beginTransaction');
         $repositoryMock->expects($this->once())->method('commit');
 
-        $destinationLocationTarget = (new DestinationLocation(
-            ['id' => $locationCreateStruct->parentLocationId, 'targetContentInfo' => $contentInfoMock]
-        ));
+        $destinationLocationTarget = (new DestinationLocation($locationCreateStruct->parentLocationId, $contentInfoMock));
         $permissionResolverMock
             ->method('canUser')
             ->withConsecutive(
@@ -6115,9 +6111,7 @@ class ContentTest extends BaseServiceMockTest
         $repositoryMock->expects($this->once())->method('beginTransaction');
         $repositoryMock->expects($this->once())->method('rollback');
 
-        $destinationLocationTarget = (new DestinationLocation(
-            ['id' => $locationCreateStruct->parentLocationId, 'targetContentInfo' => $contentInfoMock]
-        ));
+        $destinationLocationTarget = (new DestinationLocation($locationCreateStruct->parentLocationId, $contentInfoMock));
         $permissionResolverMock
             ->method('canUser')
             ->withConsecutive(

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -54,6 +54,7 @@ use eZ\Publish\SPI\Persistence\Content\ObjectState as SPIObjectState;
 use eZ\Publish\SPI\Persistence\Content\ObjectState\Group as SPIObjectStateGroup;
 use eZ\Publish\SPI\Persistence\Content\UpdateStruct as SPIContentUpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo as SPIVersionInfo;
+use Ibexa\Contracts\Core\Limitation\Target\DestinationLocation;
 
 /**
  * Mock test case for Content service.
@@ -5760,31 +5761,34 @@ class ContentTest extends BaseServiceMockTest
         $locationServiceMock = $this->getLocationServiceMock();
         $permissionResolver = $this->getPermissionResolverMock();
 
-        $repository->expects($this->once())
+        $repository->expects(self::once())
             ->method('getLocationService')
-            ->will($this->returnValue($locationServiceMock));
+            ->will(self::returnValue($locationServiceMock));
 
-        $locationServiceMock->expects($this->once())
+        $locationServiceMock->expects(self::once())
             ->method('loadLocation')
             ->with(
                 $locationCreateStruct->parentLocationId
             )
-            ->will($this->returnValue($location));
+            ->will(self::returnValue($location));
 
-        $contentInfo->expects($this->any())
+        $contentInfo->expects(self::any())
             ->method('__get')
             ->with('sectionId')
-            ->will($this->returnValue(42));
+            ->will(self::returnValue(42));
 
+        $destinationLocationTarget = (new DestinationLocation(
+            ['id' => $locationCreateStruct->parentLocationId, 'targetContentInfo' => $contentInfo]
+        ));
         $permissionResolver
             ->method('canUser')
             ->with(
                 'content',
                 'create',
                 $contentInfo,
-                [$location]
+                [$location, $destinationLocationTarget]
             )
-            ->will($this->returnValue(false));
+            ->will(self::returnValue(false));
 
         /* @var \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo */
         $contentService->copyContent($contentInfo, $locationCreateStruct);
@@ -5869,14 +5873,16 @@ class ContentTest extends BaseServiceMockTest
         $repositoryMock->expects($this->once())->method('beginTransaction');
         $repositoryMock->expects($this->once())->method('commit');
 
+        $destinationLocationTarget = (new DestinationLocation(
+            ['id' => $locationCreateStruct->parentLocationId, 'targetContentInfo' => $contentInfoMock]
+        ));
         $permissionResolverMock
             ->method('canUser')
-            ->willReturnMap(
-                [
-                    ['content', 'create', $contentInfoMock, [$location], true],
-                    ['content', 'manage_locations', $contentInfoMock, [$location], true],
-                ]
-            );
+            ->withConsecutive(
+                ['content', 'create', $contentInfoMock, [$location, $destinationLocationTarget]],
+                ['content', 'manage_locations', $contentInfoMock, [$location]],
+            )
+            ->willReturnOnConsecutiveCalls(true, true);
 
         $spiContentInfo = new SPIContentInfo(['id' => 42]);
         $spiVersionInfo = new SPIVersionInfo(
@@ -6001,14 +6007,16 @@ class ContentTest extends BaseServiceMockTest
         $repositoryMock->expects($this->once())->method('beginTransaction');
         $repositoryMock->expects($this->once())->method('commit');
 
+        $destinationLocationTarget = (new DestinationLocation(
+            ['id' => $locationCreateStruct->parentLocationId, 'targetContentInfo' => $contentInfoMock]
+        ));
         $permissionResolverMock
             ->method('canUser')
-            ->willReturnMap(
-                [
-                    ['content', 'create', $contentInfoMock, [$location], true],
-                    ['content', 'manage_locations', $contentInfoMock, [$location], true],
-                ]
-            );
+            ->withConsecutive(
+                ['content', 'create', $contentInfoMock, [$location, $destinationLocationTarget]],
+                ['content', 'manage_locations', $contentInfoMock, [$location]],
+            )
+            ->willReturnOnConsecutiveCalls(true, true);
 
         $spiContentInfo = new SPIContentInfo(['id' => 42]);
         $spiVersionInfo = new SPIVersionInfo(
@@ -6107,14 +6115,16 @@ class ContentTest extends BaseServiceMockTest
         $repositoryMock->expects($this->once())->method('beginTransaction');
         $repositoryMock->expects($this->once())->method('rollback');
 
+        $destinationLocationTarget = (new DestinationLocation(
+            ['id' => $locationCreateStruct->parentLocationId, 'targetContentInfo' => $contentInfoMock]
+        ));
         $permissionResolverMock
             ->method('canUser')
-            ->willReturnMap(
-                [
-                    ['content', 'create', $contentInfoMock, [$location], true],
-                    ['content', 'manage_locations', $contentInfoMock, [$location], true],
-                ]
-            );
+            ->withConsecutive(
+                ['content', 'create', $contentInfoMock, [$location, $destinationLocationTarget]],
+                ['content', 'manage_locations', $contentInfoMock, [$location]],
+            )
+            ->willReturnOnConsecutiveCalls(true, true);
 
         $contentHandlerMock->expects($this->once())
             ->method('copy')

--- a/eZ/Publish/SPI/Limitation/Target/Builder/VersionBuilder.php
+++ b/eZ/Publish/SPI/Limitation/Target/Builder/VersionBuilder.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace eZ\Publish\SPI\Limitation\Target\Builder;
 
-use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Field;
 use eZ\Publish\API\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Base\Exceptions\InvalidArgumentException;

--- a/src/contracts/Limitation/Target/DestinationLocation.php
+++ b/src/contracts/Limitation/Target/DestinationLocation.php
@@ -18,22 +18,22 @@ use eZ\Publish\SPI\Persistence\ValueObject;
 final class DestinationLocation extends ValueObject implements Target
 {
     /** @var int */
-    private $id;
+    private $locationId;
 
     /** @var \eZ\Publish\API\Repository\Values\Content\ContentInfo */
     private $targetContentInfo;
 
-    public function __construct(int $id, ContentInfo $targetContentInfo, array $properties = [])
+    public function __construct(int $locationId, ContentInfo $targetContentInfo, array $properties = [])
     {
-        $this->id = $id;
+        $this->locationId = $locationId;
         $this->targetContentInfo = $targetContentInfo;
 
         parent::__construct($properties);
     }
 
-    public function getId(): int
+    public function getLocationId(): int
     {
-        return $this->id;
+        return $this->locationId;
     }
 
     public function getTargetContentInfo(): ContentInfo

--- a/src/contracts/Limitation/Target/DestinationLocation.php
+++ b/src/contracts/Limitation/Target/DestinationLocation.php
@@ -8,24 +8,36 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Limitation\Target;
 
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
 use eZ\Publish\SPI\Limitation\Target;
 use eZ\Publish\SPI\Persistence\ValueObject;
 
 /**
  * Location Limitation target.
- *
- * @property-read int $id
- * @property-read \eZ\Publish\API\Repository\Values\Content\ContentInfo $targetContentInfo
  */
-class DestinationLocation extends ValueObject implements Target
+final class DestinationLocation extends ValueObject implements Target
 {
-    /**
-     * @var int
-     */
-    protected $id;
+    /** @var int */
+    private $id;
 
-    /**
-     * @var \eZ\Publish\API\Repository\Values\Content\ContentInfo
-     */
-    protected $targetContentInfo;
+    /** @var \eZ\Publish\API\Repository\Values\Content\ContentInfo */
+    private $targetContentInfo;
+
+    public function __construct(int $id, ContentInfo $targetContentInfo, array $properties = [])
+    {
+        $this->id = $id;
+        $this->targetContentInfo = $targetContentInfo;
+
+        parent::__construct($properties);
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getTargetContentInfo(): ContentInfo
+    {
+        return $this->targetContentInfo;
+    }
 }

--- a/src/contracts/Limitation/Target/DestinationLocation.php
+++ b/src/contracts/Limitation/Target/DestinationLocation.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Limitation\Target;
+
+use eZ\Publish\SPI\Limitation\Target;
+use eZ\Publish\SPI\Persistence\ValueObject;
+
+/**
+ * Location Limitation target.
+ *
+ * @property-read int $id
+ * @property-read \eZ\Publish\API\Repository\Values\Content\ContentInfo $targetContentInfo
+ */
+class DestinationLocation extends ValueObject implements Target
+{
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var \eZ\Publish\API\Repository\Values\Content\ContentInfo
+     */
+    protected $targetContentInfo;
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2825](https://issues.ibexa.co/browse/IBX-2825)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

`Location` target in Language Limitation will now verify if all content's translations are contained in the current user's languages in his Language Limitation. If that is the case the Limitation will pass, if not it will deny the access.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
