### PR TITLE
IBX-3588: Enhanced `ContentFieldValidation` exception

### DIFF
--- a/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
@@ -40,7 +40,8 @@ class ContentFieldValidationException extends APIContentFieldValidationException
     public function __construct(array $errors)
     {
         $this->errors = $errors;
-        $this->setMessageTemplate('Content Fields did not validate');
+        $this->setMessageTemplate('Content Fields did not validate: %errors%');
+        $this->setParameters(['%errors%' => $this->generateErrorsMessage()]);
         parent::__construct($this->getBaseTranslation());
     }
 
@@ -52,5 +53,17 @@ class ContentFieldValidationException extends APIContentFieldValidationException
     public function getFieldErrors()
     {
         return $this->errors;
+    }
+
+    private function generateErrorsMessage(): string
+    {
+        $message = '';
+        foreach ($this->getFieldErrors() as $validationErrors) {
+            foreach ($validationErrors as $validationError) {
+                $message .= sprintf("\n-%s", $validationError->getTranslatableMessage());
+            }
+        }
+
+        return $message;
     }
 }

--- a/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
@@ -67,15 +67,15 @@ class ContentFieldValidationException extends APIContentFieldValidationException
 
     private function generateValidationErrorsMessages(): string
     {
-        $validationErrors = $this->collectValidationErrors();
+        $validationErrors = $this->collectValidationErrorsMessages();
 
         return "\n- " . implode("\n- ", $validationErrors);
     }
 
     /**
-     * @return array<\eZ\Publish\Core\FieldType\ValidationError>
+     * @return array<string>
      */
-    private function collectValidationErrors(): array
+    private function collectValidationErrorsMessages(): array
     {
         $messages = [];
         foreach ($this->getFieldErrors() as $validationErrors) {

--- a/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
@@ -59,7 +59,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
         $exception = new self($errors);
         $exception->contentName = $contentName;
 
-        $exception->setMessageTemplate('Content %contentName% fields did not validate: %errors%');
+        $exception->setMessageTemplate('Content "%contentName%" fields did not validate: %errors%');
         $exception->setParameters([
             '%errors%' => $exception->generateValidationErrorsMessages(),
             '%contentName%' => $exception->contentName !== null ? $exception->contentName : '',

--- a/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
@@ -64,6 +64,7 @@ class ContentFieldValidationException extends APIContentFieldValidationException
             '%errors%' => $exception->generateValidationErrorsMessages(),
             '%contentName%' => $exception->contentName !== null ? $exception->contentName : '',
         ]);
+        $exception->message = $exception->getBaseTranslation();
 
         return $exception;
     }

--- a/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
+++ b/eZ/Publish/Core/Base/Exceptions/ContentFieldValidationException.php
@@ -42,23 +42,30 @@ class ContentFieldValidationException extends APIContentFieldValidationException
      *
      * @param array<array-key, array<string, \eZ\Publish\Core\FieldType\ValidationError>> $errors
      */
-    public function __construct(array $errors, ?string $contentName = null)
+    public function __construct(array $errors)
     {
         $this->errors = $errors;
-        $this->contentName = $contentName;
-
-        $this->setMessageTemplate('Content %contentName%fields did not validate: %errors%');
-        $this->setParameters([
-            '%errors%' => $this->generateValidationErrorsMessages(),
-            '%contentName%' => $this->contentName !== null ? sprintf('"%s" ', $this->contentName) : '',
-        ]);
-
+        $this->setMessageTemplate('Content fields did not validate');
         parent::__construct($this->getBaseTranslation());
     }
 
+    /**
+     * Generates: Content fields did not validate exception with additional information on affected fields.
+     *
+     * @param array<array-key, array<string, \eZ\Publish\Core\FieldType\ValidationError>> $errors
+     */
     public static function createNewWithMultiline(array $errors, ?string $contentName = null): self
     {
-        return new self($errors, $contentName);
+        $exception = new self($errors);
+        $exception->contentName = $contentName;
+
+        $exception->setMessageTemplate('Content %contentName% fields did not validate: %errors%');
+        $exception->setParameters([
+            '%errors%' => $exception->generateValidationErrorsMessages(),
+            '%contentName%' => $exception->contentName !== null ? $exception->contentName : '',
+        ]);
+
+        return $exception;
     }
 
     /**

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1282,7 +1282,7 @@ class ContentService implements ContentServiceInterface
         );
 
         if (!empty($errors)) {
-            throw new ContentFieldValidationException($errors);
+            throw new ContentFieldValidationException($errors, $content->getName());
         }
 
         $mainLanguageCode = $content->contentInfo->mainLanguageCode;
@@ -1632,7 +1632,7 @@ class ContentService implements ContentServiceInterface
         );
 
         if (!empty($errors)) {
-            throw new ContentFieldValidationException($errors);
+            throw new ContentFieldValidationException($errors, $versionInfo->getName());
         }
 
         $contentInfo = $versionInfo->getContentInfo();

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1282,7 +1282,7 @@ class ContentService implements ContentServiceInterface
         );
 
         if (!empty($errors)) {
-            throw new ContentFieldValidationException($errors, $content->getName());
+            throw ContentFieldValidationException::createNewWithMultiline($errors, $content->getName());
         }
 
         $mainLanguageCode = $content->contentInfo->mainLanguageCode;
@@ -1632,7 +1632,7 @@ class ContentService implements ContentServiceInterface
         );
 
         if (!empty($errors)) {
-            throw new ContentFieldValidationException($errors, $versionInfo->getName());
+            throw ContentFieldValidationException::createNewWithMultiline($errors, $versionInfo->getContentInfo()->name);
         }
 
         $contentInfo = $versionInfo->getContentInfo();

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5501,7 +5501,7 @@ class ContentTest extends BaseServiceMockTest
         $allFieldErrors
     ): void {
         $this->expectException(\eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException::class);
-        $this->expectExceptionMessage('Content "Test" fields did not validate');
+        $this->expectExceptionMessage('Content fields did not validate');
         list($existingFields, $fieldDefinitions) = $this->fixturesForTestUpdateContentNonRedundantFieldSetComplex();
         list($versionInfo, $contentUpdateStruct) =
             $this->assertForTestUpdateContentThrowsContentFieldValidationException(

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5501,7 +5501,7 @@ class ContentTest extends BaseServiceMockTest
         $allFieldErrors
     ): void {
         $this->expectException(\eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException::class);
-        $this->expectExceptionMessage('Content fields did not validate');
+        $this->expectExceptionMessage('Content "Test" fields did not validate');
         list($existingFields, $fieldDefinitions) = $this->fixturesForTestUpdateContentNonRedundantFieldSetComplex();
         list($versionInfo, $contentUpdateStruct) =
             $this->assertForTestUpdateContentThrowsContentFieldValidationException(

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5422,53 +5422,57 @@ class ContentTest extends BaseServiceMockTest
 
     public function providerForTestUpdateContentThrowsContentFieldValidationException()
     {
+        $newValue1engGBValidationError = new ValidationError('newValue1-eng-GB');
+        $newValue2ValidationError = new ValidationError('newValue2');
+        $newValue4ValidationError = new ValidationError('newValue4');
+
         $allFieldErrors = [
             [
                 'fieldDefinitionId1' => [
-                    'eng-GB' => new ValidationError('newValue1-eng-GB'),
-                    'eng-US' => new ValidationError('newValue1-eng-GB'),
+                    'eng-GB' => $newValue1engGBValidationError,
+                    'eng-US' => $newValue1engGBValidationError,
                 ],
                 'fieldDefinitionId4' => [
-                    'eng-GB' => new ValidationError('newValue4'),
-                    'eng-US' => new ValidationError('newValue4'),
+                    'eng-GB' => $newValue4ValidationError,
+                    'eng-US' => $newValue4ValidationError,
                 ],
             ],
             [
                 'fieldDefinitionId1' => [
-                    'eng-GB' => new ValidationError('newValue1-eng-GB'),
-                    'eng-US' => new ValidationError('newValue1-eng-GB'),
+                    'eng-GB' => $newValue1engGBValidationError,
+                    'eng-US' => $newValue1engGBValidationError,
                 ],
             ],
             [
                 'fieldDefinitionId1' => [
-                    'eng-GB' => new ValidationError('newValue1-eng-GB'),
-                    'eng-US' => new ValidationError('newValue1-eng-GB'),
+                    'eng-GB' => $newValue1engGBValidationError,
+                    'eng-US' => $newValue1engGBValidationError,
                 ],
                 'fieldDefinitionId2' => [
-                    'eng-GB' => new ValidationError('newValue2'),
-                    'eng-US' => new ValidationError('newValue2'),
+                    'eng-GB' => $newValue2ValidationError,
+                    'eng-US' => $newValue2ValidationError,
                 ],
             ],
             [
                 'fieldDefinitionId1' => [
-                    'eng-GB' => new ValidationError('newValue1-eng-GB'),
-                    'eng-US' => new ValidationError('newValue1-eng-GB'),
+                    'eng-GB' => $newValue1engGBValidationError,
+                    'eng-US' => $newValue1engGBValidationError,
                 ],
             ],
             [
                 'fieldDefinitionId1' => [
-                    'eng-GB' => new ValidationError('newValue1-eng-GB'),
-                    'ger-DE' => new ValidationError('newValue1-eng-GB'),
-                    'eng-US' => new ValidationError('newValue1-eng-GB'),
+                    'eng-GB' => $newValue1engGBValidationError,
+                    'ger-DE' => $newValue1engGBValidationError,
+                    'eng-US' => $newValue1engGBValidationError,
                 ],
                 'fieldDefinitionId2' => [
-                    'eng-GB' => new ValidationError('newValue2'),
-                    'eng-US' => new ValidationError('newValue2'),
+                    'eng-GB' => $newValue2ValidationError,
+                    'eng-US' => $newValue2ValidationError,
                 ],
             ],
             [
                 'fieldDefinitionId2' => [
-                    'eng-US' => new ValidationError('newValue2'),
+                    'eng-US' => $newValue2ValidationError,
                 ],
             ],
         ];

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -1341,29 +1341,16 @@ class ContentTest extends BaseServiceMockTest
             $mainLanguageCode
         );
 
-        $languageHandlerMock->expects(self::any())
-            ->method('loadByLanguageCode')
-            ->with(self::isType('string'))
-            ->will(
-                self::returnCallback(
-                    static function () {
-                        return new Language(['id' => 4242]);
-                    }
-                )
-            );
+        $this->commonContentCreateMocks(
+            $languageHandlerMock,
+            $contentTypeServiceMock,
+            $repositoryMock,
+            $contentType
+        );
 
         $repositoryMock->expects(self::once())->method('beginTransaction');
-
-        $contentTypeServiceMock->expects(self::once())
-            ->method('loadContentType')
-            ->with(self::equalTo($contentType->id))
-            ->will(self::returnValue($contentType));
-
-        $repositoryMock->expects(self::once())
-            ->method('getContentTypeService')
-            ->will(self::returnValue($contentTypeServiceMock));
-
         $that = $this;
+
         $permissionResolverMock->expects(self::once())
             ->method('canUser')
             ->with(
@@ -2203,6 +2190,33 @@ class ContentTest extends BaseServiceMockTest
         return [$contentType, $contentCreateStruct];
     }
 
+    private function commonContentCreateMocks(
+        \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock,
+        \PHPUnit\Framework\MockObject\MockObject $contentTypeServiceMock,
+        \PHPUnit\Framework\MockObject\MockObject $repositoryMock,
+        ContentType $contentType
+    ): void {
+        $languageHandlerMock->expects(self::any())
+            ->method('loadByLanguageCode')
+            ->with(self::isType('string'))
+            ->will(
+                self::returnCallback(
+                    static function () {
+                        return new Language(['id' => 4242]);
+                    }
+                )
+            );
+
+        $contentTypeServiceMock->expects(self::once())
+            ->method('loadContentType')
+            ->with(self::equalTo($contentType->id))
+            ->will(self::returnValue($contentType));
+
+        $repositoryMock->expects(self::once())
+            ->method('getContentTypeService')
+            ->will(self::returnValue($contentTypeServiceMock));
+    }
+
     /**
      * Asserts behaviour necessary for testing ContentFieldValidationException because of required
      * field being empty.
@@ -2232,25 +2246,12 @@ class ContentTest extends BaseServiceMockTest
             $mainLanguageCode
         );
 
-        $languageHandlerMock->expects(self::any())
-            ->method('loadByLanguageCode')
-            ->with(self::isType('string'))
-            ->will(
-                self::returnCallback(
-                    static function () {
-                        return new Language(['id' => 4242]);
-                    }
-                )
-            );
-
-        $contentTypeServiceMock->expects(self::once())
-            ->method('loadContentType')
-            ->with(self::equalTo($contentType->id))
-            ->will(self::returnValue($contentType));
-
-        $repositoryMock->expects(self::once())
-            ->method('getContentTypeService')
-            ->will(self::returnValue($contentTypeServiceMock));
+        $this->commonContentCreateMocks(
+            $languageHandlerMock,
+            $contentTypeServiceMock,
+            $repositoryMock,
+            $contentType
+        );
 
         $that = $this;
         $permissionResolver->expects(self::once())
@@ -2397,25 +2398,12 @@ class ContentTest extends BaseServiceMockTest
             ]
         );
 
-        $languageHandlerMock->expects(self::any())
-            ->method('loadByLanguageCode')
-            ->with(self::isType('string'))
-            ->will(
-                self::returnCallback(
-                    static function () {
-                        return new Language(['id' => 4242]);
-                    }
-                )
-            );
-
-        $contentTypeServiceMock->expects(self::once())
-            ->method('loadContentType')
-            ->with(self::equalTo($contentType->id))
-            ->will(self::returnValue($contentType));
-
-        $repositoryMock->expects(self::once())
-            ->method('getContentTypeService')
-            ->will(self::returnValue($contentTypeServiceMock));
+        $this->commonContentCreateMocks(
+            $languageHandlerMock,
+            $contentTypeServiceMock,
+            $repositoryMock,
+            $contentType
+        );
 
         $that = $this;
         $permissionResolver->expects(self::once())

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -2512,7 +2512,7 @@ class ContentTest extends BaseServiceMockTest
     public function testCreateContentThrowsContentFieldValidationException($mainLanguageCode, $structFields): void
     {
         $this->expectException(\eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException::class);
-        $this->expectExceptionMessage('Content Fields did not validate');
+        $this->expectExceptionMessage('Content fields did not validate');
 
         $fieldDefinitions = $this->fixturesForTestCreateContentNonRedundantFieldSetComplex();
         list($contentCreateStruct, $allFieldErrors) =
@@ -5501,7 +5501,7 @@ class ContentTest extends BaseServiceMockTest
         $allFieldErrors
     ): void {
         $this->expectException(\eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException::class);
-        $this->expectExceptionMessage('Content Fields of Content "Test" did not validate');
+        $this->expectExceptionMessage('Content "Test" fields did not validate');
         list($existingFields, $fieldDefinitions) = $this->fixturesForTestUpdateContentNonRedundantFieldSetComplex();
         list($versionInfo, $contentUpdateStruct) =
             $this->assertForTestUpdateContentThrowsContentFieldValidationException(

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -5198,13 +5198,11 @@ class ContentTest extends BaseServiceMockTest
         $structFields,
         $existingFields,
         $fieldDefinitions
-    ) {
-        $repositoryMock = $this->getRepositoryMock();
+    ): array {
         $permissionResolver = $this->getPermissionResolverMock();
         $mockedService = $this->getPartlyMockedContentService(['internalLoadContentById', 'loadContent']);
         /** @var \PHPUnit\Framework\MockObject\MockObject $languageHandlerMock */
         $languageHandlerMock = $this->getPersistenceMock()->contentLanguageHandler();
-        $contentTypeServiceMock = $this->getContentTypeServiceMock();
         $fieldTypeMock = $this->createMock(SPIFieldType::class);
         $existingLanguageCodes = array_map(
             static function (Field $field) {
@@ -5224,6 +5222,10 @@ class ContentTest extends BaseServiceMockTest
                 'versionNo' => 7,
                 'languageCodes' => $existingLanguageCodes,
                 'status' => VersionInfo::STATUS_DRAFT,
+                'names' => [
+                    'eng-GB' => 'Test',
+                ],
+                'initialLanguageCode' => 'eng-GB',
             ]
         );
         $contentType = new ContentType([
@@ -5237,11 +5239,11 @@ class ContentTest extends BaseServiceMockTest
             ]
         );
 
-        $languageHandlerMock->expects($this->any())
+        $languageHandlerMock->expects(self::any())
             ->method('loadByLanguageCode')
-            ->with($this->isType('string'))
+            ->with(self::isType('string'))
             ->will(
-                $this->returnCallback(
+                self::returnCallback(
                     static function () {
                         return new Language(['id' => 4242]);
                     }
@@ -5251,32 +5253,32 @@ class ContentTest extends BaseServiceMockTest
         $mockedService
             ->method('loadContent')
             ->with(
-                $this->equalTo(42),
-                $this->equalTo(null),
-                $this->equalTo(7)
+                self::equalTo(42),
+                self::equalTo(null),
+                self::equalTo(7)
             )->will(
-                $this->returnValue($content)
+                self::returnValue($content)
             );
 
         $mockedService
             ->method('internalLoadContentById')
             ->will(
-                $this->returnValue($content)
+                self::returnValue($content)
             );
 
-        $permissionResolver->expects($this->any())
+        $permissionResolver->expects(self::any())
             ->method('canUser')
             ->with(
-                $this->equalTo('content'),
-                $this->equalTo('edit'),
-                $this->equalTo($content),
-                $this->isType('array')
-            )->will($this->returnValue(true));
+                self::equalTo('content'),
+                self::equalTo('edit'),
+                self::equalTo($content),
+                self::isType('array')
+            )->will(self::returnValue(true));
 
-        $fieldTypeMock->expects($this->any())
+        $fieldTypeMock->expects(self::any())
             ->method('acceptValue')
             ->will(
-                $this->returnCallback(
+                self::returnCallback(
                     static function ($valueString) {
                         return new ValueStub($valueString);
                     }
@@ -5284,24 +5286,24 @@ class ContentTest extends BaseServiceMockTest
             );
 
         $emptyValue = new ValueStub(self::EMPTY_FIELD_VALUE);
-        $fieldTypeMock->expects($this->any())
+        $fieldTypeMock->expects(self::any())
             ->method('isEmptyValue')
             ->will(
-                $this->returnCallback(
+                self::returnCallback(
                     static function (ValueStub $value) use ($emptyValue) {
                         return (string)$emptyValue === (string)$value;
                     }
                 )
             );
 
-        $fieldTypeMock->expects($this->any())
+        $fieldTypeMock->expects(self::any())
             ->method('validate')
             ->with(
-                $this->isInstanceOf(APIFieldDefinition::class),
-                $this->isInstanceOf(Value::class)
+                self::isInstanceOf(APIFieldDefinition::class),
+                self::isInstanceOf(Value::class)
             );
 
-        $this->getFieldTypeRegistryMock()->expects($this->any())
+        $this->getFieldTypeRegistryMock()->expects(self::any())
             ->method('getFieldType')
             ->will($this->returnValue($fieldTypeMock));
 
@@ -5423,6 +5425,10 @@ class ContentTest extends BaseServiceMockTest
                 'versionNo' => 7,
                 'languageCodes' => $existingLanguageCodes,
                 'status' => VersionInfo::STATUS_DRAFT,
+                'names' => [
+                    'eng-GB' => 'Test',
+                ],
+                'initialLanguageCode' => 'eng-GB',
             ]
         );
         $contentType = new ContentType([
@@ -5602,7 +5608,7 @@ class ContentTest extends BaseServiceMockTest
         $allFieldErrors
     ): void {
         $this->expectException(\eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException::class);
-        $this->expectExceptionMessage('Content Fields did not validate');
+        $this->expectExceptionMessage('Content Fields of Content "Test" did not validate');
         list($existingFields, $fieldDefinitions) = $this->fixturesForTestUpdateContentNonRedundantFieldSetComplex();
         list($versionInfo, $contentUpdateStruct) =
             $this->assertForTestUpdateContentThrowsContentFieldValidationException(

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -762,7 +762,7 @@ class UserService implements UserServiceInterface
 
         $errors = $this->passwordValidator->validatePassword($newPassword, $userFieldDefinition);
         if (!empty($errors)) {
-            throw new ContentFieldValidationException($errors, $loadedUser->getName());
+            throw ContentFieldValidationException::createNewWithMultiline($errors, $loadedUser->getName());
         }
 
         $passwordHashAlgorithm = (int) $loadedUser->hashAlgorithm;

--- a/eZ/Publish/Core/Repository/UserService.php
+++ b/eZ/Publish/Core/Repository/UserService.php
@@ -762,7 +762,7 @@ class UserService implements UserServiceInterface
 
         $errors = $this->passwordValidator->validatePassword($newPassword, $userFieldDefinition);
         if (!empty($errors)) {
-            throw new ContentFieldValidationException($errors);
+            throw new ContentFieldValidationException($errors, $loadedUser->getName());
         }
 
         $passwordHashAlgorithm = (int) $loadedUser->hashAlgorithm;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3588](https://issues.ibexa.co/browse/IBX-3588)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

`ContentFieldValidation` exception message to include validation messages for each field.

Related PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/2060

Example:
![image](https://user-images.githubusercontent.com/22300504/184341348-9e515865-4b1b-465b-a157-a29cd0a05129.png)

SonarCloud duplication analysis is not related to this PR.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x]  Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
