### PR TITLE
Optimized API Content::getField method

### DIFF
--- a/eZ/Publish/Core/Repository/Values/Content/Content.php
+++ b/eZ/Publish/Core/Repository/Values/Content/Content.php
@@ -139,7 +139,7 @@ class Content extends APIContent
 
         $filteredFields = array_filter(
             $this->internalFields,
-            static function (Field $field) use ($languageCode) {
+            static function (Field $field) use ($languageCode): bool {
                 return $field->languageCode === $languageCode;
             }
         );

--- a/tests/lib/Repository/Values/Content/ContentTest.php
+++ b/tests/lib/Repository/Values/Content/ContentTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Repository\Values\Content;
+
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @see \eZ\Publish\Core\Repository\Tests\Values\Content\ContentTest for Legacy set of unit tests.
+ *
+ * @covers \eZ\Publish\Core\Repository\Values\Content\Content
+ */
+final class ContentTest extends TestCase
+{
+    /** @var \eZ\Publish\API\Repository\Values\Content\Field[] */
+    private $internalFields;
+
+    /** @var \eZ\Publish\Core\Repository\Values\Content\Content */
+    private $content;
+
+    protected function setUp(): void
+    {
+        $this->internalFields = [
+            new Field(
+                [
+                    'fieldDefIdentifier' => 'foo',
+                    'languageCode' => 'pol-PL',
+                    'value' => new TextLineValue('Foo'),
+                    'fieldTypeIdentifier' => 'string',
+                ]
+            ),
+            new Field(
+                [
+                    'fieldDefIdentifier' => 'foo',
+                    'languageCode' => 'eng-GB',
+                    'value' => new TextLineValue('English Foo'),
+                    'fieldTypeIdentifier' => 'string',
+                ]
+            ),
+            new Field(
+                [
+                    'fieldDefIdentifier' => 'bar',
+                    'languageCode' => 'pol-PL',
+                    'value' => new TextLineValue('Bar'),
+                    'fieldTypeIdentifier' => 'custom_type',
+                ]
+            ),
+        ];
+
+        $this->content = new Content(
+            [
+                'internalFields' => $this->internalFields,
+                'prioritizedFieldLanguageCode' => 'pol-PL',
+            ]
+        );
+    }
+
+    public function testGetFields(): void
+    {
+        self::assertSame($this->internalFields, $this->content->getFields());
+    }
+
+    public function testGetField(): void
+    {
+        self::assertSame($this->internalFields[0], $this->content->getField('foo'));
+        self::assertSame($this->internalFields[1], $this->content->getField('foo', 'eng-GB'));
+    }
+
+    public function testGetFieldValue(): void
+    {
+        self::assertEquals(new TextLineValue('Bar'), $this->content->getFieldValue('bar', 'pol-PL'));
+        self::assertNull($this->content->getFieldValue('bar', 'eng-GB'));
+    }
+
+    public function testGetFieldsByLanguage(): void
+    {
+        self::assertSame(
+            [
+                'foo' => $this->internalFields[0],
+                'bar' => $this->internalFields[2],
+            ],
+            $this->content->getFieldsByLanguage('pol-PL')
+        );
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | Related to [IBX-3167](https://issues.ibexa.co/browse/IBX-3167)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no

I've identified small area while analyzing blackfire profiles of Version Publish operation, which can be optimized a bit.

- Removed magic from API `Content::getField` method & improved PHPDoc.
- Optimized API `Content::getField` method
- [Tests] Added unit test coverage for API Content `getField*` methods

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
