### PR TITLE
[POC] IBX-4031: Force copying non-translateable fields to existing drafts during publish

### DIFF
--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1517,10 +1517,20 @@ class ContentService implements ContentServiceInterface
         }
 
         foreach ($versions as $versionInfo) {
+            $draftContent = $this->loadContentByVersionInfo($versionInfo);
+            $draftFieldValues = $fieldValues;
+            foreach ($draftContent->getFields() as $draftField) {
+                if ($draftField->languageCode === $currentVersionLanguageCode) {
+                    continue;
+                }
+                $fieldDefinition = $contentType->getFieldDefinition($draftField->fieldDefIdentifier);
+                $draftFieldValues[$fieldDefinition->identifier][$draftField->languageCode] = $draftField->getValue();
+            }
+
             $updateStruct = new SPIContentUpdateStruct();
             $updateStruct->name = $this->nameSchemaService->resolveNameSchema(
                 $content,
-                $fieldValues,
+                $draftFieldValues,
                 $versionInfo->languageCodes,
                 $contentType
             );


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4031](https://issues.ibexa.co/browse/IBX-4031)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | ?

Please, note that this PR is a proof of concept for now and unit tests will be implemented after everyone agrees that this is the correct approach.

**Reasoning:**
Currently, when a draft in a different language is way behind the newest, published version and has an old non-translatable field, publishing it will override the newest, published version and therefore update the non-translatable field to an old value.

This seems like a loophole as an editor managing for example a German translation can completely remove changes published long ago by an English (main language) editor.

This PR implements copying non-translateable fields to all drafts that have a different language than main language after publishing a version of main language. I'd be grateful for your opinions on this.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
