### PR TITLE
avoid duplacted image path for the same contentobject_attribute

### DIFF
--- a/eZ/Publish/Core/FieldType/Image/ImageStorage.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage.php
@@ -128,6 +128,9 @@ class ImageStorage extends GatewayBasedStorage
             $field->value->externalData = null;
         }
 
+        if ($this->gateway->hasImageReference($field->value->data['uri'], $field->id) === true) {
+            return true;
+        }
         $this->gateway->storeImageReference($field->value->data['uri'], $field->id);
 
         // Data has been updated and needs to be stored!

--- a/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
+++ b/eZ/Publish/Core/FieldType/Image/ImageStorage/Gateway.php
@@ -24,6 +24,15 @@ abstract class Gateway extends StorageGateway
     abstract public function getNodePathString(VersionInfo $versionInfo);
 
     /**
+     * return true if image reference already exists (avoid image duplication for the same contentobject_attribute_id) false otherwise
+     *
+     * @param string $uri File IO uri
+     * @param mixed $fieldId
+     * @return bool
+     */
+    abstract public function hasImageReference($uri, $fieldId): bool;
+
+    /**
      * Stores a reference to the image in $path for $fieldId.
      *
      * @param string $uri File IO uri


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [COM-20126](ttps://issues.ibexa.co/browse/COM-20126)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

How to check it:

- Create a content type 'picture' with title (eztring) and picture (ezimage) (you could also use the original existing 'image' content type
- Create a 'picture content' (upload a new picture) and publish it.
- Anew row is added to ezimagefile with contentobject_attribute_id and file path
- Edit that content again, in draft mode a new row is added in ezimagefile table with same filepath. (real use case)
- Publish the content again without changing the path, a new line is added to ezimagefile table without changing anything in the table.

So every published version of  the content will create two rows in ezimagefile (except first version). even if the path doesn't change.

Quick fix:

 - look for existing row With (contentobject_attribute_id, path) if there is one, we shouldn't create new One.

Notice:
https://issues.ibexa.co/browse/COM-20126
#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
