### PR TITLE
IBX-3791: Fixed DFS queries for Postgres

### DIFF
--- a/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIterator/LegacyStorageFileIterator.php
+++ b/eZ/Bundle/EzPublishIOBundle/Migration/FileLister/FileIterator/LegacyStorageFileIterator.php
@@ -33,6 +33,7 @@ final class LegacyStorageFileIterator implements FileIteratorInterface
         $this->rowReader = $rowReader;
     }
 
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return $this->item;
@@ -43,6 +44,7 @@ final class LegacyStorageFileIterator implements FileIteratorInterface
         $this->fetchRow();
     }
 
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return $this->cursor;

--- a/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
@@ -89,7 +89,6 @@ ON DUPLICATE KEY UPDATE
 SQL;
         }
 
-
         try {
             $this->db->executeStatement($sql, $params);
         } catch (DBALException $e) {

--- a/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/LegacyDFSCluster.php
@@ -120,8 +120,8 @@ class LegacyDFSCluster implements IOMetadataHandler
     {
         $path = (string)$this->addPrefix($spiBinaryFileId);
 
-        $qb = $this->db->createQueryBuilder();
-        $result = $qb
+        $queryBuilder = $this->db->createQueryBuilder();
+        $result = $queryBuilder
             ->select(
                 'e.name_hash',
                 'e.name',
@@ -164,8 +164,8 @@ class LegacyDFSCluster implements IOMetadataHandler
     {
         $path = (string)$this->addPrefix($spiBinaryFileId);
 
-        $qb = $this->db->createQueryBuilder();
-        $result = $qb
+        $queryBuilder = $this->db->createQueryBuilder();
+        $result = $queryBuilder
             ->select(
                 'e.name_hash',
                 'e.name',
@@ -251,8 +251,8 @@ class LegacyDFSCluster implements IOMetadataHandler
 
     public function getMimeType($spiBinaryFileId)
     {
-        $qb = $this->db->createQueryBuilder();
-        $result = $qb
+        $queryBuilder = $this->db->createQueryBuilder();
+        $result = $queryBuilder
             ->select('e.datatype')
             ->from('ezdfsfile', 'e')
             ->andWhere('e.name_hash = :name_hash')


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3791](https://issues.ibexa.co/browse/IBX-3791)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR allows DFS to work with Postgres database on a best effort basis.

It replaces two things:
 * ~Custom SQL code for upserts is now platform-dependent, with Postgres being tailored to work in the same fashion as MySQL one~ Code was replaced to comply with SQL standard in each case.
 * SQL select conditions no longer use `expired != 1` comparison, which is invalid (boolean vs. int) comparison in Postgres. They are replaced with `expired != true`, which is handled by both databases (MySQL treats `true` as `1` and `false` as `0` - see https://dev.mysql.com/doc/refman/8.0/en/boolean-literals.html).

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] ~Provided automated test coverage~.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
