### PR TITLE
IBX-3856: Changed Checkbox's value to never be considered empty

### DIFF
--- a/eZ/Publish/API/Repository/Tests/FieldType/CheckboxIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/CheckboxIntegrationTest.php
@@ -387,18 +387,16 @@ class CheckboxIntegrationTest extends SearchBaseIntegrationTest
         self::assertSame($isActive, $value->bool);
     }
 
-    public function testAddFieldDefinition()
+    public function testAddFieldDefinition(): void
     {
+        $fieldTypeService = $this->getRepository()->getFieldTypeService();
         $content = $this->addFieldDefinition();
 
-        $this->assertCount(2, $content->getFields());
-
-        $this->assertFalse(
-            $this->getRepository()->getFieldTypeService()->getFieldType(
-                $this->getTypeName()
-            )->isEmptyValue(
-                $content->getFieldValue('data')
-            )
+        self::assertCount(2, $content->getFields());
+        self::assertFalse(
+            $fieldTypeService
+                ->getFieldType($this->getTypeName())
+                ->isEmptyValue($content->getFieldValue('data'))
         );
     }
 

--- a/eZ/Publish/API/Repository/Tests/FieldType/CheckboxIntegrationTest.php
+++ b/eZ/Publish/API/Repository/Tests/FieldType/CheckboxIntegrationTest.php
@@ -306,22 +306,17 @@ class CheckboxIntegrationTest extends SearchBaseIntegrationTest
 
     public function providerForTestIsEmptyValue()
     {
-        return [
-            [new CheckboxValue()],
-            [new CheckboxValue(null)],
-            [new CheckboxValue(false)],
-        ];
+        return [];
     }
 
     public function providerForTestIsNotEmptyValue()
     {
         return [
-            [
-                $this->getValidCreationFieldData(),
-            ],
-            [
-                new CheckboxValue(true),
-            ],
+            [$this->getValidCreationFieldData()],
+            [new CheckboxValue(true)],
+            [new CheckboxValue()],
+            [new CheckboxValue(null)],
+            [new CheckboxValue(false)],
         ];
     }
 
@@ -390,6 +385,21 @@ class CheckboxIntegrationTest extends SearchBaseIntegrationTest
         $value = $contentItem->getField('is_active')->value;
         /** @var \eZ\Publish\Core\FieldType\Checkbox\Value $value */
         self::assertSame($isActive, $value->bool);
+    }
+
+    public function testAddFieldDefinition()
+    {
+        $content = $this->addFieldDefinition();
+
+        $this->assertCount(2, $content->getFields());
+
+        $this->assertFalse(
+            $this->getRepository()->getFieldTypeService()->getFieldType(
+                $this->getTypeName()
+            )->isEmptyValue(
+                $content->getFieldValue('data')
+            )
+        );
     }
 
     protected function createCheckboxContentItems(Repository $repository): void

--- a/eZ/Publish/Core/FieldType/Checkbox/Type.php
+++ b/eZ/Publish/Core/FieldType/Checkbox/Type.php
@@ -48,6 +48,11 @@ class Type extends FieldType
         return new Value(false);
     }
 
+    public function isEmptyValue(SPIValue $value): bool
+    {
+        return false;
+    }
+
     /**
      * Inspects given $inputValue and potentially converts it into a dedicated value object.
      *

--- a/eZ/Publish/Core/FieldType/FieldType.php
+++ b/eZ/Publish/Core/FieldType/FieldType.php
@@ -349,7 +349,7 @@ abstract class FieldType extends SPIFieldType implements Comparable
      */
     public function isEmptyValue(SPIValue $value)
     {
-        return $value === null || $value == $this->getEmptyValue();
+        return $value == $this->getEmptyValue();
     }
 
     /**

--- a/eZ/Publish/Core/FieldType/Tests/CheckboxTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/CheckboxTest.php
@@ -318,4 +318,9 @@ class CheckboxTest extends FieldTypeTest
         yield [new CheckboxValue(true)];
         yield [new CheckboxValue(false)];
     }
+
+    public function testEmptyValueIsEmpty(): void
+    {
+        self::markTestSkipped('Value of Checkbox fieldtype is never considered empty');
+    }
 }

--- a/eZ/Publish/Core/FieldType/Tests/CheckboxTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/CheckboxTest.php
@@ -301,7 +301,7 @@ class CheckboxTest extends FieldTypeTest
     /**
      * @dataProvider provideForValueIsNeverEmpty
      */
-    public function testValueIsNeverEmpty(CheckboxValue $value)
+    public function testValueIsNeverEmpty(CheckboxValue $value): void
     {
         $fieldType = $this->getFieldTypeUnderTest();
 

--- a/eZ/Publish/Core/FieldType/Tests/CheckboxTest.php
+++ b/eZ/Publish/Core/FieldType/Tests/CheckboxTest.php
@@ -297,4 +297,25 @@ class CheckboxTest extends FieldTypeTest
             [new CheckboxValue(false), '0', [], 'en_GB'],
         ];
     }
+
+    /**
+     * @dataProvider provideForValueIsNeverEmpty
+     */
+    public function testValueIsNeverEmpty(CheckboxValue $value)
+    {
+        $fieldType = $this->getFieldTypeUnderTest();
+
+        self::assertFalse($fieldType->isEmptyValue($value));
+    }
+
+    /**
+     * @return iterable<array{
+     *     \eZ\Publish\Core\FieldType\Checkbox\Value,
+     * }>
+     */
+    public function provideForValueIsNeverEmpty(): iterable
+    {
+        yield [new CheckboxValue(true)];
+        yield [new CheckboxValue(false)];
+    }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3856](https://issues.ibexa.co/browse/IBX-3856)
| **Type**                                   |bugfix
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          |  yes, not significant

Replacement for https://github.com/ezsystems/ezplatform-version-comparison/pull/81 

I've:
1) implemented a failing test showing the desired behaviour (https://github.com/ezsystems/ezplatform-kernel/pull/336/commits/ab459ce3aa17f8ee78148f2f6c4cb64d8ff39ea1)
2) implemented the actual change (the new test now passes) (https://github.com/ezsystems/ezplatform-kernel/pull/336/commits/e01db7a34233f697c30e982cd924b516af3d188a)
3) smuggled a small improvement to the codebase (https://github.com/ezsystems/ezplatform-kernel/pull/336/commits/9f21465e5a7bcb3b6717f1648fcc514c331dc84f) - the `isEmptyValue(SPIValue $value)` signature does not allow nulls, this removal is even suggested by PHPStorm.

In the original discussion there was this suggestion:
```
From my point of view, isEmptyValue for CheckboxFieldtype should check only for null value as default value have that value set.
```

But I'm not sure about it - the default value seems to be `false` and `null` seems is not even specified as an allowed value:
https://github.com/ezsystems/ezplatform-kernel/blob/1.3/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/CheckboxConverter.php#L74
https://github.com/ezsystems/ezplatform-kernel/blob/1.3/eZ/Publish/Core/Persistence/Legacy/Content/FieldValue/Converter/CheckboxConverter.php#L39
https://github.com/ezsystems/ezplatform-kernel/blob/1.3/eZ/Publish/Core/FieldType/Checkbox/Value.php#L16-L21

Changing the default value to `null` (and allowing the value to be `bool|null`) seems like asking for trouble, because 3rd party code might not be ready to deal with nulls in the value - that's why I went the "this field is never empty" way.

If accepted, I will prepare a PR removing this condition:
https://github.com/ezsystems/ezplatform-admin-ui/blob/e9f2b07f26a47f0158417ea0e2ddf4f0ea5436b7/src/bundle/Resources/views/themes/admin/content/content_view_fields.html.twig#L25

as it will be no longer needed.

I will gladly accept any feedback, as my kernel-fu is very, very basic 😄 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
