### PR TITLE
IBX-3877: Made SettingHandler cache transaction-aware

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/SettingHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/SettingHandler.php
@@ -12,7 +12,7 @@ use eZ\Publish\SPI\Persistence\Setting\Setting;
 /**
  * @see \eZ\Publish\SPI\Persistence\Setting\Handler
  */
-final class SettingHandler extends AbstractHandler implements SettingHandlerInterface
+final class SettingHandler extends AbstractInMemoryPersistenceHandler implements SettingHandlerInterface
 {
     private const SETTING_IDENTIFIER = 'setting';
 

--- a/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/AbstractBaseHandlerTest.php
@@ -102,7 +102,7 @@ abstract class AbstractBaseHandlerTest extends TestCase
             new CacheNotificationHandler(...$cacheAbstractHandlerArguments),
             new CacheUserPreferenceHandler(...$cacheInMemoryHandlerArguments),
             new CacheUrlWildcardHandler(...$cacheAbstractHandlerArguments),
-            new CacheSettingHandler(...$cacheAbstractHandlerArguments),
+            new CacheSettingHandler(...$cacheInMemoryHandlerArguments),
             $this->loggerMock
         );
 

--- a/eZ/Publish/Core/settings/storage_engines/cache.yml
+++ b/eZ/Publish/Core/settings/storage_engines/cache.yml
@@ -343,7 +343,7 @@ services:
         parent: ezpublish.spi.persistence.cache.abstractHandler
 
     eZ\Publish\Core\Persistence\Cache\SettingHandler:
-        parent: ezpublish.spi.persistence.cache.abstractHandler
+        parent: ezpublish.spi.persistence.cache.abstractInMemoryPersistenceHandler
 
     ezpublish.spi.persistence.cache:
         class: eZ\Publish\Core\Persistence\Cache\Handler


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3877](https://issues.ibexa.co/browse/IBX-3877)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

When performing `ibexa:install`, if at any point a command is issued that performs operations on settings, it is possible to insert entry to shared cache, which is then not removed when the command fails (and database transaction is rolled back).

This PR tries to remedy this by changing the implementation of cache to in memory, transaction aware one (as is the case for multitude of other handlers).

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (main for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ibexa/engineering`).
