### PR TITLE
IBX-4008: Fixed incorrect total count of LocationService::find items

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1122,7 +1122,7 @@ class LocationServiceTest extends BaseTest
     public function testLoadLocationChildrenData(LocationList $locations)
     {
         $this->assertCount(5, $locations->locations);
-        $this->assertEquals(5, $locations->totalCount);
+        $this->assertEquals(5, $locations->getTotalCount());
 
         foreach ($locations->locations as $location) {
             $this->assertInstanceOf(
@@ -1188,7 +1188,7 @@ class LocationServiceTest extends BaseTest
     public function testLoadLocationChildrenDataWithOffset(LocationList $locations)
     {
         $this->assertCount(3, $locations->locations);
-        $this->assertEquals(5, $locations->totalCount);
+        $this->assertEquals(5, $locations->getTotalCount());
 
         foreach ($locations->locations as $location) {
             $this->assertInstanceOf(
@@ -1252,7 +1252,7 @@ class LocationServiceTest extends BaseTest
     public function testLoadLocationChildrenDataWithOffsetAndLimit(LocationList $locations)
     {
         $this->assertCount(2, $locations->locations);
-        $this->assertEquals(5, $locations->totalCount);
+        $this->assertEquals(5, $locations->getTotalCount());
 
         foreach ($locations->locations as $location) {
             $this->assertInstanceOf(

--- a/eZ/Publish/API/Repository/Values/Content/ContentList.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentList.php
@@ -9,13 +9,14 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Values\Content;
 
 use ArrayIterator;
+use Ibexa\Contracts\Core\Repository\Collections\TotalCountAwareInterface;
 use IteratorAggregate;
 use Traversable;
 
 /**
  * A filtered Content items list iterator.
  */
-final class ContentList implements IteratorAggregate
+final class ContentList implements IteratorAggregate, TotalCountAwareInterface
 {
     /** @var int */
     private $totalCount;

--- a/eZ/Publish/API/Repository/Values/Content/LocationList.php
+++ b/eZ/Publish/API/Repository/Values/Content/LocationList.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\API\Repository\Values\Content;
 
 use ArrayIterator;
 use eZ\Publish\API\Repository\Values\ValueObject;
+use Ibexa\Contracts\Core\Repository\Collections\TotalCountAwareInterface;
 use IteratorAggregate;
 use Traversable;
 
@@ -18,12 +19,15 @@ use Traversable;
  * (by offset/limit parameters and permission filters).
  *
  * @property-read int $totalCount - the total count of found locations (filtered by permissions)
- * @property-read \eZ\Publish\API\Repository\Values\Content\Location[] $locations - the partial list of locations controlled by offset/limit
+ * @property-read \eZ\Publish\API\Repository\Values\Content\Location[] $locations - the partial list of
+ *                Locations controlled by offset/limit.
  **/
-class LocationList extends ValueObject implements IteratorAggregate
+class LocationList extends ValueObject implements IteratorAggregate, TotalCountAwareInterface
 {
     /**
-     * the total count of found locations (filtered by permissions).
+     * The total count of non-paginated Locations (filtered by permissions).
+     *
+     * Use {@see getTotalCount} to fetch it.
      *
      * @var int
      */
@@ -42,5 +46,10 @@ class LocationList extends ValueObject implements IteratorAggregate
     public function getIterator(): Traversable
     {
         return new ArrayIterator($this->locations);
+    }
+
+    public function getTotalCount(): int
+    {
+        return $this->totalCount;
     }
 }

--- a/eZ/Publish/Core/Pagination/Pagerfanta/LocationFilteringAdapter.php
+++ b/eZ/Publish/Core/Pagination/Pagerfanta/LocationFilteringAdapter.php
@@ -45,7 +45,7 @@ final class LocationFilteringAdapter implements AdapterInterface
             $this->totalCount = $this->locationService->find(
                 $countFilter,
                 $this->languageFilter
-            )->totalCount;
+            )->getTotalCount();
         }
 
         return $this->totalCount;
@@ -58,7 +58,7 @@ final class LocationFilteringAdapter implements AdapterInterface
 
         $results = $this->locationService->find($selectFilter, $this->languageFilter);
         if ($this->totalCount === null) {
-            $this->totalCount = $results->totalCount;
+            $this->totalCount = $results->getTotalCount();
         }
 
         return $results;

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Repository;
 
-use function count;
 use Exception;
 use eZ\Publish\API\Repository\ContentTypeService;
 use eZ\Publish\API\Repository\Exceptions\NotFoundException as APINotFoundException;
@@ -929,7 +928,8 @@ class LocationService implements LocationServiceInterface
         }
 
         $locations = [];
-        foreach ($this->locationFilteringHandler->find($filter) as $locationWithContentInfo) {
+        $locationListIterator = $this->locationFilteringHandler->find($filter);
+        foreach ($locationListIterator as $locationWithContentInfo) {
             $spiContentInfo = $locationWithContentInfo->getContentInfo();
             $locations[] = $this->contentDomainMapper->buildLocationWithContent(
                 $locationWithContentInfo->getLocation(),
@@ -940,7 +940,7 @@ class LocationService implements LocationServiceInterface
 
         return new LocationList(
             [
-                'totalCount' => count($locations),
+                'totalCount' => $locationListIterator->getTotalCount(),
                 'locations' => $locations,
             ]
         );

--- a/eZ/Publish/SPI/Persistence/Filter/Location/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Filter/Location/Handler.php
@@ -18,7 +18,7 @@ use eZ\Publish\API\Repository\Values\Filter\Filter;
 interface Handler
 {
     /**
-     * @return \eZ\Publish\SPI\Persistence\Content\LocationWithContentInfo[]
+     * @return \eZ\Publish\SPI\Persistence\Filter\Location\LazyLocationListIterator
      */
     public function find(Filter $filter): iterable;
 }

--- a/src/contracts/Repository/Collections/TotalCountAwareInterface.php
+++ b/src/contracts/Repository/Collections/TotalCountAwareInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Repository\Collections;
+
+interface TotalCountAwareInterface
+{
+    /**
+     * Get a total number of items matched by criteria, regardless of slice (page, collection) size.
+     */
+    public function getTotalCount(): int;
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4008](https://issues.ibexa.co/browse/IBX-4008)
| **Required by**                      | [IBX-3794](https://issues.ibexa.co/browse/IBX-3794): ezsystems/ezplatform-kernel#340
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | yes, behavior did not follow the spec

Repository Filtering bug. We expect that `totalCount` on a `LocationList` returned by `LocationService` contains the total number of items matching Filtering Criterion, not the total number of items on a current page. Seems like [`ContentService::find` returns proper results](https://github.com/ezsystems/ezplatform-kernel/blob/v1.3.25/eZ/Publish/Core/Repository/ContentService.php#L2504), so this indeed was a mistake for `LocationService`. The change on SPI\Persistence interface was done to just PHPDoc, to align with [Content counterpart](https://github.com/ezsystems/ezplatform-kernel/blob/v1.3.25/eZ/Publish/SPI/Persistence/Filter/Content/Handler.php#L21).

### TODO
- [x] Seems we're missing integration test coverage for this code path

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
