### PR TITLE
IBX-2880: Added PasswordExpiredException

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserCheckerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/Tests/UserCheckerTest.php
@@ -17,8 +17,8 @@ use eZ\Publish\Core\MVC\Symfony\Security\UserChecker;
 use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use eZ\Publish\Core\Repository\Values\User\User as APIUser;
+use Ibexa\Core\MVC\Symfony\Security\Exception\PasswordExpiredException;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Throwable;
 
@@ -156,7 +156,7 @@ final class UserCheckerTest extends TestCase
                 )
             );
 
-        $this->expectException(CredentialsExpiredException::class);
+        $this->expectException(PasswordExpiredException::class);
         $this->expectExceptionMessage('User account has expired.');
 
         $this->userChecker->checkPostAuth(new User($apiUser));

--- a/eZ/Publish/Core/MVC/Symfony/Security/UserChecker.php
+++ b/eZ/Publish/Core/MVC/Symfony/Security/UserChecker.php
@@ -10,7 +10,7 @@ namespace eZ\Publish\Core\MVC\Symfony\Security;
 
 use eZ\Publish\API\Repository\UserService;
 use eZ\Publish\Core\MVC\Symfony\Security\UserInterface as EzUserInterface;
-use Symfony\Component\Security\Core\Exception\CredentialsExpiredException;
+use Ibexa\Core\MVC\Symfony\Security\Exception\PasswordExpiredException;
 use Symfony\Component\Security\Core\Exception\DisabledException;
 use Symfony\Component\Security\Core\User\UserCheckerInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
@@ -46,7 +46,7 @@ final class UserChecker implements UserCheckerInterface
         }
 
         if ($this->userService->getPasswordInfo($user->getAPIUser())->isPasswordExpired()) {
-            $exception = new CredentialsExpiredException('User account has expired.');
+            $exception = new PasswordExpiredException('User account has expired.');
             $exception->setUser($user);
 
             throw $exception;

--- a/src/lib/MVC/Symfony/Security/Exception/PasswordExpiredException.php
+++ b/src/lib/MVC/Symfony/Security/Exception/PasswordExpiredException.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Core\MVC\Symfony\Security\Exception;
+
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
+
+class PasswordExpiredException extends CustomUserMessageAccountStatusException
+{
+    public function __construct(string $message = '')
+    {
+        parent::__construct($message);
+    }
+}

--- a/src/lib/MVC/Symfony/Security/Exception/PasswordExpiredException.php
+++ b/src/lib/MVC/Symfony/Security/Exception/PasswordExpiredException.php
@@ -8,7 +8,7 @@ namespace Ibexa\Core\MVC\Symfony\Security\Exception;
 
 use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusException;
 
-class PasswordExpiredException extends CustomUserMessageAccountStatusException
+final class PasswordExpiredException extends CustomUserMessageAccountStatusException
 {
     public function __construct(string $message = 'User account has expired.')
     {

--- a/src/lib/MVC/Symfony/Security/Exception/PasswordExpiredException.php
+++ b/src/lib/MVC/Symfony/Security/Exception/PasswordExpiredException.php
@@ -10,7 +10,7 @@ use Symfony\Component\Security\Core\Exception\CustomUserMessageAccountStatusExce
 
 class PasswordExpiredException extends CustomUserMessageAccountStatusException
 {
-    public function __construct(string $message = '')
+    public function __construct(string $message = 'User account has expired.')
     {
         parent::__construct($message);
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2880](https://issues.ibexa.co/browse/IBX-2880)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

[CredentialsExpiredListener](https://github.com/ezsystems/ezplatform-admin-ui/blob/2.3/src/lib/EventListener/CredentialsExpiredListener.php#L57) expects `CredentialsExpiredException` which will never happen, as the Exception is immediately replaced with `BadCredentialsException` in  https://github.com/symfony/security-core/blob/5.4/Authentication/Provider/UserAuthenticationProvider.php#L90

This PR adds a new `PasswordExpiredException` exception which extends `CustomUserMessageAccountStatusException` which allows for it to be propagated to the top so `CredentialsExpiredListener` can act properly when it happens.

AdminUI part of PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/2045

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
