### PR TITLE
IBX-3110: Added `version` parameter validation in `DownloadController`

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -47,7 +47,11 @@ class DownloadController extends Controller
     public function downloadBinaryFileAction($contentId, $fieldIdentifier, $filename, Request $request)
     {
         if ($request->query->has('version')) {
-            $content = $this->contentService->loadContent($contentId, null, $request->query->get('version'));
+            $version = $request->query->get('version');
+            if (!is_int($version)) {
+                throw new NotFoundException('File', $filename);
+            }
+            $content = $this->contentService->loadContent($contentId, null, $version);
         } else {
             $content = $this->contentService->loadContent($contentId);
         }

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -50,8 +50,8 @@ class DownloadController extends Controller
     public function downloadBinaryFileAction($contentId, $fieldIdentifier, $filename, Request $request)
     {
         if ($request->query->has('version')) {
-            $version = $request->query->get('version');
-            if (!is_int($version)) {
+            $version = (int) $request->query->get('version');
+            if ($version <= 0) {
                 throw new NotFoundException('File', $filename);
             }
             $content = $this->contentService->loadContent($contentId, null, $version);

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -45,7 +45,7 @@ class DownloadController extends Controller
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      */
     public function downloadBinaryFileAction($contentId, $fieldIdentifier, $filename, Request $request)
     {

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -41,7 +41,7 @@ class DownloadController extends Controller
      * @param string $filename
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
-     * @return BinaryStreamResponse
+     * @return \eZ\Bundle\EzPublishIOBundle\BinaryStreamResponse
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -41,8 +41,11 @@ class DownloadController extends Controller
      * @param string $filename
      * @param \Symfony\Component\HttpFoundation\Request $request
      *
-     * @return \eZ\Bundle\EzPublishIOBundle\BinaryStreamResponse
-     * @return \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @return BinaryStreamResponse
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue
      */
     public function downloadBinaryFileAction($contentId, $fieldIdentifier, $filename, Request $request)
     {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3110](https://issues.ibexa.co/browse/IBX-3110)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
