### PR TITLE
IBX-2618: Optimized search indexing performance

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -343,7 +343,7 @@ class ReindexCommand extends Command implements BackwardCompatibleCommand
                             sprintf(
                                 'Child indexer process returned: %s - %s',
                                 $process->getExitCodeText(),
-                                $process->getOutput()
+                                $process->getErrorOutput()
                             )
                         );
                     }

--- a/eZ/Publish/Core/Base/Container/Compiler/Search/AggregateFieldValueMapperPass.php
+++ b/eZ/Publish/Core/Base/Container/Compiler/Search/AggregateFieldValueMapperPass.php
@@ -15,27 +15,27 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class AggregateFieldValueMapperPass implements CompilerPassInterface
 {
+    public const SERVICE_ID = 'ezpublish.search.common.field_value_mapper.aggregate';
+    public const TAG = 'ezpublish.search.common.field_value_mapper';
+
     /**
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
-        if (!$container->hasDefinition('ezpublish.search.common.field_value_mapper.aggregate')) {
+        if (!$container->hasDefinition(self::SERVICE_ID)) {
             return;
         }
 
-        $aggregateFieldValueMapperDefinition = $container->getDefinition(
-            'ezpublish.search.common.field_value_mapper.aggregate'
-        );
-
-        $taggedServiceIds = $container->findTaggedServiceIds(
-            'ezpublish.search.common.field_value_mapper'
-        );
-        foreach ($taggedServiceIds as $id => $attributes) {
-            $aggregateFieldValueMapperDefinition->addMethodCall(
-                'addMapper',
-                [new Reference($id)]
-            );
+        $aggregateFieldValueMapperDefinition = $container->getDefinition(self::SERVICE_ID);
+        $taggedServiceIds = $container->findTaggedServiceIds(self::TAG);
+        foreach ($taggedServiceIds as $id => $tags) {
+            foreach ($tags as $tagAttributes) {
+                $aggregateFieldValueMapperDefinition->addMethodCall(
+                    'addMapper',
+                    [new Reference($id), $tagAttributes['maps'] ?? null]
+                );
+            }
         }
     }
 }

--- a/eZ/Publish/Core/Search/Common/FieldNameGenerator.php
+++ b/eZ/Publish/Core/Search/Common/FieldNameGenerator.php
@@ -68,23 +68,14 @@ class FieldNameGenerator
      * types, or names.
      *
      * Only the field with the name 'id' remains untouched.
-     *
-     * @param string $name
-     * @param \eZ\Publish\SPI\Search\FieldType $type
-     *
-     * @return string
      */
-    public function getTypedName($name, FieldType $type)
+    public function getTypedName(string $name, FieldType $type): string
     {
         if ($name === 'id') {
             return $name;
         }
 
-        $typeName = $type->type;
-
-        if (isset($this->fieldNameMapping[$typeName])) {
-            $typeName = $this->fieldNameMapping[$typeName];
-        }
+        $typeName = $this->fieldNameMapping[$type->getType()] ?? $type->getType();
 
         return $name . '_' . $typeName;
     }

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/Aggregate.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/Aggregate.php
@@ -41,6 +41,9 @@ class Aggregate extends FieldValueMapper
         }
     }
 
+    /**
+     * @param class-string<\eZ\Publish\SPI\Search\Field>|null $searchTypeFQCN
+     */
     public function addMapper(FieldValueMapper $mapper, ?string $searchTypeFQCN = null): void
     {
         if (null !== $searchTypeFQCN) {

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/Aggregate.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/Aggregate.php
@@ -34,24 +34,12 @@ class Aggregate extends FieldValueMapper
         }
     }
 
-    /**
-     * Adds mapper.
-     *
-     * @param \eZ\Publish\Core\Search\Common\FieldValueMapper $mapper
-     */
-    public function addMapper(FieldValueMapper $mapper)
+    public function addMapper(FieldValueMapper $mapper): void
     {
         $this->mappers[] = $mapper;
     }
 
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
         return true;
     }
@@ -74,7 +62,7 @@ class Aggregate extends FieldValueMapper
         }
 
         throw new NotImplementedException(
-            'No mapper available for: ' . get_class($field->type)
+            'No mapper available for: ' . get_class($field->getType())
         );
     }
 }

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/BooleanMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/BooleanMapper.php
@@ -15,27 +15,13 @@ use eZ\Publish\SPI\Search\FieldType\BooleanField;
  */
 class BooleanMapper extends FieldValueMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
-        return $field->type instanceof BooleanField;
+        return $field->getType() instanceof BooleanField;
     }
 
-    /**
-     * Map field value to a proper search engine representation.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return mixed
-     */
     public function map(Field $field)
     {
-        return (bool)$field->value;
+        return (bool)$field->getValue();
     }
 }

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/DateMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/DateMapper.php
@@ -18,34 +18,21 @@ use InvalidArgumentException;
  */
 class DateMapper extends FieldValueMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return mixed
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
-        return $field->type instanceof DateField;
+        return $field->getType() instanceof DateField;
     }
 
-    /**
-     * Map field value to a proper search engine representation.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return mixed
-     */
     public function map(Field $field)
     {
-        if (is_numeric($field->value)) {
-            $date = new DateTime("@{$field->value}");
+        $value = $field->getValue();
+        if (is_numeric($value)) {
+            $date = new DateTime("@{$value}");
         } else {
             try {
-                $date = new DateTime($field->value);
+                $date = new DateTime($value);
             } catch (Exception $e) {
-                throw new InvalidArgumentException('Invalid date provided: ' . $field->value);
+                throw new InvalidArgumentException('Invalid date provided: ' . $value);
             }
         }
 

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/DocumentMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/DocumentMapper.php
@@ -15,27 +15,13 @@ use eZ\Publish\SPI\Search\FieldType\DocumentField;
  */
 class DocumentMapper extends FieldValueMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
-        return $field->type instanceof DocumentField;
+        return $field->getType() instanceof DocumentField;
     }
 
-    /**
-     * Map field value to a proper search engine representation.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return mixed
-     */
     public function map(Field $field)
     {
-        return $field->value;
+        return $field->getValue();
     }
 }

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/FloatMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/FloatMapper.php
@@ -15,27 +15,13 @@ use eZ\Publish\SPI\Search\FieldType\FloatField;
  */
 class FloatMapper extends FieldValueMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
-        return $field->type instanceof FloatField;
+        return $field->getType() instanceof FloatField;
     }
 
-    /**
-     * Map field value to a proper search engine representation.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return mixed
-     */
     public function map(Field $field)
     {
-        return sprintf('%F', (float)$field->value);
+        return sprintf('%F', (float)$field->getValue());
     }
 }

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/GeoLocationMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/GeoLocationMapper.php
@@ -15,31 +15,18 @@ use eZ\Publish\SPI\Search\FieldType\GeoLocationField;
  */
 class GeoLocationMapper extends FieldValueMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
-        return $field->type instanceof GeoLocationField;
+        return $field->getType() instanceof GeoLocationField;
     }
 
-    /**
-     * Map field value to a proper search engine representation.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return mixed|null Returns null on empty value
-     */
     public function map(Field $field)
     {
-        if ($field->value['latitude'] === null || $field->value['longitude'] === null) {
+        $value = $field->getValue();
+        if ($value['latitude'] === null || $value['longitude'] === null) {
             return null;
         }
 
-        return sprintf('%F,%F', $field->value['latitude'], $field->value['longitude']);
+        return sprintf('%F,%F', $value['latitude'], $value['longitude']);
     }
 }

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/IdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/IdentifierMapper.php
@@ -15,16 +15,9 @@ use eZ\Publish\SPI\Search\FieldType\IdentifierField;
  */
 class IdentifierMapper extends FieldValueMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
-        return $field->type instanceof IdentifierField;
+        return $field->getType() instanceof IdentifierField;
     }
 
     /**
@@ -36,21 +29,19 @@ class IdentifierMapper extends FieldValueMapper
      */
     public function map(Field $field)
     {
-        if ($field->type->raw) {
-            return $field->value;
+        if ($field->getType()->raw) {
+            return $field->getValue();
         }
 
-        return $this->convert($field->value);
+        return $this->convert($field->getValue());
     }
 
     /**
      * Convert to a proper search engine representation.
      *
      * @param mixed $value
-     *
-     * @return string
      */
-    protected function convert($value)
+    protected function convert($value): string
     {
         // Remove non-printable characters
         return preg_replace('([^A-Za-z0-9/]+)', '', $value);

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/IntegerMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/IntegerMapper.php
@@ -15,38 +15,22 @@ use eZ\Publish\SPI\Search\FieldType\IntegerField;
  */
 class IntegerMapper extends FieldValueMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
-        return $field->type instanceof IntegerField;
+        return $field->getType() instanceof IntegerField;
     }
 
-    /**
-     * Map field value to a proper search engine representation.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return mixed
-     */
     public function map(Field $field)
     {
-        return $this->convert($field->value);
+        return $this->convert($field->getValue());
     }
 
     /**
      * Convert to a proper search engine representation.
      *
      * @param mixed $value
-     *
-     * @return int
      */
-    protected function convert($value)
+    protected function convert($value): int
     {
         return (int)$value;
     }

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleBooleanMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleBooleanMapper.php
@@ -15,30 +15,16 @@ use eZ\Publish\SPI\Search\FieldType\MultipleBooleanField;
  */
 class MultipleBooleanMapper extends FieldValueMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
-        return $field->type instanceof MultipleBooleanField;
+        return $field->getType() instanceof MultipleBooleanField;
     }
 
-    /**
-     * Map field value to a proper search engine representation.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return mixed
-     */
     public function map(Field $field)
     {
         $values = [];
 
-        foreach ((array)$field->value as $value) {
+        foreach ((array)$field->getValue() as $value) {
             $values[] = (bool)$value;
         }
 

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleIdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleIdentifierMapper.php
@@ -14,16 +14,9 @@ use eZ\Publish\SPI\Search\FieldType\MultipleIdentifierField;
  */
 class MultipleIdentifierMapper extends IdentifierMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
-        return $field->type instanceof MultipleIdentifierField;
+        return $field->getType() instanceof MultipleIdentifierField;
     }
 
     /**
@@ -37,8 +30,9 @@ class MultipleIdentifierMapper extends IdentifierMapper
     {
         $values = [];
 
-        foreach ($field->value as $value) {
-            if (!$field->type->raw) {
+        $isRaw = $field->getType()->raw;
+        foreach ($field->getValue() as $value) {
+            if (!$isRaw) {
                 $value = $this->convert($value);
             }
 

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleIntegerMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleIntegerMapper.php
@@ -14,30 +14,16 @@ use eZ\Publish\SPI\Search\FieldType\MultipleIntegerField;
  */
 class MultipleIntegerMapper extends IntegerMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
-        return $field->type instanceof MultipleIntegerField;
+        return $field->getType() instanceof MultipleIntegerField;
     }
 
-    /**
-     * Map field value to a proper search engine representation.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return array
-     */
     public function map(Field $field)
     {
         $values = [];
 
-        foreach ((array)$field->value as $value) {
+        foreach ((array)$field->getValue() as $value) {
             $values[] = $this->convert($value);
         }
 

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleRemoteIdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleRemoteIdentifierMapper.php
@@ -14,23 +14,16 @@ use eZ\Publish\SPI\Search\FieldType\MultipleRemoteIdentifierField;
  */
 final class MultipleRemoteIdentifierMapper extends RemoteIdentifierMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
     public function canMap(Field $field): bool
     {
-        return $field->type instanceof MultipleRemoteIdentifierField;
+        return $field->getType() instanceof MultipleRemoteIdentifierField;
     }
 
     public function map(Field $field)
     {
         $values = [];
 
-        foreach ($field->value as $value) {
+        foreach ($field->getValue() as $value) {
             $values[] = $this->convert($value);
         }
 

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleStringMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/MultipleStringMapper.php
@@ -14,19 +14,14 @@ use eZ\Publish\SPI\Search\FieldType;
  */
 class MultipleStringMapper extends StringMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
+        $searchFieldType = $field->getType();
+
         return
-            $field->type instanceof FieldType\MultipleStringField ||
-            $field->type instanceof FieldType\TextField ||
-            $field->type instanceof FieldType\FullTextField;
+            $searchFieldType instanceof FieldType\MultipleStringField ||
+            $searchFieldType instanceof FieldType\TextField ||
+            $searchFieldType instanceof FieldType\FullTextField;
     }
 
     /**
@@ -40,7 +35,7 @@ class MultipleStringMapper extends StringMapper
     {
         $values = [];
 
-        foreach ((array)$field->value as $value) {
+        foreach ((array)$field->getValue() as $value) {
             $values[] = $this->convert($value);
         }
 

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/PriceMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/PriceMapper.php
@@ -15,16 +15,9 @@ use eZ\Publish\SPI\Search\FieldType\PriceField;
  */
 class PriceMapper extends FieldValueMapper
 {
-    /**
-     * Check if field can be mapped.
-     *
-     * @param \eZ\Publish\SPI\Search\Field $field
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
-        return $field->type instanceof PriceField;
+        return $field->getType() instanceof PriceField;
     }
 
     /**
@@ -36,6 +29,6 @@ class PriceMapper extends FieldValueMapper
      */
     public function map(Field $field)
     {
-        return (float)$field->value;
+        return (float)$field->getValue();
     }
 }

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/RemoteIdentifierMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/RemoteIdentifierMapper.php
@@ -20,6 +20,6 @@ class RemoteIdentifierMapper extends StringMapper
 {
     public function canMap(Field $field): bool
     {
-        return $field->type instanceof RemoteIdentifierField;
+        return $field->getType() instanceof RemoteIdentifierField;
     }
 }

--- a/eZ/Publish/Core/Search/Common/FieldValueMapper/StringMapper.php
+++ b/eZ/Publish/Core/Search/Common/FieldValueMapper/StringMapper.php
@@ -18,35 +18,22 @@ class StringMapper extends FieldValueMapper
     public const REPLACE_WITH_SPACE_PATTERN = '([\x09\x0B\x0C]+)';
     public const REMOVE_PATTERN = '([\x00-\x08\x0E-\x1F]+)';
 
-    /**
-     * Check if field can be mapped.
-     *
-     * @return bool
-     */
-    public function canMap(Field $field)
+    public function canMap(Field $field): bool
     {
-        return
-            $field->type instanceof FieldType\StringField;
+        return $field->getType() instanceof FieldType\StringField;
     }
 
-    /**
-     * Map field value to a proper search engine representation.
-     *
-     * @return mixed
-     */
     public function map(Field $field)
     {
-        return $this->convert($field->value);
+        return $this->convert($field->getValue());
     }
 
     /**
      * Convert to a proper search engine representation.
      *
      * @param mixed $value
-     *
-     * @return string
      */
-    protected function convert($value)
+    protected function convert($value): string
     {
         // Replace tab, vertical tab, form-feed chars to single space.
         $value = preg_replace(

--- a/eZ/Publish/Core/settings/search_engines/field_value_mappers.yml
+++ b/eZ/Publish/Core/settings/search_engines/field_value_mappers.yml
@@ -2,72 +2,74 @@ services:
     ezpublish.search.common.field_value_mapper.boolean:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\BooleanMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\BooleanField }
 
     ezpublish.search.common.field_value_mapper.date:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\DateMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\DateField }
 
     ezpublish.search.common.field_value_mapper.document:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\DocumentMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\DocumentField }
 
     ezpublish.search.common.field_value_mapper.geo_location:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\GeoLocationMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\GeoLocationField }
 
     ezpublish.search.common.field_value_mapper.float:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\FloatMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\FloatField }
 
     ezpublish.search.common.field_value_mapper.identifier:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\IdentifierMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\IdentifierField }
 
     ezpublish.search.common.field_value_mapper.multiple_integer:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\MultipleIntegerMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\MultipleIntegerField }
 
     ezpublish.search.common.field_value_mapper.integer:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\IntegerMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\IntegerField }
 
     ezpublish.search.common.field_value_mapper.multiple_boolean:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\MultipleBooleanMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\MultipleBooleanField }
 
     ezpublish.search.common.field_value_mapper.multiple_identifier:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\MultipleIdentifierMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\MultipleIdentifierField }
 
     ezpublish.search.common.field_value_mapper.multiple_string:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\MultipleStringMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\MultipleStringField }
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\TextField }
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\FullTextField }
 
     ezpublish.search.common.field_value_mapper.price:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\PriceMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\PriceField }
 
     ezpublish.search.common.field_value_mapper.string:
         class: eZ\Publish\Core\Search\Common\FieldValueMapper\StringMapper
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\StringField }
 
     eZ\Publish\Core\Search\Common\FieldValueMapper\RemoteIdentifierMapper:
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\RemoteIdentifierField }
 
     eZ\Publish\Core\Search\Common\FieldValueMapper\MultipleRemoteIdentifierMapper:
         tags:
-            - {name: ezpublish.search.common.field_value_mapper}
+            - { name: ezpublish.search.common.field_value_mapper, maps: eZ\Publish\SPI\Search\FieldType\MultipleRemoteIdentifierField }

--- a/eZ/Publish/SPI/Search/Field.php
+++ b/eZ/Publish/SPI/Search/Field.php
@@ -36,16 +36,14 @@ class Field extends ValueObject
     /**
      * Type of the search field.
      *
-     * @var FieldType
+     * @var \eZ\Publish\SPI\Search\FieldType
      */
     protected $type;
 
     /**
-     * Construct from name and value.
-     *
      * @param string $name
      * @param mixed $value
-     * @param FieldType $type
+     * @param \eZ\Publish\SPI\Search\FieldType $type
      */
     public function __construct($name, $value, FieldType $type)
     {

--- a/eZ/Publish/SPI/Search/FieldType.php
+++ b/eZ/Publish/SPI/Search/FieldType.php
@@ -11,7 +11,7 @@ use eZ\Publish\SPI\Persistence\ValueObject;
 /**
  * Base class for document field definitions.
  *
- * @property-read string $type The type name of the facet
+ * @property-read string $type [deprecated] The type name of the facet, deprecated - use {@see \eZ\Publish\SPI\Search\FieldType::getType} instead.
  */
 abstract class FieldType extends ValueObject
 {
@@ -56,4 +56,9 @@ abstract class FieldType extends ValueObject
      * @var bool
      */
     public $inResult = true;
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
 }

--- a/tests/bundle/Core/DependencyInjection/Compiler/AggregateFieldValueMapperPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/AggregateFieldValueMapperPassTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\Core\DependencyInjection\Compiler;
+
+use eZ\Publish\Core\Base\Container\Compiler\Search\AggregateFieldValueMapperPass;
+use eZ\Publish\SPI\Search\FieldType\BooleanField;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
+
+class AggregateFieldValueMapperPassTest extends AbstractCompilerPassTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->setDefinition(AggregateFieldValueMapperPass::SERVICE_ID, new Definition());
+    }
+
+    protected function registerCompilerPass(ContainerBuilder $container): void
+    {
+        $container->addCompilerPass(new AggregateFieldValueMapperPass());
+    }
+
+    public function testAddMapper(): void
+    {
+        $booleanMapper = new Definition();
+        $fieldValueMapperServiceId = 'field_value_mapper_service_id';
+        $booleanMapper->addTag(
+            AggregateFieldValueMapperPass::TAG,
+            ['maps' => BooleanField::class]
+        );
+
+        $this->setDefinition($fieldValueMapperServiceId, $booleanMapper);
+        $this->compile();
+
+        $this->assertContainerBuilderHasServiceDefinitionWithMethodCall(
+            AggregateFieldValueMapperPass::SERVICE_ID,
+            'addMapper',
+            [new Reference($fieldValueMapperServiceId), BooleanField::class]
+        );
+    }
+}

--- a/tests/bundle/Core/DependencyInjection/Compiler/AggregateFieldValueMapperPassTest.php
+++ b/tests/bundle/Core/DependencyInjection/Compiler/AggregateFieldValueMapperPassTest.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
-class AggregateFieldValueMapperPassTest extends AbstractCompilerPassTestCase
+final class AggregateFieldValueMapperPassTest extends AbstractCompilerPassTestCase
 {
     protected function setUp(): void
     {

--- a/tests/integration/Core/Repository/SearchService/MultilingualContentSearchIndexingTest.php
+++ b/tests/integration/Core/Repository/SearchService/MultilingualContentSearchIndexingTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\Repository\SearchService;
+
+use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\Tests\BaseTest;
+use eZ\Publish\API\Repository\Values\Content\LanguageCreateStruct;
+use eZ\Publish\API\Repository\Values\Content\Query;
+use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
+
+class MultilingualContentSearchIndexingTest extends BaseTest
+{
+    private const MODIFIED_TRANSLATION = 'pol-PL';
+
+    private const LANGUAGES = [
+        'eng-US' => 'English (American)',
+        'eng-GB' => 'English (United Kingdom)',
+        self::MODIFIED_TRANSLATION => 'Polish (Poland)',
+        'nor-NO' => 'Norwegian (Norway)',
+        'ger-DE' => 'German (Germany)',
+        'afr-AF' => 'Afrikaans (South Africa)',
+        'ben-BN' => 'Bengali (Bangladesh)',
+        'cha-CH' => 'Chamorro (Guam)',
+        'cro-HR' => 'Croatian (Croatia)',
+        'cze-CS' => 'Czech (Czechia)',
+        'dan-DA' => 'Danish (Denmark)',
+        'esp-ES' => 'Spanish (Spain)',
+        'esp-MX' => 'Spanish (Mexico)',
+        'fra-CA' => 'French (Canada)',
+        'fra-FR' => 'French (France)',
+        'nld-NL' => 'Dutch (Netherlands)',
+        'por-PT' => 'Portuguese (Portugal)',
+        'slo-SK' => 'Slovak (Slovak Republic)',
+        'ukr-UA' => 'Ukrainian (Ukraine)',
+        'zho-ZH' => 'Chinese (China)',
+    ];
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\ForbiddenException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testPublishingSingleTranslationKeepsSearchIndexConsistent(): void
+    {
+        $repository = $this->getRepository();
+        $contentService = $repository->getContentService();
+        $searchService = $repository->getSearchService();
+        $this->createMissingLanguages($repository->getContentLanguageService());
+
+        // create Folder with a single translation
+        $folder = $this->createFolder(['eng-US' => 'Test eng-US']);
+
+        // add 20 translations
+        $folderUpdate = $contentService->newContentUpdateStruct();
+        $translations = array_keys(self::LANGUAGES);
+        foreach ($translations as $translation) {
+            $folderUpdate->setField('name', 'Test ' . $translation, $translation);
+        }
+        $folderDraft = $contentService->updateContent(
+            $contentService->createContentDraft($folder->contentInfo)->getVersionInfo(),
+            $folderUpdate
+        );
+        $folder = $contentService->publishVersion($folderDraft->getVersionInfo());
+
+        // update single translation
+        $folderUpdate = $contentService->newContentUpdateStruct();
+        $folderUpdate->setField('name', 'Updated Polish version', self::MODIFIED_TRANSLATION);
+        $folderDraft = $contentService->updateContent(
+            $contentService->createContentDraft($folder->contentInfo)->getVersionInfo(),
+            $folderUpdate
+        );
+        $folder = $contentService->publishVersion(
+            $folderDraft->getVersionInfo(),
+            [self::MODIFIED_TRANSLATION]
+        );
+
+        $this->refreshSearch($repository);
+
+        $query = new Query([
+            'filter' => new Criterion\ContentId(
+                [$folder->id]
+            ),
+        ]);
+        $searchResult = $searchService->findContent($query, ['languages' => $translations]);
+        self::assertSame(1, $searchResult->totalCount);
+        /** @var \eZ\Publish\API\Repository\Values\Content\Content $foundContent */
+        $foundContent = $searchResult->searchHits[0]->valueObject;
+        $expectedContentInfo = $foundContent->contentInfo;
+        $expectedVersionNo = $foundContent->getVersionInfo()->versionNo;
+
+        $searchResult = $searchService->findContent(
+            $query,
+            ['languages' => [self::MODIFIED_TRANSLATION]]
+        );
+        self::assertSame(1, $searchResult->totalCount);
+        /** @var \eZ\Publish\API\Repository\Values\Content\Content $foundContent */
+        $foundContent = $searchResult->searchHits[0]->valueObject;
+        self::assertEquals($expectedContentInfo, $foundContent->contentInfo);
+        self::assertEquals($expectedVersionNo, $foundContent->getVersionInfo()->versionNo);
+    }
+
+    /**
+     * Create required languages which are not pre-defined by Repository test setup.
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    private function createMissingLanguages(LanguageService $languageService): void
+    {
+        $languages = $languageService->loadLanguages();
+        $missingLanguages = array_diff(
+            array_keys(self::LANGUAGES),
+            array_column($languages, 'languageCode')
+        );
+
+        foreach ($missingLanguages as $languageCode) {
+            $languageService->createLanguage(
+                new LanguageCreateStruct(
+                    [
+                        'languageCode' => $languageCode,
+                        'name' => self::LANGUAGES[$languageCode],
+                        'enabled' => true,
+                    ]
+                )
+            );
+        }
+    }
+}

--- a/tests/integration/Core/Repository/SearchService/MultilingualContentSearchIndexingTest.php
+++ b/tests/integration/Core/Repository/SearchService/MultilingualContentSearchIndexingTest.php
@@ -14,7 +14,7 @@ use eZ\Publish\API\Repository\Values\Content\LanguageCreateStruct;
 use eZ\Publish\API\Repository\Values\Content\Query;
 use eZ\Publish\API\Repository\Values\Content\Query\Criterion;
 
-class MultilingualContentSearchIndexingTest extends BaseTest
+final class MultilingualContentSearchIndexingTest extends BaseTest
 {
     private const MODIFIED_TRANSLATION = 'pol-PL';
 

--- a/tests/lib/Search/Common/FieldValueMapper/AggregateTest.php
+++ b/tests/lib/Search/Common/FieldValueMapper/AggregateTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Search\Common\FieldValueMapper;
+
+use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
+use eZ\Publish\Core\Search\Common\FieldValueMapper\Aggregate;
+use eZ\Publish\Core\Search\Common\FieldValueMapper\BooleanMapper;
+use eZ\Publish\SPI\Search\Field;
+use eZ\Publish\SPI\Search\FieldType\BooleanField;
+use eZ\Publish\SPI\Search\FieldType\FloatField;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \eZ\Publish\Core\Search\Common\FieldValueMapper\Aggregate
+ */
+final class AggregateTest extends TestCase
+{
+    private const MAPPED_VALUE = true;
+
+    /** @var \eZ\Publish\Core\Search\Common\FieldValueMapper\Aggregate */
+    private $aggregateMapper;
+
+    public function setUp(): void
+    {
+        $this->aggregateMapper = new Aggregate();
+    }
+
+    public function testMapUsingSimpleMapper(): void
+    {
+        $booleanMapperMock = $this->createMock(BooleanMapper::class);
+        $this->aggregateMapper->addMapper($booleanMapperMock, BooleanField::class);
+
+        $booleanField = new BooleanField();
+        $searchFieldMock = $this->createMock(Field::class);
+        $searchFieldMock
+            ->method('getType')
+            ->willReturn($booleanField);
+        $booleanMapperMock
+            ->method('map')
+            ->with($searchFieldMock)
+            ->willReturn(self::MAPPED_VALUE);
+
+        self::assertSame(self::MAPPED_VALUE, $this->aggregateMapper->map($searchFieldMock));
+    }
+
+    public function testMapUsingCanMap(): void
+    {
+        $booleanMapper = new BooleanMapper();
+        $this->aggregateMapper->addMapper($booleanMapper);
+
+        $booleanField = new BooleanField();
+        $searchFieldMock = $this->createMock(Field::class);
+        $searchFieldMock
+            ->method('getType')
+            ->willReturn($booleanField);
+        $searchFieldMock
+            ->method('getValue')
+            ->willReturn(self::MAPPED_VALUE);
+
+        self::assertSame(self::MAPPED_VALUE, $this->aggregateMapper->map($searchFieldMock));
+    }
+
+    public function testMapThrowsNotImplementedException(): void
+    {
+        $booleanMapperMock = $this->createMock(BooleanMapper::class);
+        $this->aggregateMapper->addMapper($booleanMapperMock);
+
+        $floatFieldMock = $this->createMock(FloatField::class);
+        $searchFieldMock = $this->createMock(Field::class);
+        $searchFieldMock
+            ->method('getType')
+            ->willReturn($floatFieldMock);
+        $booleanMapperMock
+            ->method('canMap')
+            ->willReturn(false);
+
+        $this->expectException(NotImplementedException::class);
+        $this->expectExceptionMessage('No mapper available for: ' . get_class($floatFieldMock));
+        $this->aggregateMapper->map($searchFieldMock);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2618](https://issues.ibexa.co/browse/IBX-2618)
| **Requires**                            | ezsystems/ezplatform-solr-search-engine#235
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no

This PR optimizes several code paths performance related to the process of indexing. The PR is split into meaningful commits representing separate optimization changes:
* Search Field Value mappers were optimized to use strict `SPI\Search\Field` getters (#311) rather than magic `__get`
* Aggregate Field Value mapper was optimized to have O(1) rather than O(N) complexity when accessing concrete mappers
* `FieldNameGenerator::getTypedName` was simplified (irrelevant micro-optimization) and magic getter was replaced with the strict one.

## Road not taken

I've spent a lot of time trying to introduce partial search index updates for AdminUI publishing, which publishes only a single translation, copying 1:1 the others (via 2nd argument of `ContentService::publishVersion($versionInfo, [$translations]`). The idea was to load only specific translation(s) of a `Content` item and perform partial update for the remaining languages. Almost all went well, but in the end, when comparing Solr index contents before and after the changes, it turned out that nested `Location` documents were missing for the documents which were partially updated (for `Solr` the `Location`-related documents are nested inside `Content` documents). I haven't found a way to reindex them without reindexing the whole Content item and there seems to be no explanation for this in the Solr doc. The issue might be revisited after we process the first batch of optimization changes.


## TODO
- [x] See if this breaks anything (CI, regression tests)
- [x] Check on Elasticsearch
- [x] Remove TMP commit before merging
- [x] Hook the solution to blackfire to see performance changes

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
