### PR TITLE
IBX-3595: Fixed processing timestamps in ibexa:timestamps:to-utc command

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/UpdateTimestampsToUTCCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/UpdateTimestampsToUTCCommand.php
@@ -234,9 +234,7 @@ EOT
                     $processScriptFragments[] = '--dry-run';
                 }
 
-                $process = new Process(
-                    implode(' ', $processScriptFragments)
-                );
+                $process = new Process($processScriptFragments);
 
                 $process->setEnv(['INNER_CALL' => 1]);
                 $process->run();
@@ -274,7 +272,7 @@ EOT
         $dateTimeInUTC->setTimezone(new DateTimeZone('UTC'));
 
         foreach ($timestampBasedFields as $timestampBasedField) {
-            $timestamp = $timestampBasedField['data_int'];
+            $timestamp = (int)$timestampBasedField['data_int'];
             $dateTimeInUTC->setTimestamp($timestamp);
             $newTimestamp = $this->convertToUtcTimestamp($timestamp);
 
@@ -375,7 +373,7 @@ EOT
         $dateTimeZone = new DateTimeZone($this->timezone);
         $dateTimeZoneUTC = new DateTimeZone('UTC');
 
-        $dateTime = new DateTime(null, $dateTimeZone);
+        $dateTime = new DateTime('now', $dateTimeZone);
         $dateTime->setTimestamp($timestamp);
         $dateTimeUTC = new DateTime($dateTime->format('Y-m-d H:i:s'), $dateTimeZoneUTC);
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3595](https://issues.ibexa.co/browse/IBX-3595)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Date Field shows -1D after update to v3.3.15+ (from v3.3.14)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
