### PR TITLE
IBX-3794: Used Filtering to load Location children & impl. count method

### DIFF
--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -568,4 +568,13 @@ interface ContentService
      *        for a SiteAccess in a current context will be used.
      */
     public function find(Filter $filter, ?array $languages = null): ContentList;
+
+    /**
+     * Count total number of items returned by {@see find} method.
+     *
+     * @param string[] $languages a list of language codes to be added as additional constraints.
+     *        If skipped, by default, unless SiteAccessAware layer has been disabled, languages set
+     *        for a SiteAccess in a current context will be used.
+     */
+    public function count(Filter $filter, ?array $languages = null): int;
 }

--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -257,4 +257,13 @@ interface LocationService
      *        for a SiteAccess in a current context will be used.
      */
     public function find(Filter $filter, ?array $languages = null): LocationList;
+
+    /**
+     * Count total number of items returned by {@see find} method.
+     *
+     * @param string[] $languages a list of language codes to be added as additional constraints.
+     *        If skipped, by default, unless SiteAccessAware layer has been disabled, languages set
+     *        for a SiteAccess in a current context will be used.
+     */
+    public function count(Filter $filter, ?array $languages = null): int;
 }

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1149,30 +1149,22 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
-     * Test for the loadLocationChildren() method.
-     *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location[]
-     *
-     * @see \eZ\Publish\API\Repository\LocationService::loadLocationChildren($location, $offset)
-     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadLocationChildren
+     * @covers \eZ\Publish\API\Repository\LocationService::loadLocationChildren
      */
-    public function testLoadLocationChildrenWithOffset()
+    public function testLoadLocationChildrenWithOffset(): LocationList
     {
         $repository = $this->getRepository();
 
         $locationId = $this->generateId('location', 5);
-        /* BEGIN: Use Case */
         // $locationId is the ID of an existing location
         $locationService = $repository->getLocationService();
 
         $location = $locationService->loadLocation($locationId);
 
         $childLocations = $locationService->loadLocationChildren($location, 2);
-        /* END: Use Case */
 
-        $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\Content\\LocationList', $childLocations);
-        $this->assertIsArray($childLocations->locations);
-        $this->assertIsInt($childLocations->totalCount);
+        self::assertIsIterable($childLocations);
+        self::assertIsInt($childLocations->totalCount);
 
         return $childLocations;
     }
@@ -1182,59 +1174,50 @@ class LocationServiceTest extends BaseTest
      *
      * @param \eZ\Publish\API\Repository\Values\Content\LocationList $locations
      *
-     * @see \eZ\Publish\API\Repository\LocationService::loadLocationChildren($location, $offset)
-     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadLocationChildrenWithOffset
+     * @covers \eZ\Publish\API\Repository\LocationService::loadLocationChildren
+     *
+     * @depends testLoadLocationChildrenWithOffset
      */
-    public function testLoadLocationChildrenDataWithOffset(LocationList $locations)
+    public function testLoadLocationChildrenDataWithOffset(LocationList $locations): void
     {
-        $this->assertCount(3, $locations->locations);
-        $this->assertEquals(5, $locations->getTotalCount());
+        self::assertCount(3, $locations->locations);
+        self::assertEquals(5, $locations->getTotalCount());
 
+        $actualLocationIds = [];
         foreach ($locations->locations as $location) {
-            $this->assertInstanceOf(
-                '\\eZ\\Publish\\API\\Repository\\Values\\Content\\Location',
-                $location
-            );
+            self::assertInstanceOf(Location::class, $location);
+            $actualLocationIds[] = $location->id;
         }
 
-        $this->assertEquals(
+        self::assertEquals(
             [
                 $this->generateId('location', 14),
                 $this->generateId('location', 44),
                 $this->generateId('location', 61),
             ],
-            array_map(
-                static function (Location $location) {
-                    return $location->id;
-                },
-                $locations->locations
-            )
+            $actualLocationIds
         );
     }
 
     /**
      * Test for the loadLocationChildren() method.
      *
-     * @return \eZ\Publish\API\Repository\Values\Content\Location[]
+     * @covers \eZ\Publish\API\Repository\LocationService::loadLocationChildren
      *
-     * @see \eZ\Publish\API\Repository\LocationService::loadLocationChildren($location, $offset, $limit)
      * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadLocationChildren
      */
-    public function testLoadLocationChildrenWithOffsetAndLimit()
+    public function testLoadLocationChildrenWithOffsetAndLimit(): LocationList
     {
         $repository = $this->getRepository();
 
         $locationId = $this->generateId('location', 5);
-        /* BEGIN: Use Case */
         // $locationId is the ID of an existing location
         $locationService = $repository->getLocationService();
 
         $location = $locationService->loadLocation($locationId);
 
         $childLocations = $locationService->loadLocationChildren($location, 2, 2);
-        /* END: Use Case */
 
-        $this->assertInstanceOf('\\eZ\\Publish\\API\\Repository\\Values\\Content\\LocationList', $childLocations);
         $this->assertIsArray($childLocations->locations);
         $this->assertIsInt($childLocations->totalCount);
 
@@ -1242,23 +1225,19 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
-     * Test for the loadLocationChildren() method.
+     * @covers \eZ\Publish\API\Repository\LocationService::loadLocationChildren
      *
-     * @param \eZ\Publish\API\Repository\Values\Content\Location[] $locations
-     *
-     * @see \eZ\Publish\API\Repository\LocationService::loadLocationChildren($location, $offset, $limit)
-     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadLocationChildrenWithOffsetAndLimit
+     * @depends testLoadLocationChildrenWithOffsetAndLimit
      */
-    public function testLoadLocationChildrenDataWithOffsetAndLimit(LocationList $locations)
+    public function testLoadLocationChildrenDataWithOffsetAndLimit(LocationList $locations): void
     {
         $this->assertCount(2, $locations->locations);
         $this->assertEquals(5, $locations->getTotalCount());
 
+        $actualLocationIds = [];
         foreach ($locations->locations as $location) {
-            $this->assertInstanceOf(
-                '\\eZ\\Publish\\API\\Repository\\Values\\Content\\Location',
-                $location
-            );
+            self::assertInstanceOf(Location::class, $location);
+            $actualLocationIds[] = $location->id;
         }
 
         $this->assertEquals(
@@ -1266,12 +1245,7 @@ class LocationServiceTest extends BaseTest
                 $this->generateId('location', 14),
                 $this->generateId('location', 44),
             ],
-            array_map(
-                static function (Location $location) {
-                    return $location->id;
-                },
-                $locations->locations
-            )
+            $actualLocationIds
         );
     }
 

--- a/eZ/Publish/Core/Pagination/Pagerfanta/ContentFilteringAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/ContentFilteringAdapter.php
@@ -42,13 +42,7 @@ final class ContentFilteringAdapter implements AdapterInterface
     public function getNbResults(): int
     {
         if ($this->totalCount === null) {
-            $countFilter = clone $this->filter;
-            $countFilter->sliceBy(0, 0);
-
-            $this->totalCount = $this->contentService->find(
-                $countFilter,
-                $this->languageFilter
-            )->getTotalCount();
+            $this->totalCount = $this->contentService->count($this->filter, $this->languageFilter);
         }
 
         return $this->totalCount;

--- a/eZ/Publish/Core/Pagination/Pagerfanta/LocationFilteringAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/LocationFilteringAdapter.php
@@ -39,13 +39,7 @@ final class LocationFilteringAdapter implements AdapterInterface
     public function getNbResults(): int
     {
         if ($this->totalCount === null) {
-            $countFilter = clone $this->filter;
-            $countFilter->sliceBy(0, 0);
-
-            $this->totalCount = $this->locationService->find(
-                $countFilter,
-                $this->languageFilter
-            )->getTotalCount();
+            $this->totalCount = $this->locationService->count($this->filter, $this->languageFilter);
         }
 
         return $this->totalCount;

--- a/eZ/Publish/Core/Pagination/Tests/ContentFilteringAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/ContentFilteringAdapterTest.php
@@ -34,21 +34,29 @@ final class ContentFilteringAdapterTest extends TestCase
     {
         $expectedNumberOfItems = 10;
 
+        $filter = new Filter();
+        $filter->sliceBy(5, 0);
+
+        // Make sure that count query doesn't fetch results
         $this->contentService
-            ->method('find')
+            ->expects(self::never())
+            ->method('find');
+
+        $this->contentService
+            ->method('count')
             ->with(
-                (new Filter())->sliceBy(0, 0), // Make sure that count query doesn't fetch results
+                $filter,
                 self::EXAMPLE_LANGUAGE_FILTER
             )
-            ->willReturn($this->createExpectedContentList($expectedNumberOfItems));
+            ->willReturn($expectedNumberOfItems);
 
         $adapter = new ContentFilteringAdapter(
             $this->contentService,
-            (new Filter())->sliceBy(10, 0),
+            $filter,
             self::EXAMPLE_LANGUAGE_FILTER
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedNumberOfItems,
             $adapter->getNbResults()
         );

--- a/eZ/Publish/Core/Pagination/Tests/LocationFilteringAdapterTest.php
+++ b/eZ/Publish/Core/Pagination/Tests/LocationFilteringAdapterTest.php
@@ -34,21 +34,29 @@ final class LocationFilteringAdapterTest extends TestCase
     {
         $expectedNumberOfItems = 10;
 
+        $filter = new Filter();
+        $filter->sliceBy(5, 0);
+
+        // Make sure that count query doesn't fetch results
         $this->locationService
-            ->method('find')
+            ->expects(self::never())
+            ->method('find');
+
+        $this->locationService
+            ->method('count')
             ->with(
-                (new Filter())->sliceBy(0, 0), // Make sure that count query doesn't fetch results
+                $filter,
                 self::EXAMPLE_LANGUAGE_FILTER
             )
-            ->willReturn($this->createExpectedLocationList($expectedNumberOfItems));
+            ->willReturn($expectedNumberOfItems);
 
         $adapter = new LocationFilteringAdapter(
             $this->locationService,
-            (new Filter())->sliceBy(10, 0),
+            $filter,
             self::EXAMPLE_LANGUAGE_FILTER
         );
 
-        $this->assertEquals(
+        self::assertEquals(
             $expectedNumberOfItems,
             $adapter->getNbResults()
         );

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Handler/ContentFilteringHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Handler/ContentFilteringHandler.php
@@ -72,4 +72,9 @@ final class ContentFilteringHandler implements Handler
 
         return $list;
     }
+
+    public function count(Filter $filter): int
+    {
+        return $this->gateway->count($filter->getCriterion());
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Handler/LocationFilteringHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Handler/LocationFilteringHandler.php
@@ -68,4 +68,9 @@ class LocationFilteringHandler implements Handler
 
         return $list;
     }
+
+    public function count(Filter $filter): int
+    {
+        return $this->gateway->count($filter->getCriterion());
+    }
 }

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -2503,4 +2503,27 @@ class ContentService implements ContentServiceInterface
 
         return new ContentList($contentItemsIterator->getTotalCount(), $contentItems);
     }
+
+    public function count(Filter $filter, ?array $languages = null): int
+    {
+        $filter = clone $filter;
+        if (!empty($languages)) {
+            $filter->andWithCriterion(new LanguageCode($languages));
+        }
+
+        $permissionCriterion = $this->permissionResolver->getQueryPermissionsCriterion();
+        if ($permissionCriterion instanceof Criterion\MatchNone) {
+            return 0;
+        }
+
+        if (!$permissionCriterion instanceof Criterion\MatchAll) {
+            if (!$permissionCriterion instanceof FilteringCriterion) {
+                return 0;
+            }
+
+            $filter->andWithCriterion($permissionCriterion);
+        }
+
+        return $this->contentFilteringHandler->count($filter);
+    }
 }

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -946,6 +946,29 @@ class LocationService implements LocationServiceInterface
         );
     }
 
+    public function count(Filter $filter, ?array $languages = null): int
+    {
+        $filter = clone $filter;
+        if (!empty($languages)) {
+            $filter->andWithCriterion(new LanguageCode($languages));
+        }
+
+        $permissionCriterion = $this->permissionCriterionResolver->getQueryPermissionsCriterion();
+        if ($permissionCriterion instanceof Criterion\MatchNone) {
+            return 0;
+        }
+
+        if (!$permissionCriterion instanceof Criterion\MatchAll) {
+            if (!$permissionCriterion instanceof FilteringCriterion) {
+                return 0;
+            }
+
+            $filter->andWithCriterion($permissionCriterion);
+        }
+
+        return $this->locationFilteringHandler->count($filter);
+    }
+
     private function checkCreatePermissionOnSubtreeTarget(APILocation $targetParentLocation, APILocation $loadedSubtree, APILocation $loadedTargetLocation): void
     {
         $locationTarget = (new DestinationLocationTarget($targetParentLocation->id, $loadedSubtree->contentInfo));

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -278,4 +278,12 @@ class ContentService implements ContentServiceInterface
             $this->languageResolver->getPrioritizedLanguages($languages)
         );
     }
+
+    public function count(Filter $filter, ?array $languages = null): int
+    {
+        return $this->service->count(
+            $filter,
+            $this->languageResolver->getPrioritizedLanguages($languages)
+        );
+    }
 }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
@@ -186,4 +186,12 @@ class LocationService implements LocationServiceInterface
             $this->languageResolver->getPrioritizedLanguages($languages)
         );
     }
+
+    public function count(Filter $filter, ?array $languages = null): int
+    {
+        return $this->service->count(
+            $filter,
+            $this->languageResolver->getPrioritizedLanguages($languages)
+        );
+    }
 }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/ContentServiceTest.php
@@ -157,6 +157,9 @@ class ContentServiceTest extends AbstractServiceTest
 
             ['find', [$filter], new ContentList(1, [$content]), 1],
             ['find', [$filter, self::LANG_ARG], new ContentList(1, [$content]), 1],
+
+            ['count', [$filter], 0, 1],
+            ['count', [$filter, self::LANG_ARG], 0, 1],
         ];
     }
 }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LocationServiceTest.php
@@ -99,6 +99,9 @@ class LocationServiceTest extends AbstractServiceTest
 
             ['find', [$filter], $locationList, 1],
             ['find', [$filter, self::LANG_ARG], $locationList, 1],
+
+            ['count', [$filter], 0, 1],
+            ['count', [$filter, self::LANG_ARG], 0, 1],
         ];
     }
 }

--- a/eZ/Publish/SPI/Persistence/Filter/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Filter/Content/Handler.php
@@ -21,4 +21,6 @@ interface Handler
      * @return \eZ\Publish\SPI\Persistence\Filter\Content\LazyContentItemListIterator
      */
     public function find(Filter $filter): iterable;
+
+    public function count(Filter $filter): int;
 }

--- a/eZ/Publish/SPI/Persistence/Filter/Location/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Filter/Location/Handler.php
@@ -21,4 +21,6 @@ interface Handler
      * @return \eZ\Publish\SPI\Persistence\Filter\Location\LazyLocationListIterator
      */
     public function find(Filter $filter): iterable;
+
+    public function count(Filter $filter): int;
 }

--- a/eZ/Publish/SPI/Repository/Decorator/ContentServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/ContentServiceDecorator.php
@@ -270,4 +270,9 @@ abstract class ContentServiceDecorator implements ContentService
     {
         return $this->innerService->find($filter, $languages);
     }
+
+    public function count(Filter $filter, ?array $languages = null): int
+    {
+        return $this->innerService->count($filter, $languages);
+    }
 }

--- a/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
@@ -154,4 +154,9 @@ abstract class LocationServiceDecorator implements LocationService
     {
         return $this->innerService->find($filter, $languages);
     }
+
+    public function count(Filter $filter, ?array $languages = null): int
+    {
+        return $this->innerService->count($filter, $languages);
+    }
 }

--- a/tests/lib/Repository/ContentServiceTest.php
+++ b/tests/lib/Repository/ContentServiceTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Repository;
+
+use eZ\Publish\API\Repository\PermissionService;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Filter\Filter;
+use eZ\Publish\Core\FieldType\FieldTypeRegistry;
+use eZ\Publish\Core\Repository\ContentService;
+use eZ\Publish\Core\Repository\Helper\NameSchemaService;
+use eZ\Publish\Core\Repository\Helper\RelationProcessor;
+use eZ\Publish\Core\Repository\Mapper\ContentDomainMapper;
+use eZ\Publish\Core\Repository\Mapper\ContentMapper;
+use eZ\Publish\SPI\Persistence\Filter\Content\Handler as ContentFilteringHandler;
+use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
+use eZ\Publish\SPI\Repository\Validator\ContentValidator;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @internal
+ */
+final class ContentServiceTest extends TestCase
+{
+    /** @var \eZ\Publish\API\Repository\ContentService */
+    private $contentService;
+
+    protected function setUp(): void
+    {
+        $this->contentService = new ContentService(
+            $this->createMock(Repository::class),
+            $this->createMock(PersistenceHandler::class),
+            $this->createMock(ContentDomainMapper::class),
+            $this->createMock(RelationProcessor::class),
+            $this->createMock(NameSchemaService::class),
+            $this->createMock(FieldTypeRegistry::class),
+            $this->createMock(PermissionService::class),
+            $this->createMock(ContentMapper::class),
+            $this->createMock(ContentValidator::class),
+            $this->createMock(ContentFilteringHandler::class)
+        );
+    }
+
+    public function testFindDoesNotModifyFilter(): void
+    {
+        $filter = new Filter();
+        $originalFilter = clone $filter;
+        $this->contentService->find($filter, ['eng-GB']);
+        self::assertEquals($originalFilter, $filter);
+    }
+
+    public function testCountDoesNotModifyFilter(): void
+    {
+        $filter = new Filter();
+        $originalFilter = clone $filter;
+        $this->contentService->count($filter, ['eng-GB']);
+        self::assertEquals($originalFilter, $filter);
+    }
+}

--- a/tests/lib/Repository/LocationServiceTest.php
+++ b/tests/lib/Repository/LocationServiceTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Repository;
+
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\PermissionCriterionResolver;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\Repository;
+use eZ\Publish\API\Repository\Values\Filter\Filter;
+use eZ\Publish\Core\Repository\Helper\NameSchemaService;
+use eZ\Publish\Core\Repository\LocationService;
+use eZ\Publish\Core\Repository\Mapper\ContentDomainMapper;
+use eZ\Publish\SPI\Persistence\Filter\Location\Handler as LocationFilteringHandler;
+use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
+use PHPUnit\Framework\TestCase;
+
+final class LocationServiceTest extends TestCase
+{
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    protected function setUp(): void
+    {
+        $this->locationService = new LocationService(
+            $this->createMock(Repository::class),
+            $this->createMock(PersistenceHandler::class),
+            $this->createMock(ContentDomainMapper::class),
+            $this->createMock(NameSchemaService::class),
+            $this->createMock(PermissionCriterionResolver::class),
+            $this->createMock(PermissionResolver::class),
+            $this->createMock(LocationFilteringHandler::class),
+            $this->createMock(ContentTypeService::class)
+        );
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\Exception
+     */
+    public function testFindDoesNotModifyFilter(): void
+    {
+        $filter = new Filter();
+        $originalFilter = clone $filter;
+        $this->locationService->find($filter, ['eng-GB']);
+        self::assertEquals($originalFilter, $filter);
+    }
+
+    public function testCountDoesNotModifyFilter(): void
+    {
+        $filter = new Filter();
+        $originalFilter = clone $filter;
+        $this->locationService->count($filter, ['eng-GB']);
+        self::assertEquals($originalFilter, $filter);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3794](https://issues.ibexa.co/browse/IBX-3794)
| **Requires**                            | ezsystems/ezplatform-kernel#341, ezsystems/ezplatform-admin-ui#2072
| **Type**                                   | feature
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | yes, on API interfaces, which you shouldn't implement ;)

Addressing Search service usage issues on multiple layer:
1. Seems for better performance of changes done in https://github.com/ezsystems/ezplatform-admin-ui/pull/2072 we need `count` method which would return only the number of items matching by Repository filtering `find` methods (in `ContentService` and `LocationService` respectively).
2. LocationService::loadLocationChildren should rely on Repository Filtering instead of search.

### TODO
- [x] Manual tests
- [x] Integration tests

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
