### PR TITLE
IBX-2844: Handled historic URL aliases cache invalidation

### DIFF
--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
@@ -1457,6 +1457,31 @@ class URLAliasServiceTest extends BaseTest
         $urlAliasService->refreshSystemUrlAliasesForLocation($nestedFolderLocation);
     }
 
+    public function testOverrideHistoryUrlAliasAtTheSameLocation(): void
+    {
+        $repository = $this->getRepository();
+        $urlAliasService = $repository->getURLAliasService();
+        $locationService = $repository->getLocationService();
+
+        $folderNames = ['eng-GB' => 'foo'];
+        $folder = $this->createFolder($folderNames, 2);
+
+        $location = $locationService->loadLocation($folder->contentInfo->mainLocationId);
+        $newLocation = $locationService->loadLocation(43);
+
+        $locationService->moveSubtree($location, $newLocation);
+
+        $urlAliasService->lookup('foo');
+        $urlAliasService->lookup('media/foo');
+
+        $newFolder = ['eng-GB' => 'foo'];
+        $this->createFolder($newFolder, 2);
+
+        $newAlias = $urlAliasService->lookup('foo');
+
+        self::assertFalse($newAlias->isHistory);
+    }
+
     /**
      * Lookup given URL and check if it is archived and points to the given Location Id.
      *

--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
@@ -1465,14 +1465,15 @@ class URLAliasServiceTest extends BaseTest
 
         $folderNames = ['eng-GB' => 'foo'];
         $folder = $this->createFolder($folderNames, 2);
+        $destinationFolder = $this->createFolder($folderNames, 2);
 
         $location = $locationService->loadLocation($folder->contentInfo->mainLocationId);
-        $newLocation = $locationService->loadLocation(43);
+        $destinationFolderLocation = $locationService->loadLocation($destinationFolder->contentInfo->mainLocationId);
 
-        $locationService->moveSubtree($location, $newLocation);
+        $locationService->moveSubtree($location, $destinationFolderLocation);
 
         $urlAliasService->lookup('foo');
-        $urlAliasService->lookup('media/foo');
+        $urlAliasService->lookup('foo2/foo');
 
         $newFolder = ['eng-GB' => 'foo'];
         $this->createFolder($newFolder, 2);

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -24,21 +24,45 @@ class UrlAliasHandlerTest extends AbstractInMemoryCacheHandlerTest
         return SPIUrlAliasHandler::class;
     }
 
+    public function testPublishUrlAliasForLocation(): void
+    {
+        $this->loggerMock->expects(self::once())->method('logCall');
+
+        $innerHandlerMock = $this->createMock($this->getHandlerClassName());
+        $this->persistenceHandlerMock
+            ->expects(self::once())
+            ->method('urlAliasHandler')
+            ->willReturn($innerHandlerMock);
+
+        $innerHandlerMock
+            ->expects(self::once())
+            ->method('publishUrlAliasForLocation')
+            ->with(44, 2, 'name', 'eng-GB', true, false);
+
+        $innerHandlerMock
+            ->expects(self::once())
+            ->method('listURLAliasesForLocation')
+            ->with(44)
+            ->willReturn([]);
+
+        $this->cacheIdentifierGeneratorMock
+            ->expects(self::exactly(3))
+            ->method('generateTag')
+            ->withConsecutive(
+                ['url_alias_location', [44], false],
+                ['url_alias_location_path', [44], false],
+                ['url_alias_not_found', [], false]
+            )
+            ->willReturnOnConsecutiveCalls('urlal-44', 'urlalp-44', 'urlanf');
+
+        $handler = $this->persistenceCacheHandler->urlAliasHandler();
+        $handler->publishUrlAliasForLocation(44, 2, 'name', 'eng-GB', true, false);
+    }
+
     public function providerForUnCachedMethods(): array
     {
         // string $method, array $arguments, array? $tagGeneratingArguments, array? $keyGeneratingArguments, array? $tags, array? $key, ?mixed $returnValue
         return [
-            [
-                'publishUrlAliasForLocation',
-                [44, 2, 'name', 'eng-GB', true, false],
-                [
-                    ['url_alias_location', [44], false],
-                    ['url_alias_location_path', [44], false],
-                    ['url_alias_not_found', [], false],
-                ],
-                null,
-                ['urlal-44', 'urlalp-44', 'urlanf'],
-            ],
             [
                 'createCustomUrlAlias',
                 [44, '1/2/44', true, null, false],

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -72,8 +72,8 @@ class UrlAliasHandler extends AbstractInMemoryPersistenceHandler implements UrlA
         }
 
         $existingLocationAliasesTags = [];
-        foreach ($existingLocationAliases ?? [] as $existingAlias) {
-            $existingLocationAliasesTags[] = $this->cacheIdentifierGenerator->generateKey(
+        foreach ($existingLocationAliases as $existingAlias) {
+            $existingLocationAliasesTags[] = $this->cacheIdentifierGenerator->generateTag(
                 self::URL_ALIAS_IDENTIFIER,
                 [$existingAlias->id]
             );

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache;
 
+use eZ\Publish\API\Repository\Exceptions\BadStateException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\SPI\Persistence\Content\UrlAlias;
@@ -64,7 +65,12 @@ class UrlAliasHandler extends AbstractInMemoryPersistenceHandler implements UrlA
             $updatePathIdentificationString
         );
 
-        $existingLocationAliases = $urlAliasHandler->listURLAliasesForLocation($locationId);
+        try {
+            $existingLocationAliases = $urlAliasHandler->listURLAliasesForLocation($locationId);
+        } catch (BadStateException $e) {
+            $existingLocationAliases = [];
+        }
+
         $existingLocationAliasesTags = [];
         foreach ($existingLocationAliases ?? [] as $existingAlias) {
             $existingLocationAliasesTags[] = $this->cacheIdentifierGenerator->generateKey(


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2844](https://issues.ibexa.co/browse/IBX-2844)
| **Type**                                   |bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

During publication, if there was exactly the same alias existing before (originating from moved content), but pointing to different content, such alias was not properly invalidated, hence it was still resolved as it was attached to moved content.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
