### PR TITLE
Added missing getter methods to Search Field class

### DIFF
--- a/eZ/Publish/SPI/Search/Field.php
+++ b/eZ/Publish/SPI/Search/Field.php
@@ -49,8 +49,27 @@ class Field extends ValueObject
      */
     public function __construct($name, $value, FieldType $type)
     {
+        parent::__construct();
         $this->name = $name;
         $this->value = $value;
         $this->type = $type;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getType(): FieldType
+    {
+        return $this->type;
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Added missing getter methods to Search Field class.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
