### PR TITLE
IBX-3823: Fixed appending limitations, when there are no initial values

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilder.php
+++ b/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilder.php
@@ -23,7 +23,7 @@ class PoliciesConfigBuilder extends ContainerConfigBuilder
         foreach ($config as $module => $functionArray) {
             foreach ($functionArray as $function => $limitationCollection) {
                 if (null !== $limitationCollection && $this->policyExists($previousPolicyMap, $module, $function)) {
-                    $limitations = array_merge_recursive($previousPolicyMap[$module][$function], array_fill_keys((array)$limitationCollection, true));
+                    $limitations = array_merge_recursive($previousPolicyMap[$module][$function] ?? [], array_fill_keys((array)$limitationCollection, true));
                 } else {
                     $limitations = array_fill_keys((array)$limitationCollection, true);
                 }

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilderTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/DependencyInjection/Security/PolicyProvider/PoliciesConfigBuilderTest.php
@@ -14,20 +14,46 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class PoliciesConfigBuilderTest extends TestCase
 {
-    public function testAddConfig()
+    /**
+     * @dataProvider policiesConfigProvider
+     */
+    public function testAddConfig(array $configOne, array $configTwo, array $expectedConfig): void
     {
         $containerBuilder = new ContainerBuilder();
         $configBuilder = new PoliciesConfigBuilder($containerBuilder);
-        $config1 = ['foo' => ['bar' => null]];
-        $config2 = ['some' => ['thing' => ['limitation']]];
-        $expected = [
-            'foo' => ['bar' => []],
-            'some' => ['thing' => ['limitation' => true]],
-        ];
-        $configBuilder->addConfig($config1);
-        $configBuilder->addConfig($config2);
 
-        self::assertSame($expected, $containerBuilder->getParameter('ezpublish.api.role.policy_map'));
+        $configBuilder->addConfig($configOne);
+        $configBuilder->addConfig($configTwo);
+
+        self::assertSame($expectedConfig, $containerBuilder->getParameter('ezpublish.api.role.policy_map'));
+    }
+
+    public function policiesConfigProvider(): array
+    {
+        return [
+            'add' => [
+                ['foo' => ['bar' => null]],
+                ['some' => ['thing' => ['limitation']]],
+                [
+                    'foo' => ['bar' => []],
+                    'some' => ['thing' => ['limitation' => true]],
+                ],
+            ],
+            'append' => [
+                ['foo' => ['bar' => ['limitation']]],
+                ['foo' => ['bar' => ['new_limitation']]],
+                [
+                    'foo' => ['bar' => ['limitation' => true, 'new_limitation' => true]],
+                ],
+            ],
+            'append_to_empty' => [
+                ['foo' => ['bar' => null]],
+                ['foo' => ['bar' => ['new_limitation']]],
+                [
+                    'foo' => ['bar' => ['new_limitation' => true]],
+                ],
+            ],
+        ];
     }
 
     public function testAddResource()


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3823](https://issues.ibexa.co/browse/IBX-3823)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

As when there were no limitations assigned to policy, `$previousPolicyMap[$module][$function]` is null, and `array_merge_recursive` was throwing type error.


This could be reproduced with new `PolicyProviderInterface` for example with:

```php
    public function addPolicies(ConfigBuilderInterface $configBuilder)
    {
        $configBuilder->addConfig([
            'setup' => [
                'administrate' => ['SiteAccess'],
            ],
        ]);
    }
```
#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
