### PR TITLE
IBX-3553: Moved common search service compiler passes to CoreBundle

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EzPublishCoreBundle.php
@@ -41,6 +41,8 @@ use eZ\Bundle\EzPublishCoreBundle\DependencyInjection\Security\HttpBasicFactory;
 use eZ\Publish\Core\Base\Container\Compiler\FieldTypeRegistryPass;
 use eZ\Publish\Core\Base\Container\Compiler\GenericFieldTypeConverterPass;
 use eZ\Publish\Core\Base\Container\Compiler\Persistence\FieldTypeRegistryPass as PersistenceFieldTypeRegistryPass;
+use eZ\Publish\Core\Base\Container\Compiler\Search\AggregateFieldValueMapperPass;
+use eZ\Publish\Core\Base\Container\Compiler\Search\FieldRegistryPass;
 use eZ\Publish\Core\Base\Container\Compiler\Storage\ExternalStorageRegistryPass;
 use eZ\Publish\Core\Base\Container\Compiler\Storage\Legacy\FieldValueConverterRegistryPass;
 use eZ\Publish\Core\Base\Container\Compiler\Storage\Legacy\RoleLimitationConverterPass;
@@ -63,6 +65,8 @@ class EzPublishCoreBundle extends Bundle
         $container->addCompilerPass(new RegisterStorageEnginePass());
         $container->addCompilerPass(new RegisterSearchEnginePass());
         $container->addCompilerPass(new RegisterSearchEngineIndexerPass());
+        $container->addCompilerPass(new AggregateFieldValueMapperPass());
+        $container->addCompilerPass(new FieldRegistryPass());
         $container->addCompilerPass(new ContentViewPass());
         $container->addCompilerPass(new LocationViewPass());
         $container->addCompilerPass(new RouterPass());

--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIterator/LegacyStorageFileIterator.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIterator/LegacyStorageFileIterator.php
@@ -33,6 +33,7 @@ final class LegacyStorageFileIterator implements FileIteratorInterface
         $this->rowReader = $rowReader;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->item;
@@ -43,6 +44,7 @@ final class LegacyStorageFileIterator implements FileIteratorInterface
         $this->fetchRow();
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->cursor;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3553](https://issues.ibexa.co/browse/IBX-3553)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Companion PR:
 * https://github.com/ezsystems/ezplatform-solr-search-engine/pull/240

Moves compiler passes from SolrBundle into CoreBundle.

This fixes an issue that might occur if SolrBundle is not enabled, but Elasticsearch bundle is used:

```
Ibexa\Contracts\Migration\Exception\UnhandledMigrationException {#3839
  #message: "Intentionally not implemented: No mapper available for: Ibexa\Contracts\Core\Search\FieldType\IdentifierField"
  #code: 0
  #file: "./vendor/ibexa/migrations/src/lib/MigrationExecutor.php"
  #line: 71
  -previous: Ibexa\Contracts\Core\Repository\Exceptions\NotImplementedException {#5709
    #message: "Intentionally not implemented: No mapper available for: Ibexa\Contracts\Core\Search\FieldType\IdentifierField"
    #code: 0
    #file: "./vendor/ibexa/core/src/lib/Search/Common/FieldValueMapper/Aggregate.php"
    #line: 90
    trace: {
      ./vendor/ibexa/core/src/lib/Search/Common/FieldValueMapper/Aggregate.php:90 { …}
      ./vendor/ibexa/core/src/lib/Search/Common/FieldValueMapper/Aggregate.php:74 { …}
```
Where `Aggregate` class responsible for finding mappers is empty.

#### Checklist:
- [x] Provided PR description.
- [ ] Tested the solution manually.
- [ ] ~Provided automated test coverage~.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
