### PR TITLE
IBX-1119: Implemented Site Access listener for IO requests

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
+++ b/eZ/Bundle/EzPublishIOBundle/Resources/config/io.yml
@@ -157,3 +157,12 @@ services:
             - '@eZ\Publish\Core\IO\IOConfigProvider'
         tags:
             - { name: kernel.event_subscriber }
+
+    Ibexa\Bundle\IO\EventListener\StreamFileSiteAccessListener:
+        arguments:
+            - '@ezpublish.config.resolver'
+            - '@ezpublish.siteaccess_router'
+            - '@ezpublish.siteaccess_service'
+            - '%ezpublish.siteaccess.list%'
+        tags:
+            - { name: kernel.event_subscriber }

--- a/src/bundle/IO/EventListener/StreamFileSiteAccessListener.php
+++ b/src/bundle/IO/EventListener/StreamFileSiteAccessListener.php
@@ -1,0 +1,68 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Bundle\IO\EventListener;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+final class StreamFileSiteAccessListener implements EventSubscriberInterface
+{
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface */
+    private $configResolver;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface */
+    private $siteAccessRouter;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface */
+    private $siteAccessService;
+
+    /** @var array<string> */
+    private $siteAccessList;
+
+    public function __construct(
+        ConfigResolverInterface $configResolver,
+        SiteAccessRouterInterface $siteAccessRouter,
+        SiteAccessServiceInterface $siteAccessService,
+        array $siteAccessList
+    ) {
+        $this->configResolver = $configResolver;
+        $this->siteAccessRouter = $siteAccessRouter;
+        $this->siteAccessService = $siteAccessService;
+        $this->siteAccessList = $siteAccessList;
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 43],
+        ];
+    }
+
+    public function onKernelRequest(RequestEvent $event): void
+    {
+        if ($event->getRequestType() !== HttpKernelInterface::MAIN_REQUEST) {
+            return;
+        }
+
+        $pathInfo = $event->getRequest()->getPathInfo();
+
+        foreach ($this->siteAccessList as $siteAccess) {
+            $varDir = $this->configResolver->getParameter('var_dir', null, $siteAccess);
+            if (strpos($pathInfo, $varDir) === 1) {
+                $this->siteAccessService->setSiteAccess($this->siteAccessRouter->matchByName($siteAccess));
+                break;
+            }
+        }
+    }
+}

--- a/tests/bundle/IO/EventListener/StreamFileSiteAccessListenerTest.php
+++ b/tests/bundle/IO/EventListener/StreamFileSiteAccessListenerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\IO\EventListener;
+
+use eZ\Publish\Core\MVC\ConfigResolverInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessProviderInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface;
+use eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessService;
+use Ibexa\Bundle\IO\EventListener\StreamFileSiteAccessListener;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Event\RequestEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+final class StreamFileSiteAccessListenerTest extends TestCase
+{
+    /** @var \Ibexa\Bundle\IO\EventListener\StreamFileSiteAccessListener */
+    private $eventListener;
+
+    /** @var \eZ\Publish\Core\MVC\ConfigResolverInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $configResolver;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessRouterInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $siteAccessRouter;
+
+    /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\SiteAccessServiceInterface|\PHPUnit\Framework\MockObject\MockObject */
+    private $siteAccessService;
+
+    /** @var array<string> */
+    private $siteAccessList;
+
+    protected function setUp(): void
+    {
+        $this->configResolver = $this->createMock(ConfigResolverInterface::class);
+        $this->siteAccessRouter = $this->createMock(SiteAccessRouterInterface::class);
+        $this->siteAccessService = new SiteAccessService(
+            $this->createMock(SiteAccessProviderInterface::class),
+            $this->createMock(ConfigResolverInterface::class)
+        );
+        $this->siteAccessList = [
+            'admin',
+            'admin2',
+            'site',
+            'site2',
+        ];
+
+        $this->eventListener = new StreamFileSiteAccessListener(
+            $this->configResolver,
+            $this->siteAccessRouter,
+            $this->siteAccessService,
+            $this->siteAccessList
+        );
+    }
+
+    public function testDoNotSwitchSiteAccessIfPathIsNotStoragePath(): void
+    {
+        $request = Request::create('http://localhost/article');
+        $event = $this->createEvent($request);
+
+        $this->configResolver
+            ->expects(self::exactly(4))
+            ->method('getParameter')
+            ->withConsecutive(
+                ['var_dir', null, $this->siteAccessList[0]],
+                ['var_dir', null, $this->siteAccessList[1]],
+                ['var_dir', null, $this->siteAccessList[2]],
+                ['var_dir', null, $this->siteAccessList[3]],
+            )
+            ->willReturnOnConsecutiveCalls(
+                'var/site',
+                'var/repository2',
+                'var/site',
+                'var/repository2',
+            );
+
+        $this->siteAccessRouter
+            ->expects(self::never())
+            ->method('matchByName');
+
+        $this->eventListener->onKernelRequest($event);
+
+        self::assertNull($this->siteAccessService->getCurrent());
+    }
+
+    public function testSwitchSiteAccessToTheOneFromTheSecondRepository(): void
+    {
+        $request = Request::create('http://localhost/var/repository2/storage/images/image.png');
+        $event = $this->createEvent($request);
+
+        $siteAccessToBeSet = $this->siteAccessList[1];
+
+        $this->configResolver
+            ->expects(self::exactly(2))
+            ->method('getParameter')
+            ->withConsecutive(
+                ['var_dir', null, $this->siteAccessList[0]],
+                ['var_dir', null, $siteAccessToBeSet],
+            )
+            ->willReturnOnConsecutiveCalls(
+                'var/site',
+                'var/repository2',
+            );
+
+        $this->siteAccessRouter
+            ->expects(self::once())
+            ->method('matchByName')
+            ->with($siteAccessToBeSet)
+            ->willReturn(new SiteAccess($siteAccessToBeSet));
+
+        $this->eventListener->onKernelRequest($event);
+
+        self::assertSame('admin2', $this->siteAccessService->getCurrent()->name);
+    }
+
+    protected function createEvent(Request $request): RequestEvent
+    {
+        return new RequestEvent(
+            $this->createMock(HttpKernelInterface::class),
+            $request,
+            HttpKernelInterface::MAIN_REQUEST
+        );
+    }
+}

--- a/tests/bundle/IO/EventListener/StreamFileSiteAccessListenerTest.php
+++ b/tests/bundle/IO/EventListener/StreamFileSiteAccessListenerTest.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Event\RequestEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-final class StreamFileSiteAccessListenerTest extends TestCase
+class StreamFileSiteAccessListenerTest extends TestCase
 {
     /** @var \Ibexa\Bundle\IO\EventListener\StreamFileSiteAccessListener */
     private $eventListener;
@@ -119,7 +119,7 @@ final class StreamFileSiteAccessListenerTest extends TestCase
         self::assertSame('admin2', $this->siteAccessService->getCurrent()->name);
     }
 
-    protected function createEvent(Request $request): RequestEvent
+    private function createEvent(Request $request): RequestEvent
     {
         return new RequestEvent(
             $this->createMock(HttpKernelInterface::class),


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-1119](https://issues.ibexa.co/browse/IBX-1119)
| **Type**                                   |bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Injecting a SiteAccess allows for proper resolution of a repository, and hence, a `var_dir`.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x]  Asked for a review (ping `@ezsystems/engineering-team`).
