### PR TITLE
IBX-3167: Fixed performance issue in URL Alias cache invalidation

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
@@ -200,6 +200,11 @@ class ContentInfo extends ValueObject
         return $this->mainLanguage;
     }
 
+    public function getMainLanguageCode(): string
+    {
+        return $this->mainLanguageCode;
+    }
+
     public function getMainLocation(): ?Location
     {
         return $this->mainLocation;

--- a/eZ/Publish/API/Repository/Values/Content/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Field.php
@@ -26,7 +26,7 @@ class Field extends ValueObject
      *
      * @todo may be not needed
      *
-     * @var mixed
+     * @var int
      */
     protected $id;
 
@@ -57,4 +57,32 @@ class Field extends ValueObject
      * @var string
      */
     protected $fieldTypeIdentifier;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getFieldDefinitionIdentifier(): string
+    {
+        return $this->fieldDefIdentifier;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getLanguageCode(): string
+    {
+        return $this->languageCode;
+    }
+
+    public function getFieldTypeIdentifier(): string
+    {
+        return $this->fieldTypeIdentifier;
+    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/Language.php
+++ b/eZ/Publish/API/Repository/Values/Content/Language.php
@@ -28,28 +28,40 @@ class Language extends ValueObject
     /**
      * The language id (auto generated).
      *
-     * @var mixed
+     * @var int
      */
     protected $id;
 
-    /**
-     * the languageCode code.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $languageCode;
 
     /**
-     * Human readable name of the language.
+     * Human-readable name of the language.
      *
      * @var string
      */
     protected $name;
 
-    /**
-     * Indicates if the language is enabled or not.
-     *
-     * @var bool
-     */
+    /** @var bool */
     protected $enabled;
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getLanguageCode(): string
+    {
+        return $this->languageCode;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
 }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -34,10 +34,13 @@ class UrlAliasHandlerTest extends AbstractInMemoryCacheHandlerTest
                 [
                     ['url_alias_location', [44], false],
                     ['url_alias_location_path', [44], false],
+                    ['url_alias', ['44-abc'], false],
                     ['url_alias_not_found', [], false],
                 ],
                 null,
-                ['urlal-44', 'urlalp-44', 'urlanf'],
+                ['urlal-44', 'urlalp-44', 'urla-44-abc', 'urlanf'],
+                null,
+                '44-abc',
             ],
             [
                 'createCustomUrlAlias',

--- a/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/UrlAliasHandlerTest.php
@@ -24,45 +24,21 @@ class UrlAliasHandlerTest extends AbstractInMemoryCacheHandlerTest
         return SPIUrlAliasHandler::class;
     }
 
-    public function testPublishUrlAliasForLocation(): void
-    {
-        $this->loggerMock->expects(self::once())->method('logCall');
-
-        $innerHandlerMock = $this->createMock($this->getHandlerClassName());
-        $this->persistenceHandlerMock
-            ->expects(self::once())
-            ->method('urlAliasHandler')
-            ->willReturn($innerHandlerMock);
-
-        $innerHandlerMock
-            ->expects(self::once())
-            ->method('publishUrlAliasForLocation')
-            ->with(44, 2, 'name', 'eng-GB', true, false);
-
-        $innerHandlerMock
-            ->expects(self::once())
-            ->method('listURLAliasesForLocation')
-            ->with(44)
-            ->willReturn([]);
-
-        $this->cacheIdentifierGeneratorMock
-            ->expects(self::exactly(3))
-            ->method('generateTag')
-            ->withConsecutive(
-                ['url_alias_location', [44], false],
-                ['url_alias_location_path', [44], false],
-                ['url_alias_not_found', [], false]
-            )
-            ->willReturnOnConsecutiveCalls('urlal-44', 'urlalp-44', 'urlanf');
-
-        $handler = $this->persistenceCacheHandler->urlAliasHandler();
-        $handler->publishUrlAliasForLocation(44, 2, 'name', 'eng-GB', true, false);
-    }
-
     public function providerForUnCachedMethods(): array
     {
         // string $method, array $arguments, array? $tagGeneratingArguments, array? $keyGeneratingArguments, array? $tags, array? $key, ?mixed $returnValue
         return [
+            [
+                'publishUrlAliasForLocation',
+                [44, 2, 'name', 'eng-GB', true, false],
+                [
+                    ['url_alias_location', [44], false],
+                    ['url_alias_location_path', [44], false],
+                    ['url_alias_not_found', [], false],
+                ],
+                null,
+                ['urlal-44', 'urlalp-44', 'urlanf'],
+            ],
             [
                 'createCustomUrlAlias',
                 [44, '1/2/44', true, null, false],

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -53,7 +53,9 @@ class UrlAliasHandler extends AbstractInMemoryPersistenceHandler implements UrlA
             ]
         );
 
-        $urlAliasIdentity = $this->persistenceHandler->urlAliasHandler()->publishUrlAliasForLocation(
+        $urlAliasHandler = $this->persistenceHandler->urlAliasHandler();
+
+        $urlAliasIdentity = $urlAliasHandler->publishUrlAliasForLocation(
             $locationId,
             $parentLocationId,
             $name,

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -6,7 +6,6 @@
  */
 namespace eZ\Publish\Core\Persistence\Cache;
 
-use eZ\Publish\API\Repository\Exceptions\BadStateException;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\SPI\Persistence\Content\UrlAlias;
@@ -54,9 +53,7 @@ class UrlAliasHandler extends AbstractInMemoryPersistenceHandler implements UrlA
             ]
         );
 
-        $urlAliasHandler = $this->persistenceHandler->urlAliasHandler();
-
-        $urlAliasHandler->publishUrlAliasForLocation(
+        $this->persistenceHandler->urlAliasHandler()->publishUrlAliasForLocation(
             $locationId,
             $parentLocationId,
             $name,
@@ -65,30 +62,11 @@ class UrlAliasHandler extends AbstractInMemoryPersistenceHandler implements UrlA
             $updatePathIdentificationString
         );
 
-        try {
-            $existingLocationAliases = $urlAliasHandler->listURLAliasesForLocation($locationId);
-        } catch (BadStateException $e) {
-            $existingLocationAliases = [];
-        }
-
-        $existingLocationAliasesTags = [];
-        foreach ($existingLocationAliases as $existingAlias) {
-            $existingLocationAliasesTags[] = $this->cacheIdentifierGenerator->generateTag(
-                self::URL_ALIAS_IDENTIFIER,
-                [$existingAlias->id]
-            );
-        }
-
-        $this->cache->invalidateTags(
-            array_merge(
-                [
-                    $this->cacheIdentifierGenerator->generateTag(self::URL_ALIAS_LOCATION_IDENTIFIER, [$locationId]),
-                    $this->cacheIdentifierGenerator->generateTag(self::URL_ALIAS_LOCATION_PATH_IDENTIFIER, [$locationId]),
-                    $this->cacheIdentifierGenerator->generateTag(self::URL_ALIAS_NOT_FOUND_IDENTIFIER),
-                ],
-                $existingLocationAliasesTags
-            )
-        );
+        $this->cache->invalidateTags([
+            $this->cacheIdentifierGenerator->generateTag(self::URL_ALIAS_LOCATION_IDENTIFIER, [$locationId]),
+            $this->cacheIdentifierGenerator->generateTag(self::URL_ALIAS_LOCATION_PATH_IDENTIFIER, [$locationId]),
+            $this->cacheIdentifierGenerator->generateTag(self::URL_ALIAS_NOT_FOUND_IDENTIFIER),
+        ]);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/UrlAliasHandler.php
@@ -41,7 +41,7 @@ class UrlAliasHandler extends AbstractInMemoryPersistenceHandler implements UrlA
         $languageCode,
         $alwaysAvailable = false,
         $updatePathIdentificationString = false
-    ) {
+    ): string {
         $this->logger->logCall(
             __METHOD__,
             [
@@ -53,7 +53,7 @@ class UrlAliasHandler extends AbstractInMemoryPersistenceHandler implements UrlA
             ]
         );
 
-        $this->persistenceHandler->urlAliasHandler()->publishUrlAliasForLocation(
+        $urlAliasIdentity = $this->persistenceHandler->urlAliasHandler()->publishUrlAliasForLocation(
             $locationId,
             $parentLocationId,
             $name,
@@ -65,8 +65,11 @@ class UrlAliasHandler extends AbstractInMemoryPersistenceHandler implements UrlA
         $this->cache->invalidateTags([
             $this->cacheIdentifierGenerator->generateTag(self::URL_ALIAS_LOCATION_IDENTIFIER, [$locationId]),
             $this->cacheIdentifierGenerator->generateTag(self::URL_ALIAS_LOCATION_PATH_IDENTIFIER, [$locationId]),
+            $this->cacheIdentifierGenerator->generateTag(self::URL_ALIAS_IDENTIFIER, [$urlAliasIdentity]),
             $this->cacheIdentifierGenerator->generateTag(self::URL_ALIAS_NOT_FOUND_IDENTIFIER),
         ]);
+
+        return $urlAliasIdentity;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -137,10 +137,10 @@ class Handler implements UrlAliasHandlerInterface
         $languageCode,
         $alwaysAvailable = false,
         $updatePathIdentificationString = false
-    ) {
+    ): string {
         $languageId = $this->languageHandler->loadByLanguageCode($languageCode)->id;
 
-        $this->internalPublishUrlAliasForLocation(
+        return $this->internalPublishUrlAliasForLocation(
             $locationId,
             $parentLocationId,
             $name,
@@ -172,7 +172,7 @@ class Handler implements UrlAliasHandlerInterface
         $alwaysAvailable = false,
         $updatePathIdentificationString = false,
         $newId = null
-    ) {
+    ): string {
         $parentId = $this->getRealAliasId($parentLocationId);
         $name = $this->slugConverter->convert($name, 'location_' . $locationId);
         $uniqueCounter = $this->slugConverter->getUniqueCounterValue($name, $parentId == 0);
@@ -300,6 +300,8 @@ class Handler implements UrlAliasHandlerInterface
         if ($cleanup) {
             $this->gateway->cleanupAfterPublish($action, $languageId, $newId, $parentId, $newTextMD5);
         }
+
+        return $this->mapper->generateIdentityKey($parentId, $newTextMD5);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Mapper.php
@@ -43,7 +43,7 @@ class Mapper
         $urlAlias = new UrlAlias();
 
         list($type, $destination) = $this->matchTypeAndDestination($data['action']);
-        $urlAlias->id = $data['parent'] . '-' . $data['text_md5'];
+        $urlAlias->id = $this->generateIdentityKey((int)$data['parent'], $data['text_md5']);
         $urlAlias->pathData = $this->normalizePathData($data['raw_path_data']);
         $urlAlias->languageCodes = $this->languageMaskGenerator->extractLanguageCodesFromMask($data['lang_mask']);
         $urlAlias->alwaysAvailable = $this->languageMaskGenerator->isAlwaysAvailable($data['lang_mask']);
@@ -88,6 +88,11 @@ class Mapper
         }
 
         return $this->languageMaskGenerator->extractLanguageCodesFromMask($languageMask);
+    }
+
+    public function generateIdentityKey(int $parentId, string $hash): string
+    {
+        return sprintf('%d-%s', $parentId, $hash);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/Values/Content/Content.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Content.php
@@ -141,8 +141,10 @@ class Content extends APIContent
         }
 
         foreach ($this->getFields() as $field) {
-            if ($field->fieldDefIdentifier === $fieldDefIdentifier
-                && $field->languageCode === $languageCode) {
+            if (
+                $field->getFieldDefinitionIdentifier() === $fieldDefIdentifier
+                && $field->getLanguageCode() === $languageCode
+            ) {
                 return $field;
             }
         }
@@ -152,7 +154,8 @@ class Content extends APIContent
 
     public function getDefaultLanguageCode(): string
     {
-        return $this->prioritizedFieldLanguageCode ?: $this->versionInfo->contentInfo->mainLanguageCode;
+        return $this->prioritizedFieldLanguageCode
+            ?? $this->versionInfo->getContentInfo()->getMainLanguageCode();
     }
 
     /**
@@ -170,10 +173,10 @@ class Content extends APIContent
     {
         switch ($property) {
             case 'id':
-                return $this->versionInfo->contentInfo->id;
+                return $this->versionInfo->getContentInfo()->id;
 
             case 'contentInfo':
-                return $this->versionInfo->contentInfo;
+                return $this->versionInfo->getContentInfo();
 
             case 'thumbnail':
                 return $this->getThumbnail();

--- a/eZ/Publish/SPI/Persistence/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/UrlAlias/Handler.php
@@ -28,7 +28,13 @@ interface Handler
      * @param string $languageCode
      * @param bool $alwaysAvailable
      */
-    public function publishUrlAliasForLocation($locationId, $parentLocationId, $name, $languageCode, $alwaysAvailable = false);
+    public function publishUrlAliasForLocation(
+        $locationId,
+        $parentLocationId,
+        $name,
+        $languageCode,
+        $alwaysAvailable = false
+    ): string;
 
     /**
      * Create a user chosen $alias pointing to $locationId in $languageCode.


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3167](https://issues.ibexa.co/browse/IBX-3167)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no[1]

This PR reverts #308 and applies more optimal way of cache invalidation of archived entry with overlapping URL for a new Location. Looks like these entries share one tag in common: identity key (URLAlias::$id) in the form of `<url_alias_parent_id>-<name_md5_hash>`. This identity key has been returned from `\eZ\Publish\SPI\Persistence\Content\UrlAlias\Handler::publishUrlAliasForLocation` to be utilized in cache layer.

[1] The breaking interface change applies to SPI\Persistence\* interface which is excluded from BC promise.

#### TODO
- [x] See if CI passes
- [ ] Refactor some parts of related code (future PRs as it does not impact performance in the reported area)
- [x] See if there's visible effect for Reporter's profile. //


#### QA
- [ ] Try reproducing the issue in Reporter's profile (internally passed/synced)
- [ ] Test against [IBX-2844](https://issues.ibexa.co/browse/IBX-2844) regression
- [x] Run regression suite (ibexa/commerce#115)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
