### PR TITLE
Dropped `@throws \Exception` report from Repository::sudo

### DIFF
--- a/eZ/Publish/API/Repository/Repository.php
+++ b/eZ/Publish/API/Repository/Repository.php
@@ -16,7 +16,7 @@ interface Repository
     /**
      * Allows API execution to be performed with full access, sand-boxed.
      *
-     * The closure sandbox will do a catch all on exceptions and rethrow after
+     * The closure sandbox will do a "catch-all" on all exceptions and rethrow after
      * re-setting the sudo flag.
      *
      * Example use:
@@ -28,10 +28,8 @@ interface Repository
      * @template T
      *
      * @param callable(\eZ\Publish\API\Repository\Repository): T $callback
-     * @param \eZ\Publish\API\Repository\Repository|null $outerRepository Optional, mostly for internal use but allows to
-     *                                                   specify Repository to pass to closure.
-     *
-     * @throws \Exception Re-throws exceptions thrown inside $callback
+     * @param \eZ\Publish\API\Repository\Repository|null $outerRepository Optional, mostly
+     *        for internal use but allows to specify Repository to pass to closure.
      *
      * @return T
      */

--- a/eZ/Publish/Core/Repository/Repository.php
+++ b/eZ/Publish/Core/Repository/Repository.php
@@ -334,9 +334,6 @@ class Repository implements RepositoryInterface
         $this->passwordValidator = $passwordValidator;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function sudo(callable $callback, ?RepositoryInterface $outerRepository = null)
     {
         return $this->getPermissionResolver()->sudo($callback, $outerRepository ?? $this);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no

Requirement of handling \Exception when calling sudo is a bit misleading given a callback can throw any Exception. It should be a responsibility of a developer to know what his callback might throw and either handle it or report on outer method.
