### PR TITLE
IBX-2934: Proxified `FieldsGroupsList` with `lazy`

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -217,9 +217,13 @@ services:
     eZ\Publish\Core\Pagination\Pagerfanta\AdapterFactory\SearchHitAdapterFactoryInterface:
         alias: eZ\Publish\Core\Pagination\Pagerfanta\AdapterFactory\SearchHitAdapterFactory
 
-    ezpublish.fields_groups.list:
-        class: eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList
-        factory: ["@ezpublish.fields_groups.list.repository_settings_factory", "build"]
+    eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList: '@ezpublish.fields_groups.list'
+
+    ezpublish.fields_groups.list: '@eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList'
+
+    eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList:
+        lazy: eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList
+        factory: [ "@ezpublish.fields_groups.list.repository_settings_factory", "build" ]
         arguments:
             - "@translator"
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -217,8 +217,6 @@ services:
     eZ\Publish\Core\Pagination\Pagerfanta\AdapterFactory\SearchHitAdapterFactoryInterface:
         alias: eZ\Publish\Core\Pagination\Pagerfanta\AdapterFactory\SearchHitAdapterFactory
 
-    eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList: '@ezpublish.fields_groups.list'
-
     ezpublish.fields_groups.list: '@eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList'
 
     eZ\Publish\Core\Helper\FieldsGroups\ArrayTranslatorFieldsGroupsList:

--- a/eZ/Publish/Core/settings/repository/autowire.yml
+++ b/eZ/Publish/Core/settings/repository/autowire.yml
@@ -26,3 +26,5 @@ services:
     eZ\Publish\API\Repository\PermissionService: '@eZ\Publish\Core\Repository\Permission\CachedPermissionService'
     eZ\Publish\API\Repository\PermissionResolver: '@eZ\Publish\API\Repository\PermissionService'
     eZ\Publish\API\Repository\PermissionCriterionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver'
+
+    eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList: '@ezpublish.fields_groups.list'

--- a/eZ/Publish/Core/settings/repository/autowire.yml
+++ b/eZ/Publish/Core/settings/repository/autowire.yml
@@ -26,5 +26,3 @@ services:
     eZ\Publish\API\Repository\PermissionService: '@eZ\Publish\Core\Repository\Permission\CachedPermissionService'
     eZ\Publish\API\Repository\PermissionResolver: '@eZ\Publish\API\Repository\PermissionService'
     eZ\Publish\API\Repository\PermissionCriterionResolver: '@eZ\Publish\Core\Repository\Permission\PermissionCriterionResolver'
-
-    eZ\Publish\Core\Helper\FieldsGroups\FieldsGroupsList: '@ezpublish.fields_groups.list'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2934](https://issues.ibexa.co/browse/IBX-2934)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Before the following service definition refactor the `FieldsGroupsList` service was instantiated too early resulting in Site Access not being properly matched before the repository configuration was resolved.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
