### PR TITLE
IBX-3557: Provided Location target for `updateLocation` API method

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
+++ b/eZ/Publish/API/Repository/Tests/Values/User/Limitation/LanguageLimitationTest.php
@@ -812,8 +812,7 @@ class LanguageLimitationTest extends BaseTest
         $locationUpdateStruct->priority = $newPriority;
 
         if ($containsAllTranslations) {
-            $locationService->updateLocation($location, $locationUpdateStruct);
-            $updatedLocation = $locationService->loadLocation($location->id);
+            $updatedLocation = $locationService->updateLocation($location, $locationUpdateStruct);
 
             self::assertEquals($newPriority, $updatedLocation->priority);
         } else {

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -500,7 +500,6 @@ class LocationService implements LocationServiceInterface
      * Updates $location in the content repository.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue
      * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the remoteId exists already
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user is not allowed to update this location

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -499,13 +499,11 @@ class LocationService implements LocationServiceInterface
     /**
      * Updates $location in the content repository.
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to update this location
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException   if if set the remoteId exists already
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
-     * @param \eZ\Publish\API\Repository\Values\Content\LocationUpdateStruct $locationUpdateStruct
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location the updated Location
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\Core\Base\Exceptions\InvalidArgumentValue
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the remoteId exists already
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user is not allowed to update this location
      */
     public function updateLocation(APILocation $location, LocationUpdateStruct $locationUpdateStruct): APILocation
     {
@@ -537,7 +535,13 @@ class LocationService implements LocationServiceInterface
             }
         }
 
-        if (!$this->permissionResolver->canUser('content', 'edit', $loadedLocation->getContentInfo(), [$loadedLocation])) {
+        $locationTarget = (new DestinationLocationTarget($loadedLocation->id, $loadedLocation->contentInfo));
+        if (!$this->permissionResolver->canUser(
+            'content',
+            'edit',
+            $loadedLocation->getContentInfo(),
+            [$loadedLocation, $locationTarget]
+        )) {
             throw new UnauthorizedException('content', 'edit', ['locationId' => $loadedLocation->id]);
         }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3557](https://issues.ibexa.co/browse/IBX-3557)
| **Type**                                   |bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Basically the same situation as in https://github.com/ezsystems/ezplatform-kernel/pull/305 but for `updateLocation`.

This PR doesn't result as the "expected result" which is wrong in the public ticket description but it hardens the security as in mentioned PR.

One could argue if we should use `content/edit` as a validated policy.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
