### PR TITLE
IBX-3606: Removed duplicate siteaccess names

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Provider/StaticSiteAccessProvider.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Provider/StaticSiteAccessProvider.php
@@ -35,7 +35,7 @@ final class StaticSiteAccessProvider implements SiteAccessProviderInterface
         array $siteAccessList,
         array $groupsBySiteAccess = []
     ) {
-        $this->siteAccessList = $siteAccessList;
+        $this->siteAccessList = array_unique($siteAccessList);
         $this->groupsBySiteAccess = $groupsBySiteAccess;
     }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3606](https://issues.ibexa.co/browse/IBX-3606)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Yaml configuration allows to add the same Site Access  more than once resulting in :
```
    siteaccess:
        list: [admin, site, site]
        
```

This PR removes those duplicates in `StaticSiteAccessProvider` constructor.


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
