### PR TITLE
Marked `Translation` class as implementing `Stringable`

### DIFF
--- a/eZ/Publish/API/Repository/Values/Translation.php
+++ b/eZ/Publish/API/Repository/Values/Translation.php
@@ -12,6 +12,8 @@ namespace eZ\Publish\API\Repository\Values;
  * Base class fro translation messages.
  *
  * Use its extensions: Translation\Singular, Translation\Plural.
+ *
+ * @implements \Stringable
  */
 abstract class Translation extends ValueObject
 {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR adds `Stringable` as phpdoc annotation to `eZ\Publish\API\Repository\Values\Translation`.

## Reasoning

When working with content validation it become apparent for me that this class is lacking `Stringable` interface. `Ibexa\Core\FieldType\ValidationError::getTranslatableMessage` returns a `Translation` object that - judging by our implementations: `Plural` & `Message` - should always have `__toString()` method.

Of course, `Stringable` did not exist at the moment when this code was written.

However, because there is no guarantee that user code that extends it does indeed implement this method, and because `Stringable` interface is available from PHP 8.0, I'm opting to mark the class as implementing it via phpdoc instead. Otherwise we could break user code or require a polyfill (which is in itself an option, due to it's lightweight nature).

We cannot simply add this method to `Translation` without hiding the fact that implementation is missing, because as per php docs:

> Warning
> It was not possible to throw an exception from within a [__toString()](https://www.php.net/manual/en/language.oop5.magic.php#object.tostring) method prior to PHP 7.4.0. Doing so will result in a fatal error.

I propose that for 3.3:
 * We add a phpdoc to `Translation` denoting the intent of implementing `Stringable`

but for 4.x:
 * We add a polyfill requirement for `symfony/polyfill-php80`
 * Directly implement `Stringable` in `Translation`
 * Add an exception throwing implementation `__toString()` method, so that user code does not break.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
