### PR TITLE
IBX-2618: Added skipped integration tests for Solr & fixed failing test

### DIFF
--- a/phpunit-integration-legacy-solr.xml
+++ b/phpunit-integration-legacy-solr.xml
@@ -66,6 +66,9 @@
         <testsuite name="eZ\Publish\API\Repository\Tests\Regression">
             <directory>eZ/Publish/API/Repository/Tests/Regression/</directory>
         </testsuite>
+        <testsuite name="ibexa-core-integration-tests">
+            <directory>tests/integration/Core</directory>
+        </testsuite>
     </testsuites>
     <filter>
         <whitelist>

--- a/tests/integration/Core/Repository/SearchService/MultilingualContentSearchIndexingTest.php
+++ b/tests/integration/Core/Repository/SearchService/MultilingualContentSearchIndexingTest.php
@@ -24,21 +24,7 @@ final class MultilingualContentSearchIndexingTest extends BaseTest
         self::MODIFIED_TRANSLATION => 'Polish (Poland)',
         'nor-NO' => 'Norwegian (Norway)',
         'ger-DE' => 'German (Germany)',
-        'afr-AF' => 'Afrikaans (South Africa)',
-        'ben-BN' => 'Bengali (Bangladesh)',
-        'cha-CH' => 'Chamorro (Guam)',
-        'cro-HR' => 'Croatian (Croatia)',
-        'cze-CS' => 'Czech (Czechia)',
-        'dan-DA' => 'Danish (Denmark)',
-        'esp-ES' => 'Spanish (Spain)',
-        'esp-MX' => 'Spanish (Mexico)',
-        'fra-CA' => 'French (Canada)',
-        'fra-FR' => 'French (France)',
-        'nld-NL' => 'Dutch (Netherlands)',
         'por-PT' => 'Portuguese (Portugal)',
-        'slo-SK' => 'Slovak (Slovak Republic)',
-        'ukr-UA' => 'Ukrainian (Ukraine)',
-        'zho-ZH' => 'Chinese (China)',
     ];
 
     /**


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | Discovered while testing [IBX-2618](https://issues.ibexa.co/browse/IBX-2618)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no

Looks like `tests/integration/Core` from the new Ibexa structure were not added to Solr integration test config and thus all the new tests recently added there were skipped for Solr.

There was an underlying issue not detected due to those tests being skipped. In a Solr dedicated setup (one language per core) we would need to create ~16 extra cores. 22 languages don't provide too much value for that test, it was used to create a profile. Therefore instead of adding cores to Solr setup, we've decided to remove extra languages, keeping the 6 supported, which is enough to cover multilingual case.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
