### PR TITLE
EZP-30746: Fixed respecting hidden Content when moving subtree

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -3323,7 +3323,7 @@ class LocationServiceTest extends BaseTest
         $sourceFolderContent = $this->publishContentWithParentLocation('SourceFolder', $sourceLocationId); // media/SourceFolder
         $subFolderContent1 = $this->publishContentWithParentLocation('subFolderContent1', $sourceFolderContent->contentInfo->mainLocationId);
         $subFolderContent2 = $this->publishContentWithParentLocation('subFolderContent2', $sourceFolderContent->contentInfo->mainLocationId);
-        $targetFolderContent = $this->publishContentWithParentLocation('targetFolder', $sourceLocationId); // media/SourceFolder
+        $targetFolderContent = $this->publishContentWithParentLocation('targetFolder', $sourceLocationId); // media/TargetFolder
 
         $contentService->hideContent($sourceFolderContent->contentInfo);
 

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -3255,7 +3255,7 @@ class LocationServiceTest extends BaseTest
         $sourceFolderContent = $this->publishContentWithParentLocation('SourceFolder', $mediaLocationId); // media/SourceFolder
         $subFolderContent1 = $this->publishContentWithParentLocation('subFolderContent1', $sourceFolderContent->contentInfo->mainLocationId);
         $subFolderContent2 = $this->publishContentWithParentLocation('subFolderContent2', $sourceFolderContent->contentInfo->mainLocationId);
-        $targetFolderContent = $this->publishContentWithParentLocation('targetFolder', $mediaLocationId); // media/SourceFolder
+        $targetFolderContent = $this->publishContentWithParentLocation('targetFolder', $mediaLocationId); // media/TargetFolder
 
         $contentService->hideContent($subFolderContent1->contentInfo);
 

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/Location/Gateway/DoctrineDatabaseTest.php
@@ -151,6 +151,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $gateway->moveSubtreeNodes(
             [
                 'path_string' => '/1/2/69/',
+                'contentobject_id' => 67,
                 'path_identification_string' => 'products',
                 'is_hidden' => 0,
                 'is_invisible' => 0,
@@ -196,6 +197,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $gateway->moveSubtreeNodes(
             [
                 'path_string' => '/1/2/69/',
+                'contentobject_id' => 67,
                 'path_identification_string' => 'products',
                 'is_hidden' => 0,
                 'is_invisible' => 0,
@@ -241,6 +243,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $gateway->moveSubtreeNodes(
             [
                 'path_string' => '/1/2/69/',
+                'contentobject_id' => 67,
                 'path_identification_string' => 'products',
                 'is_hidden' => 1,
                 'is_invisible' => 1,
@@ -287,6 +290,7 @@ class DoctrineDatabaseTest extends LanguageAwareTestCase
         $gateway->moveSubtreeNodes(
             [
                 'path_string' => '/1/2/69/',
+                'contentobject_id' => 67,
                 'path_identification_string' => 'products',
                 'is_hidden' => 0,
                 'is_invisible' => 0,


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-30746](https://issues.ibexa.co/browse/EZP-30746)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

`DoctrineDatabase::moveSubtreeNodes` only consider `ezcontentobject_tree.is_hidden` column when checking if nodes are hidden or not.
Since https://github.com/ezsystems/ezpublish-kernel/pull/254], we also needs to check if locations are hidden due to visibility set on the object level (`ezcontentobject.is_hidden` column)

This is a replacement for https://github.com/ezsystems/ezpublish-kernel/pull/3142 which was classed as 2.5 went out of maintenance. The PR for 3.3 is much smaller as most of the helpers needed are already available in 1.3

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
