### PR TITLE
IBX-3036: Provided fallback for Content-Disposition header in `DownloadController`

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -75,7 +75,11 @@ class DownloadController extends Controller
         }
 
         $response = new BinaryStreamResponse($this->ioService->loadBinaryFile($field->value->id), $this->ioService);
-        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename, md5($filename));
+        $response->setContentDisposition(
+            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+            $filename,
+            bin2hex(random_bytes(8))
+        );
 
         return $response;
     }

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/DownloadController.php
@@ -75,7 +75,7 @@ class DownloadController extends Controller
         }
 
         $response = new BinaryStreamResponse($this->ioService->loadBinaryFile($field->value->id), $this->ioService);
-        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename);
+        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename, md5($filename));
 
         return $response;
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3036](https://issues.ibexa.co/browse/IBX-3036)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This change would still allow downloading file with the original filename.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
