### PR TITLE
IBX-360 - Added \d+ requirement on contentId parameter for ez_content_download_field_id route

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -40,3 +40,4 @@ ez_content_download_field_id:
     defaults: { _controller: ezpublish.controller.content.download_redirection:redirectToContentDownloadAction }
     requirements:
         contentId: '\d+'
+        fieldId: '\d+'

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing/internal.yml
@@ -38,3 +38,5 @@ ez_content_download:
 ez_content_download_field_id:
     path: /content/download/{contentId}/{fieldId}
     defaults: { _controller: ezpublish.controller.content.download_redirection:redirectToContentDownloadAction }
+    requirements:
+        contentId: '\d+'


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-360](https://issues.ibexa.co/browse/IBX-360)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR adds a requirement on `contentId` parameter for route `ez_content_download_field_id` so 404 will be returned instead of 500 whenever someone uses the route with a nondigit `contentId`.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
