### PR TITLE
IBX-2634: Added argument to functions to ignore ownership

### DIFF
--- a/eZ/Publish/API/Repository/Tests/BaseContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseContentTypeServiceTest.php
@@ -7,6 +7,7 @@
 namespace eZ\Publish\API\Repository\Tests;
 
 use eZ\Publish\API\Repository\Values\Content\Location;
+use eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft;
 
 /**
  * Base class for content type specific tests.
@@ -18,18 +19,18 @@ abstract class BaseContentTypeServiceTest extends BaseTest
      *
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct[] $additionalFieldDefinitionsCreateStruct
      *
-     * @return \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft
-     *
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentTypeFieldDefinitionValidationException
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    protected function createContentTypeDraft(array $additionalFieldDefinitionsCreateStruct = [])
-    {
+    protected function createContentTypeDraft(
+        array $additionalFieldDefinitionsCreateStruct = [],
+        int $creatorId = 14
+    ): ContentTypeDraft {
         $repository = $this->getRepository();
 
-        $creatorId = $this->generateId('user', 14);
+        $creatorId = $this->generateId('user', $creatorId);
         /* BEGIN: Inline */
         $contentTypeService = $repository->getContentTypeService();
 

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -1720,7 +1720,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $contentTypeService->addFieldDefinition($userContentTypeDraft, $fieldDefCreate);
         /* END: Use Case */
     }
-    
+
     /**
      * Test for the addFieldDefinition() method.
      *
@@ -1731,42 +1731,10 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
     {
         $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
         $this->expectExceptionMessage('Could not find \'The Content Type is owned by someone else\' with identifier \'37\'');
-        
-        $repository = $this->getRepository();
-        $contentTypeService = $repository->getContentTypeService();
-        
-        /* BEGIN: Use Case */
-        $contentTypeDraft = $this->createContentTypeDraft([], 10);
-        
-        $fieldDefCreate = $contentTypeService->newFieldDefinitionCreateStruct('tags', 'ezstring');
-        $fieldDefCreate->names = [
-            'eng-GB' => 'Tags',
-            'ger-DE' => 'Schlagworte',
-        ];
-        $fieldDefCreate->descriptions = [
-            'eng-GB' => 'Tags of the blog post',
-            'ger-DE' => 'Schlagworte des Blog-Eintrages',
-        ];
-        $fieldDefCreate->fieldGroup = 'blog-meta';
-        $fieldDefCreate->position = 1;
-        $fieldDefCreate->isTranslatable = true;
-        $fieldDefCreate->isRequired = true;
-        $fieldDefCreate->isInfoCollector = false;
-        $fieldDefCreate->validatorConfiguration = [
-            'StringLengthValidator' => [
-                'minStringLength' => 0,
-                'maxStringLength' => 0,
-            ],
-        ];
-        $fieldDefCreate->fieldSettings = [];
-        $fieldDefCreate->isSearchable = true;
-        $fieldDefCreate->defaultValue = 'default tags';
-        
-        $contentTypeService->addFieldDefinition($contentTypeDraft, $fieldDefCreate);
-        /* END: Use Case */
-        
+
+        $this->addFieldDefinitionOwnership(false);
     }
-    
+
     /**
      * Test for the addFieldDefinition() method.
      *
@@ -1775,39 +1743,21 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
      */
     public function testAddFieldDefinitionWithIgnoreOwnership(): void
     {
+        $this->addFieldDefinitionOwnership(true);
+    }
+
+    private function addFieldDefinitionOwnership(bool $ignoreOwnership): void
+    {
         $repository = $this->getRepository();
         $contentTypeService = $repository->getContentTypeService();
-        
-        /* BEGIN: Use Case */
         $contentTypeDraft = $this->createContentTypeDraft([], 10);
-        
-        $fieldDefCreate = $contentTypeService->newFieldDefinitionCreateStruct('tags', 'ezstring');
+        $fieldDefCreate = $contentTypeService
+            ->newFieldDefinitionCreateStruct('tags', 'ezstring');
         $fieldDefCreate->names = [
             'eng-GB' => 'Tags',
-            'ger-DE' => 'Schlagworte',
         ];
-        $fieldDefCreate->descriptions = [
-            'eng-GB' => 'Tags of the blog post',
-            'ger-DE' => 'Schlagworte des Blog-Eintrages',
-        ];
-        $fieldDefCreate->fieldGroup = 'blog-meta';
-        $fieldDefCreate->position = 1;
-        $fieldDefCreate->isTranslatable = true;
-        $fieldDefCreate->isRequired = true;
-        $fieldDefCreate->isInfoCollector = false;
-        $fieldDefCreate->validatorConfiguration = [
-            'StringLengthValidator' => [
-                'minStringLength' => 0,
-                'maxStringLength' => 0,
-            ],
-        ];
-        $fieldDefCreate->fieldSettings = [];
-        $fieldDefCreate->isSearchable = true;
-        $fieldDefCreate->defaultValue = 'default tags';
-        
-        $contentTypeService->addFieldDefinition($contentTypeDraft, $fieldDefCreate, true);
-        /* END: Use Case */
-        
+
+        $contentTypeService->addFieldDefinition($contentTypeDraft, $fieldDefCreate, $ignoreOwnership);
     }
 
     /**
@@ -2590,8 +2540,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         );
         /* END: Use Case */
     }
-    
-    
+
     /**
      * Test for the updateFieldDefinition() method.
      *
@@ -2602,44 +2551,10 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
     {
         $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
         $this->expectExceptionMessage('Could not find \'The Content Type is owned by someone else\' with identifier \'37\'');
-        
-        $repository = $this->getRepository();
-        $contentTypeService = $repository->getContentTypeService();
-        
-        /* BEGIN: Use Case */
-        $contentTypeDraft = $this->createContentTypeDraft([], 10);
-        
-        $bodyField = $contentTypeDraft->getFieldDefinition('body');
-        
-        $bodyUpdateStruct = $contentTypeService->newFieldDefinitionUpdateStruct();
-        $bodyUpdateStruct->identifier = 'blog-body';
-        $bodyUpdateStruct->names = [
-            'eng-GB' => 'Blog post body',
-            'ger-DE' => 'Blog-Eintrags-Textkörper',
-        ];
-        $bodyUpdateStruct->descriptions = [
-            'eng-GB' => 'Blog post body of the blog post',
-            'ger-DE' => 'Blog-Eintrags-Textkörper des Blog-Eintrages',
-        ];
-        $bodyUpdateStruct->fieldGroup = 'updated-blog-content';
-        $bodyUpdateStruct->position = 3;
-        $bodyUpdateStruct->isTranslatable = false;
-        $bodyUpdateStruct->isRequired = false;
-        $bodyUpdateStruct->isInfoCollector = true;
-        $bodyUpdateStruct->validatorConfiguration = [];
-        $bodyUpdateStruct->fieldSettings = [
-            'textRows' => 60,
-        ];
-        $bodyUpdateStruct->isSearchable = false;
-        
-        $contentTypeService->updateFieldDefinition(
-            $contentTypeDraft,
-            $bodyField,
-            $bodyUpdateStruct
-        );
-        /* END: Use Case */
+
+        $this->updateFieldDefinitionOwnership(false);
     }
-    
+
     /**
      * Test for the updateFieldDefinition() method.
      *
@@ -2648,42 +2563,24 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
      */
     public function testUpdateFieldDefinitionWithIgnoreOwnership(): void
     {
+        $this->updateFieldDefinitionOwnership(true);
+    }
+
+    private function updateFieldDefinitionOwnership(bool $ignoreOwnership): void
+    {
         $repository = $this->getRepository();
         $contentTypeService = $repository->getContentTypeService();
-        
-        /* BEGIN: Use Case */
+
         $contentTypeDraft = $this->createContentTypeDraft([], 10);
-        
         $bodyField = $contentTypeDraft->getFieldDefinition('body');
-        
         $bodyUpdateStruct = $contentTypeService->newFieldDefinitionUpdateStruct();
-        $bodyUpdateStruct->identifier = 'blog-body';
-        $bodyUpdateStruct->names = [
-            'eng-GB' => 'Blog post body',
-            'ger-DE' => 'Blog-Eintrags-Textkörper',
-        ];
-        $bodyUpdateStruct->descriptions = [
-            'eng-GB' => 'Blog post body of the blog post',
-            'ger-DE' => 'Blog-Eintrags-Textkörper des Blog-Eintrages',
-        ];
-        $bodyUpdateStruct->fieldGroup = 'updated-blog-content';
-        $bodyUpdateStruct->position = 3;
-        $bodyUpdateStruct->isTranslatable = false;
-        $bodyUpdateStruct->isRequired = false;
-        $bodyUpdateStruct->isInfoCollector = true;
-        $bodyUpdateStruct->validatorConfiguration = [];
-        $bodyUpdateStruct->fieldSettings = [
-            'textRows' => 60,
-        ];
-        $bodyUpdateStruct->isSearchable = false;
-        
+
         $contentTypeService->updateFieldDefinition(
             $contentTypeDraft,
             $bodyField,
             $bodyUpdateStruct,
-            true
+            $ignoreOwnership
         );
-        /* END: Use Case */
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -1720,6 +1720,95 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
         $contentTypeService->addFieldDefinition($userContentTypeDraft, $fieldDefCreate);
         /* END: Use Case */
     }
+    
+    /**
+     * Test for the addFieldDefinition() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentTypeService::addFieldDefinition()
+     * @depends eZ\Publish\API\Repository\Tests\ContentTypeServiceTest::testCreateContentType
+     */
+    public function testAddFieldDefinitionThrowsNotFoundExceptionOwnedBySomeoneElse(): void
+    {
+        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
+        $this->expectExceptionMessage('Could not find \'The Content Type is owned by someone else\' with identifier \'37\'');
+        
+        $repository = $this->getRepository();
+        $contentTypeService = $repository->getContentTypeService();
+        
+        /* BEGIN: Use Case */
+        $contentTypeDraft = $this->createContentTypeDraft([], 10);
+        
+        $fieldDefCreate = $contentTypeService->newFieldDefinitionCreateStruct('tags', 'ezstring');
+        $fieldDefCreate->names = [
+            'eng-GB' => 'Tags',
+            'ger-DE' => 'Schlagworte',
+        ];
+        $fieldDefCreate->descriptions = [
+            'eng-GB' => 'Tags of the blog post',
+            'ger-DE' => 'Schlagworte des Blog-Eintrages',
+        ];
+        $fieldDefCreate->fieldGroup = 'blog-meta';
+        $fieldDefCreate->position = 1;
+        $fieldDefCreate->isTranslatable = true;
+        $fieldDefCreate->isRequired = true;
+        $fieldDefCreate->isInfoCollector = false;
+        $fieldDefCreate->validatorConfiguration = [
+            'StringLengthValidator' => [
+                'minStringLength' => 0,
+                'maxStringLength' => 0,
+            ],
+        ];
+        $fieldDefCreate->fieldSettings = [];
+        $fieldDefCreate->isSearchable = true;
+        $fieldDefCreate->defaultValue = 'default tags';
+        
+        $contentTypeService->addFieldDefinition($contentTypeDraft, $fieldDefCreate);
+        /* END: Use Case */
+        
+    }
+    
+    /**
+     * Test for the addFieldDefinition() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentTypeService::addFieldDefinition()
+     * @depends eZ\Publish\API\Repository\Tests\ContentTypeServiceTest::testCreateContentType
+     */
+    public function testAddFieldDefinitionWithIgnoreOwnership(): void
+    {
+        $repository = $this->getRepository();
+        $contentTypeService = $repository->getContentTypeService();
+        
+        /* BEGIN: Use Case */
+        $contentTypeDraft = $this->createContentTypeDraft([], 10);
+        
+        $fieldDefCreate = $contentTypeService->newFieldDefinitionCreateStruct('tags', 'ezstring');
+        $fieldDefCreate->names = [
+            'eng-GB' => 'Tags',
+            'ger-DE' => 'Schlagworte',
+        ];
+        $fieldDefCreate->descriptions = [
+            'eng-GB' => 'Tags of the blog post',
+            'ger-DE' => 'Schlagworte des Blog-Eintrages',
+        ];
+        $fieldDefCreate->fieldGroup = 'blog-meta';
+        $fieldDefCreate->position = 1;
+        $fieldDefCreate->isTranslatable = true;
+        $fieldDefCreate->isRequired = true;
+        $fieldDefCreate->isInfoCollector = false;
+        $fieldDefCreate->validatorConfiguration = [
+            'StringLengthValidator' => [
+                'minStringLength' => 0,
+                'maxStringLength' => 0,
+            ],
+        ];
+        $fieldDefCreate->fieldSettings = [];
+        $fieldDefCreate->isSearchable = true;
+        $fieldDefCreate->defaultValue = 'default tags';
+        
+        $contentTypeService->addFieldDefinition($contentTypeDraft, $fieldDefCreate, true);
+        /* END: Use Case */
+        
+    }
 
     /**
      * Test for the ContentTypeService::createContentType() method.
@@ -2498,6 +2587,101 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
             $loadedDraft,
             $bodyField,
             $bodyUpdateStruct
+        );
+        /* END: Use Case */
+    }
+    
+    
+    /**
+     * Test for the updateFieldDefinition() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentTypeService::updateFieldDefinition()
+     * @depends eZ\Publish\API\Repository\Tests\ContentTypeServiceTest::testLoadContentTypeDraft
+     */
+    public function testUpdateFieldDefinitionThrowsNotFoundExceptionOwnedBySomeoneElse(): void
+    {
+        $this->expectException(\eZ\Publish\API\Repository\Exceptions\NotFoundException::class);
+        $this->expectExceptionMessage('Could not find \'The Content Type is owned by someone else\' with identifier \'37\'');
+        
+        $repository = $this->getRepository();
+        $contentTypeService = $repository->getContentTypeService();
+        
+        /* BEGIN: Use Case */
+        $contentTypeDraft = $this->createContentTypeDraft([], 10);
+        
+        $bodyField = $contentTypeDraft->getFieldDefinition('body');
+        
+        $bodyUpdateStruct = $contentTypeService->newFieldDefinitionUpdateStruct();
+        $bodyUpdateStruct->identifier = 'blog-body';
+        $bodyUpdateStruct->names = [
+            'eng-GB' => 'Blog post body',
+            'ger-DE' => 'Blog-Eintrags-Textkörper',
+        ];
+        $bodyUpdateStruct->descriptions = [
+            'eng-GB' => 'Blog post body of the blog post',
+            'ger-DE' => 'Blog-Eintrags-Textkörper des Blog-Eintrages',
+        ];
+        $bodyUpdateStruct->fieldGroup = 'updated-blog-content';
+        $bodyUpdateStruct->position = 3;
+        $bodyUpdateStruct->isTranslatable = false;
+        $bodyUpdateStruct->isRequired = false;
+        $bodyUpdateStruct->isInfoCollector = true;
+        $bodyUpdateStruct->validatorConfiguration = [];
+        $bodyUpdateStruct->fieldSettings = [
+            'textRows' => 60,
+        ];
+        $bodyUpdateStruct->isSearchable = false;
+        
+        $contentTypeService->updateFieldDefinition(
+            $contentTypeDraft,
+            $bodyField,
+            $bodyUpdateStruct
+        );
+        /* END: Use Case */
+    }
+    
+    /**
+     * Test for the updateFieldDefinition() method.
+     *
+     * @see \eZ\Publish\API\Repository\ContentTypeService::updateFieldDefinition()
+     * @depends eZ\Publish\API\Repository\Tests\ContentTypeServiceTest::testLoadContentTypeDraft
+     */
+    public function testUpdateFieldDefinitionWithIgnoreOwnership(): void
+    {
+        $repository = $this->getRepository();
+        $contentTypeService = $repository->getContentTypeService();
+        
+        /* BEGIN: Use Case */
+        $contentTypeDraft = $this->createContentTypeDraft([], 10);
+        
+        $bodyField = $contentTypeDraft->getFieldDefinition('body');
+        
+        $bodyUpdateStruct = $contentTypeService->newFieldDefinitionUpdateStruct();
+        $bodyUpdateStruct->identifier = 'blog-body';
+        $bodyUpdateStruct->names = [
+            'eng-GB' => 'Blog post body',
+            'ger-DE' => 'Blog-Eintrags-Textkörper',
+        ];
+        $bodyUpdateStruct->descriptions = [
+            'eng-GB' => 'Blog post body of the blog post',
+            'ger-DE' => 'Blog-Eintrags-Textkörper des Blog-Eintrages',
+        ];
+        $bodyUpdateStruct->fieldGroup = 'updated-blog-content';
+        $bodyUpdateStruct->position = 3;
+        $bodyUpdateStruct->isTranslatable = false;
+        $bodyUpdateStruct->isRequired = false;
+        $bodyUpdateStruct->isInfoCollector = true;
+        $bodyUpdateStruct->validatorConfiguration = [];
+        $bodyUpdateStruct->fieldSettings = [
+            'textRows' => 60,
+        ];
+        $bodyUpdateStruct->isSearchable = false;
+        
+        $contentTypeService->updateFieldDefinition(
+            $contentTypeDraft,
+            $bodyField,
+            $bodyUpdateStruct,
+            true
         );
         /* END: Use Case */
     }

--- a/eZ/Publish/Core/Event/ContentTypeService.php
+++ b/eZ/Publish/Core/Event/ContentTypeService.php
@@ -295,7 +295,8 @@ class ContentTypeService extends ContentTypeServiceDecorator
 
     public function addFieldDefinition(
         ContentTypeDraft $contentTypeDraft,
-        FieldDefinitionCreateStruct $fieldDefinitionCreateStruct
+        FieldDefinitionCreateStruct $fieldDefinitionCreateStruct,
+        bool $ignoreOwnership = false
     ): void {
         $eventData = [
             $contentTypeDraft,
@@ -309,7 +310,7 @@ class ContentTypeService extends ContentTypeServiceDecorator
             return;
         }
 
-        $this->innerService->addFieldDefinition($contentTypeDraft, $fieldDefinitionCreateStruct);
+        $this->innerService->addFieldDefinition($contentTypeDraft, $fieldDefinitionCreateStruct, $ignoreOwnership);
 
         $this->eventDispatcher->dispatch(
             new AddFieldDefinitionEvent(...$eventData)
@@ -342,7 +343,8 @@ class ContentTypeService extends ContentTypeServiceDecorator
     public function updateFieldDefinition(
         ContentTypeDraft $contentTypeDraft,
         FieldDefinition $fieldDefinition,
-        FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct
+        FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct,
+        bool $ignoreOwnership = false
     ): void {
         $eventData = [
             $contentTypeDraft,
@@ -357,14 +359,19 @@ class ContentTypeService extends ContentTypeServiceDecorator
             return;
         }
 
-        $this->innerService->updateFieldDefinition($contentTypeDraft, $fieldDefinition, $fieldDefinitionUpdateStruct);
+        $this->innerService->updateFieldDefinition(
+            $contentTypeDraft,
+            $fieldDefinition,
+            $fieldDefinitionUpdateStruct,
+            $ignoreOwnership
+        );
 
         $this->eventDispatcher->dispatch(
             new UpdateFieldDefinitionEvent(...$eventData)
         );
     }
 
-    public function publishContentTypeDraft(ContentTypeDraft $contentTypeDraft): void
+    public function publishContentTypeDraft(ContentTypeDraft $contentTypeDraft, bool $ignoreOwnership = false): void
     {
         $eventData = [$contentTypeDraft];
 
@@ -375,7 +382,7 @@ class ContentTypeService extends ContentTypeServiceDecorator
             return;
         }
 
-        $this->innerService->publishContentTypeDraft($contentTypeDraft);
+        $this->innerService->publishContentTypeDraft($contentTypeDraft, $ignoreOwnership);
 
         $this->eventDispatcher->dispatch(
             new PublishContentTypeDraftEvent(...$eventData)

--- a/eZ/Publish/Core/Repository/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/ContentTypeService.php
@@ -1258,14 +1258,17 @@ class ContentTypeService implements ContentTypeServiceInterface
      * @param \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft $contentTypeDraft
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct $fieldDefinitionCreateStruct
      */
-    public function addFieldDefinition(APIContentTypeDraft $contentTypeDraft, FieldDefinitionCreateStruct $fieldDefinitionCreateStruct): void
-    {
+    public function addFieldDefinition(
+        APIContentTypeDraft $contentTypeDraft,
+        FieldDefinitionCreateStruct $fieldDefinitionCreateStruct,
+        bool $ignoreOwnership = false
+    ): void {
         if (!$this->permissionResolver->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
         $this->validateInputFieldDefinitionCreateStruct($fieldDefinitionCreateStruct);
-        $loadedContentTypeDraft = $this->loadContentTypeDraft($contentTypeDraft->id);
+        $loadedContentTypeDraft = $this->loadContentTypeDraft($contentTypeDraft->id, $ignoreOwnership);
 
         if ($loadedContentTypeDraft->hasFieldDefinition($fieldDefinitionCreateStruct->identifier)) {
             throw new InvalidArgumentException(
@@ -1385,13 +1388,17 @@ class ContentTypeService implements ContentTypeServiceInterface
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinition $fieldDefinition the field definition which should be updated
      * @param \eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct
      */
-    public function updateFieldDefinition(APIContentTypeDraft $contentTypeDraft, APIFieldDefinition $fieldDefinition, FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct): void
-    {
+    public function updateFieldDefinition(
+        APIContentTypeDraft $contentTypeDraft,
+        APIFieldDefinition $fieldDefinition,
+        FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct,
+        bool $ignoreOwnership = false
+    ): void {
         if (!$this->permissionResolver->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
-        $loadedContentTypeDraft = $this->loadContentTypeDraft($contentTypeDraft->id);
+        $loadedContentTypeDraft = $this->loadContentTypeDraft($contentTypeDraft->id, $ignoreOwnership);
         $foundFieldId = false;
         foreach ($loadedContentTypeDraft->fieldDefinitions as $existingFieldDefinition) {
             if ($existingFieldDefinition->id == $fieldDefinition->id) {
@@ -1441,14 +1448,14 @@ class ContentTypeService implements ContentTypeServiceInterface
      *
      * @param \eZ\Publish\API\Repository\Values\ContentType\ContentTypeDraft $contentTypeDraft
      */
-    public function publishContentTypeDraft(APIContentTypeDraft $contentTypeDraft): void
+    public function publishContentTypeDraft(APIContentTypeDraft $contentTypeDraft, bool $ignoreOwnership = false): void
     {
         if (!$this->permissionResolver->canUser('class', 'update', $contentTypeDraft)) {
             throw new UnauthorizedException('ContentType', 'update');
         }
 
         try {
-            $loadedContentTypeDraft = $this->loadContentTypeDraft($contentTypeDraft->id);
+            $loadedContentTypeDraft = $this->loadContentTypeDraft($contentTypeDraft->id, $ignoreOwnership);
         } catch (APINotFoundException $e) {
             throw new BadStateException(
                 '$contentTypeDraft',

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentTypeService.php
@@ -156,9 +156,12 @@ class ContentTypeService implements ContentTypeServiceInterface
         $this->service->unassignContentTypeGroup($contentType, $contentTypeGroup);
     }
 
-    public function addFieldDefinition(ContentTypeDraft $contentTypeDraft, FieldDefinitionCreateStruct $fieldDefinitionCreateStruct): void
-    {
-        $this->service->addFieldDefinition($contentTypeDraft, $fieldDefinitionCreateStruct);
+    public function addFieldDefinition(
+        ContentTypeDraft $contentTypeDraft,
+        FieldDefinitionCreateStruct $fieldDefinitionCreateStruct,
+        bool $ignoreOwnership = false
+    ): void {
+        $this->service->addFieldDefinition($contentTypeDraft, $fieldDefinitionCreateStruct, $ignoreOwnership);
     }
 
     public function removeFieldDefinition(ContentTypeDraft $contentTypeDraft, FieldDefinition $fieldDefinition): void
@@ -166,14 +169,23 @@ class ContentTypeService implements ContentTypeServiceInterface
         $this->service->removeFieldDefinition($contentTypeDraft, $fieldDefinition);
     }
 
-    public function updateFieldDefinition(ContentTypeDraft $contentTypeDraft, FieldDefinition $fieldDefinition, FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct): void
-    {
-        $this->service->updateFieldDefinition($contentTypeDraft, $fieldDefinition, $fieldDefinitionUpdateStruct);
+    public function updateFieldDefinition(
+        ContentTypeDraft $contentTypeDraft,
+        FieldDefinition $fieldDefinition,
+        FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct,
+        bool $ignoreOwnership = false
+    ): void {
+        $this->service->updateFieldDefinition(
+            $contentTypeDraft,
+            $fieldDefinition,
+            $fieldDefinitionUpdateStruct,
+            $ignoreOwnership
+        );
     }
 
-    public function publishContentTypeDraft(ContentTypeDraft $contentTypeDraft): void
+    public function publishContentTypeDraft(ContentTypeDraft $contentTypeDraft, bool $ignoreOwnership = false): void
     {
-        $this->service->publishContentTypeDraft($contentTypeDraft);
+        $this->service->publishContentTypeDraft($contentTypeDraft, $ignoreOwnership);
     }
 
     public function newContentTypeGroupCreateStruct(string $identifier): ContentTypeGroupCreateStruct

--- a/eZ/Publish/SPI/Repository/Decorator/ContentTypeServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/ContentTypeServiceDecorator.php
@@ -154,9 +154,10 @@ abstract class ContentTypeServiceDecorator implements ContentTypeService
 
     public function addFieldDefinition(
         ContentTypeDraft $contentTypeDraft,
-        FieldDefinitionCreateStruct $fieldDefinitionCreateStruct
+        FieldDefinitionCreateStruct $fieldDefinitionCreateStruct,
+        bool $ignoreOwnership = false
     ): void {
-        $this->innerService->addFieldDefinition($contentTypeDraft, $fieldDefinitionCreateStruct);
+        $this->innerService->addFieldDefinition($contentTypeDraft, $fieldDefinitionCreateStruct, $ignoreOwnership);
     }
 
     public function removeFieldDefinition(
@@ -169,14 +170,20 @@ abstract class ContentTypeServiceDecorator implements ContentTypeService
     public function updateFieldDefinition(
         ContentTypeDraft $contentTypeDraft,
         FieldDefinition $fieldDefinition,
-        FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct
+        FieldDefinitionUpdateStruct $fieldDefinitionUpdateStruct,
+        bool $ignoreOwnership = false
     ): void {
-        $this->innerService->updateFieldDefinition($contentTypeDraft, $fieldDefinition, $fieldDefinitionUpdateStruct);
+        $this->innerService->updateFieldDefinition(
+            $contentTypeDraft,
+            $fieldDefinition,
+            $fieldDefinitionUpdateStruct,
+            $ignoreOwnership
+        );
     }
 
-    public function publishContentTypeDraft(ContentTypeDraft $contentTypeDraft): void
+    public function publishContentTypeDraft(ContentTypeDraft $contentTypeDraft, bool $ignoreOwnership = false): void
     {
-        $this->innerService->publishContentTypeDraft($contentTypeDraft);
+        $this->innerService->publishContentTypeDraft($contentTypeDraft, $ignoreOwnership);
     }
 
     public function newContentTypeGroupCreateStruct(string $identifier): ContentTypeGroupCreateStruct


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-2634](https://issues.ibexa.co/browse/IBX-2634)
| **Type**                                   | bug/improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

In order not to change the interface and not to cause BC, only the functions have been changed so that you can pass the argument to ignore the owner - the mechanism itself already existed in our product

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
