### PR TITLE
IBX-4018: Implement `supportsDenormalization` method for `CompoundMatcherNormalizer`

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Component/Serializer/CompoundMatcherNormalizer.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Serializer/CompoundMatcherNormalizer.php
@@ -31,4 +31,9 @@ class CompoundMatcherNormalizer extends AbstractPropertyWhitelistNormalizer
     {
         return $data instanceof Matcher\Compound;
     }
+
+    public function supportsDenormalization($data, string $type, string $format = null)
+    {
+        return $type === Matcher\Compound::class;
+    }
 }

--- a/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/CompoundMatcherNormalizerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Component/Tests/Serializer/CompoundMatcherNormalizerTest.php
@@ -51,4 +51,22 @@ final class CompoundMatcherNormalizerTest extends TestCase
         $this->assertTrue($normalizer->supportsNormalization($this->createMock(Compound::class)));
         $this->assertFalse($normalizer->supportsNormalization($this->createMock(Matcher::class)));
     }
+
+    public function testSupportsDenormalization(): void
+    {
+        $normalizer = new CompoundMatcherNormalizer();
+
+        $data = json_encode(
+            [
+                'subMatchers' => [
+                    'foo' => ['data' => 'foo'],
+                ],
+                'config' => [],
+                'matchersMap' => [],
+            ]
+        );
+
+        $this->assertTrue($normalizer->supportsDenormalization($data, Compound::class, 'json'));
+        $this->assertFalse($normalizer->supportsDenormalization($data, Matcher::class, 'json'));
+    }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4018](https://issues.ibexa.co/browse/IBX-4018)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Following PR prevents all objects to be denormalized using `CompoundMatcherNormalizer` when using Symfony's serializer.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
