### PR TITLE
IBX-3451: [Behat] Removed depending on APP_ENV when loading Context services

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php
@@ -91,8 +91,7 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
 
         $configuration = $this->getConfiguration($configs, $container);
 
-        $environment = $container->getParameter('kernel.environment');
-        if (in_array($environment, ['behat', 'test'])) {
+        if ($this->shouldLoadTestServices($container)) {
             $loader->load('feature_contexts.yml');
         }
 
@@ -667,5 +666,11 @@ class EzPublishCoreExtension extends Extension implements PrependExtensionInterf
 
         $container->registerForAutoconfiguration(FilteringSortClauseQueryBuilder::class)
             ->addTag(ServiceTags::FILTERING_SORT_CLAUSE_QUERY_BUILDER);
+    }
+
+    private function shouldLoadTestServices(ContainerBuilder $container): bool
+    {
+        return $container->hasParameter('ibexa.testing.browser.enabled')
+            && true === $container->getParameter('ibexa.testing.browser.enabled');
     }
 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/EzPublishCoreExtensionTest.php
@@ -11,6 +11,7 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Commo
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Configuration\Parser\Content;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\EzPublishCoreExtension;
 use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\ServiceTags;
+use eZ\Bundle\EzPublishCoreBundle\Features\Context\QueryControllerContext;
 use eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\Filter\CustomCriterionQueryBuilder;
 use eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\Filter\CustomSortClauseQueryBuilder;
 use eZ\Bundle\EzPublishCoreBundle\Tests\DependencyInjection\Stub\QueryTypeBundle\QueryType\TestQueryType;
@@ -851,6 +852,19 @@ class EzPublishCoreExtensionTest extends AbstractExtensionTestCase
             CustomSortClauseQueryBuilder::class,
             ServiceTags::FILTERING_SORT_CLAUSE_QUERY_BUILDER,
         ];
+    }
+
+    public function testDoesNotLoadTestServicesByDefault(): void
+    {
+        $this->load();
+        $this->assertContainerBuilderNotHasService(QueryControllerContext::class);
+    }
+
+    public function testLoadsTestServicesWhenParameterIsSpecified(): void
+    {
+        $this->container->setParameter('ibexa.testing.browser.enabled', true);
+        $this->load();
+        $this->assertContainerBuilderHasService(QueryControllerContext::class);
     }
 
     /**


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-3451 (Customer request)

Backport of a change introduced in https://github.com/ibexa/core/pull/92 (https://github.com/ibexa/core/pull/92/commits/073a5cce403fc060b803d7f98b4df253013ffc25) to v3.3 because of the ticket mentioned above.
Relying on a parameter (prepended by ibexa/behat package) is better than relying on hardcoded Symfony env (and does not require adding optional dependencies to bypass it).

I've also added small tests, because it's a Customer Request.

Related PR: https://github.com/ezsystems/ezplatform-content-forms/pull/62