### PR TITLE
Added data type for sudo $callback argument for static analysis

### DIFF
--- a/eZ/Publish/API/Repository/Repository.php
+++ b/eZ/Publish/API/Repository/Repository.php
@@ -25,14 +25,15 @@ interface Repository
      *         }
      *     );
      *
+     * @template T
      *
-     * @param callable $callback
+     * @param callable(\eZ\Publish\API\Repository\Repository): T $callback
      * @param \eZ\Publish\API\Repository\Repository|null $outerRepository Optional, mostly for internal use but allows to
      *                                                   specify Repository to pass to closure.
      *
      * @throws \Exception Re-throws exceptions thrown inside $callback
      *
-     * @return mixed
+     * @return T
      */
     public function sudo(callable $callback, ?Repository $outerRepository = null);
 

--- a/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
+++ b/eZ/Publish/Core/Repository/Permission/PermissionResolver.php
@@ -405,7 +405,7 @@ class PermissionResolver implements PermissionResolverInterface
      *         }
      *     );
      *
-     * @param \Closure $callback
+     * @param \callable(\eZ\Publish\API\Repository\Repository): mixed $callback
      * @param \eZ\Publish\API\Repository\Repository $outerRepository
      *
      * @throws \RuntimeException Thrown on recursive sudo() use.


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR adds type information for static analysis tools regarding `$callback` callable argument for `Repository::sudo`.

This ensures that code using the callback will have matching return type as needed.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] ~Provided automated test coverage.~
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
