### PR TITLE
IBX-3334: Skipped migrating binary file or its metadata when using the same handler

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileMigrator/FileMigrator.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileMigrator/FileMigrator.php
@@ -27,7 +27,7 @@ final class FileMigrator extends MigrationHandler implements FileMigratorInterfa
 
     private function migrateBinaryFile(BinaryFile $binaryFile): bool
     {
-        if (get_class($this->fromBinarydataHandler) === get_class($this->toBinarydataHandler)) {
+        if ($this->fromBinarydataHandler === $this->toBinarydataHandler) {
             return true;
         }
 
@@ -56,7 +56,7 @@ final class FileMigrator extends MigrationHandler implements FileMigratorInterfa
 
     private function migrateMetadata(BinaryFile $binaryFile): bool
     {
-        if (get_class($this->fromMetadataHandler) === get_class($this->toMetadataHandler)) {
+        if ($this->fromMetadataHandler === $this->toMetadataHandler) {
             return true;
         }
 

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileMigrator/FileMigrator.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileMigrator/FileMigrator.php
@@ -16,6 +16,21 @@ final class FileMigrator extends MigrationHandler implements FileMigratorInterfa
 {
     public function migrateFile(BinaryFile $binaryFile)
     {
+        if (!$this->migrateBinaryFile($binaryFile) || !$this->migrateMetadata($binaryFile)) {
+            return false;
+        }
+
+        $this->logInfo("Successfully migrated: '{$binaryFile->id}'");
+
+        return true;
+    }
+
+    private function migrateBinaryFile(BinaryFile $binaryFile): bool
+    {
+        if (get_class($this->fromBinarydataHandler) === get_class($this->toBinarydataHandler)) {
+            return true;
+        }
+
         try {
             $binaryFileResource = $this->fromBinarydataHandler->getResource($binaryFile->id);
         } catch (BinaryFileNotFoundException $e) {
@@ -36,6 +51,15 @@ final class FileMigrator extends MigrationHandler implements FileMigratorInterfa
             return false;
         }
 
+        return true;
+    }
+
+    private function migrateMetadata(BinaryFile $binaryFile): bool
+    {
+        if (get_class($this->fromMetadataHandler) === get_class($this->toMetadataHandler)) {
+            return true;
+        }
+
         $metadataCreateStruct = new BinaryFileCreateStruct();
         $metadataCreateStruct->id = $binaryFile->id;
         $metadataCreateStruct->size = $binaryFile->size;
@@ -49,8 +73,6 @@ final class FileMigrator extends MigrationHandler implements FileMigratorInterfa
 
             return false;
         }
-
-        $this->logInfo("Successfully migrated: '{$binaryFile->id}'");
 
         return true;
     }

--- a/tests/bundle/IO/Migration/FileMigratorTest.php
+++ b/tests/bundle/IO/Migration/FileMigratorTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Bundle\IO\Migration;
+
+use eZ\Bundle\EzPublishIOBundle\ApiLoader\HandlerRegistry;
+use eZ\Bundle\EzPublishIOBundle\Migration\FileMigrator\FileMigrator;
+use eZ\Publish\Core\IO\IOBinarydataHandler;
+use eZ\Publish\Core\IO\IOMetadataHandler;
+use eZ\Publish\SPI\IO\BinaryFile;
+use PHPUnit\Framework\TestCase;
+
+final class FileMigratorTest extends TestCase
+{
+    /** @var \eZ\Bundle\EzPublishIOBundle\ApiLoader\HandlerRegistry|\PHPUnit\Framework\MockObject\MockObject */
+    private $metadataHandlerRegistry;
+
+    /** @var \eZ\Bundle\EzPublishIOBundle\ApiLoader\HandlerRegistry|\PHPUnit\Framework\MockObject\MockObject */
+    private $binaryHandlerRegistry;
+
+    /** @var \eZ\Bundle\EzPublishIOBundle\Migration\FileMigratorInterface */
+    private $fileMigrator;
+
+    /** @var \eZ\Publish\Core\IO\IOMetadataHandler\Flysystem */
+    private $metadataFlysystem;
+
+    /** @var \eZ\Publish\Core\IO\IOMetadataHandler\LegacyDFSCluster */
+    private $metadataLegacyDFSCluster;
+
+    /** @var \eZ\Publish\Core\IO\IOBinarydataHandler\Flysystem */
+    private $binaryFlysystemFrom;
+
+    /** @var \eZ\Publish\Core\IO\IOBinarydataHandler\Flysystem */
+    private $binaryFlysystemTo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->metadataHandlerRegistry = $this->createMock(HandlerRegistry::class);
+        $this->binaryHandlerRegistry = $this->createMock(HandlerRegistry::class);
+
+        $this->metadataFlysystem = $this->createMock(IOMetadataHandler\Flysystem::class);
+        $this->metadataLegacyDFSCluster = $this->createMock(IOMetadataHandler\LegacyDFSCluster::class);
+
+        $this->binaryFlysystemFrom = $this->createMock(IOBinarydataHandler\Flysystem::class);
+        $this->binaryFlysystemTo = $this->createMock(IOBinarydataHandler\Flysystem::class);
+
+        $this->fileMigrator = new FileMigrator($this->metadataHandlerRegistry, $this->binaryHandlerRegistry);
+    }
+
+    public function testMigrateFile(): void
+    {
+        $this->metadataHandlerRegistry
+            ->expects(self::exactly(2))
+            ->method('getConfiguredHandler')
+            ->withConsecutive(
+                ['default'],
+                ['dfs']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->metadataFlysystem,
+                $this->metadataLegacyDFSCluster
+            );
+
+        $this->binaryHandlerRegistry
+            ->expects(self::exactly(2))
+            ->method('getConfiguredHandler')
+            ->withConsecutive(
+                ['default'],
+                ['nfs']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->binaryFlysystemFrom,
+                $this->binaryFlysystemTo
+            );
+
+        $this->fileMigrator->setIODataHandlersByIdentifiers('default', 'default', 'dfs', 'nfs');
+
+        $binaryFile = new BinaryFile();
+        $binaryFile->id = '1234.jpg';
+        $binaryFile->mtime = new \DateTime();
+        $binaryFile->size = 12345;
+        $binaryFile->uri = '1/1234.jpg';
+
+        $this->binaryFlysystemTo
+            ->expects(self::once())
+            ->method('create');
+
+        $this->metadataLegacyDFSCluster
+            ->expects(self::once())
+            ->method('create');
+
+        $flag = $this->fileMigrator->migrateFile($binaryFile);
+
+        self::assertTrue($flag);
+    }
+
+    public function testSkipMigratingIfSameHandlers(): void
+    {
+        $this->metadataHandlerRegistry
+            ->expects(self::exactly(2))
+            ->method('getConfiguredHandler')
+            ->withConsecutive(
+                ['default'],
+                ['default']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->metadataFlysystem,
+                $this->metadataFlysystem
+            );
+
+        $this->binaryHandlerRegistry
+            ->expects(self::exactly(2))
+            ->method('getConfiguredHandler')
+            ->withConsecutive(
+                ['default'],
+                ['default']
+            )
+            ->willReturnOnConsecutiveCalls(
+                $this->binaryFlysystemFrom,
+                $this->binaryFlysystemFrom
+            );
+
+        $this->fileMigrator->setIODataHandlersByIdentifiers('default', 'default', 'default', 'default');
+
+        $binaryFile = new BinaryFile();
+
+        $this->binaryFlysystemFrom
+            ->expects(self::never())
+            ->method('create');
+
+        $this->metadataFlysystem
+            ->expects(self::never())
+            ->method('create');
+
+        $flag = $this->fileMigrator->migrateFile($binaryFile);
+
+        self::assertTrue($flag);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3334](https://issues.ibexa.co/browse/IBX-3334)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

As stated in the title, seems like a logical thing to do as that leaves less space for errors.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
