### PR TITLE
Introduced `IbexaKernelTestTrait` to reduce code duplication

### DIFF
--- a/src/contracts/Test/IbexaKernelTestCase.php
+++ b/src/contracts/Test/IbexaKernelTestCase.php
@@ -8,23 +8,7 @@ declare(strict_types=1);
 
 namespace Ibexa\Contracts\Core\Test;
 
-use Doctrine\DBAL\Connection;
-use eZ\Publish\API\Repository\ContentService;
-use eZ\Publish\API\Repository\ContentTypeService;
-use eZ\Publish\API\Repository\LanguageService;
-use eZ\Publish\API\Repository\LocationService;
-use eZ\Publish\API\Repository\ObjectStateService;
-use eZ\Publish\API\Repository\PermissionResolver;
-use eZ\Publish\API\Repository\RoleService;
-use eZ\Publish\API\Repository\SearchService;
-use eZ\Publish\API\Repository\SectionService;
-use eZ\Publish\API\Repository\Tests\LegacySchemaImporter;
-use eZ\Publish\API\Repository\UserService;
-use eZ\Publish\Core\Repository\Values\User\UserReference;
-use eZ\Publish\SPI\Persistence\TransactionHandler;
-use eZ\Publish\SPI\Tests\Persistence\FixtureImporter;
 use LogicException;
-use RuntimeException;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -32,8 +16,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  */
 abstract class IbexaKernelTestCase extends KernelTestCase
 {
-    private const FIXTURE_USER_ADMIN_ID = 14;
-    private const FIXTURE_USER_ANONYMOUS_ID = 10;
+    use IbexaKernelTestTrait;
 
     protected static function getKernelClass(): string
     {
@@ -42,150 +25,5 @@ abstract class IbexaKernelTestCase extends KernelTestCase
         } catch (LogicException $e) {
             return IbexaTestKernel::class;
         }
-    }
-
-    final protected static function loadSchema(): void
-    {
-        /** @var \eZ\Publish\API\Repository\Tests\LegacySchemaImporter $schemaImporter */
-        $schemaImporter = self::getContainer()->get(LegacySchemaImporter::class);
-        foreach (static::getSchemaFiles() as $schemaFile) {
-            $schemaImporter->importSchema($schemaFile);
-        }
-    }
-
-    /**
-     * @return iterable<string>
-     */
-    protected static function getSchemaFiles(): iterable
-    {
-        yield from self::$kernel->getSchemaFiles();
-    }
-
-    final protected static function loadFixtures(): void
-    {
-        /** @var \eZ\Publish\SPI\Tests\Persistence\FixtureImporter $fixtureImporter */
-        $fixtureImporter = self::getContainer()->get(FixtureImporter::class);
-        foreach (static::getFixtures() as $fixture) {
-            $fixtureImporter->import($fixture);
-        }
-
-        static::postLoadFixtures();
-    }
-
-    protected static function postLoadFixtures(): void
-    {
-    }
-
-    /**
-     * @return iterable<\eZ\Publish\SPI\Tests\Persistence\Fixture>
-     */
-    protected static function getFixtures(): iterable
-    {
-        yield from self::$kernel->getFixtures();
-    }
-
-    /**
-     * @template T of object
-     * @phpstan-param class-string<T> $className
-     *
-     * @return T
-     */
-    final protected static function getServiceByClassName(string $className, ?string $id = null): object
-    {
-        if (!self::$booted) {
-            static::bootKernel();
-        }
-
-        $serviceId = self::getTestServiceId($id, $className);
-        $service = self::getContainer()->get($serviceId);
-        assert(is_object($service) && is_a($service, $className));
-
-        return $service;
-    }
-
-    protected static function getTestServiceId(?string $id, string $className): string
-    {
-        $kernel = self::$kernel;
-        if (!$kernel instanceof IbexaTestKernel) {
-            throw new RuntimeException(sprintf(
-                'Expected %s to be an instance of %s.',
-                get_class($kernel),
-                IbexaTestKernel::class,
-            ));
-        }
-
-        $id = $id ?? $className;
-
-        return $kernel->getAliasServiceId($id);
-    }
-
-    protected static function getDoctrineConnection(): Connection
-    {
-        return self::getServiceByClassName(Connection::class);
-    }
-
-    protected static function getContentTypeService(): ContentTypeService
-    {
-        return self::getServiceByClassName(ContentTypeService::class);
-    }
-
-    protected static function getContentService(): ContentService
-    {
-        return self::getServiceByClassName(ContentService::class);
-    }
-
-    protected static function getLocationService(): LocationService
-    {
-        return self::getServiceByClassName(LocationService::class);
-    }
-
-    protected static function getPermissionResolver(): PermissionResolver
-    {
-        return self::getServiceByClassName(PermissionResolver::class);
-    }
-
-    protected static function getRoleService(): RoleService
-    {
-        return self::getServiceByClassName(RoleService::class);
-    }
-
-    protected static function getSearchService(): SearchService
-    {
-        return self::getServiceByClassName(SearchService::class);
-    }
-
-    protected static function getTransactionHandler(): TransactionHandler
-    {
-        return self::getServiceByClassName(TransactionHandler::class);
-    }
-
-    protected static function getUserService(): UserService
-    {
-        return self::getServiceByClassName(UserService::class);
-    }
-
-    protected static function getObjectStateService(): ObjectStateService
-    {
-        return self::getServiceByClassName(ObjectStateService::class);
-    }
-
-    protected static function getLanguageService(): LanguageService
-    {
-        return self::getServiceByClassName(LanguageService::class);
-    }
-
-    protected static function getSectionService(): SectionService
-    {
-        return self::getServiceByClassName(SectionService::class);
-    }
-
-    protected static function setAnonymousUser(): void
-    {
-        self::getPermissionResolver()->setCurrentUserReference(new UserReference(self::FIXTURE_USER_ANONYMOUS_ID));
-    }
-
-    protected static function setAdministratorUser(): void
-    {
-        self::getPermissionResolver()->setCurrentUserReference(new UserReference(self::FIXTURE_USER_ADMIN_ID));
     }
 }

--- a/src/contracts/Test/IbexaKernelTestTrait.php
+++ b/src/contracts/Test/IbexaKernelTestTrait.php
@@ -32,7 +32,7 @@ trait IbexaKernelTestTrait
 {
     private static $anonymousUserId = 10;
 
-    private static $adminUserId = 10;
+    private static $adminUserId = 14;
 
     final protected static function loadSchema(): void
     {

--- a/src/contracts/Test/IbexaKernelTestTrait.php
+++ b/src/contracts/Test/IbexaKernelTestTrait.php
@@ -31,6 +31,7 @@ use RuntimeException;
 trait IbexaKernelTestTrait
 {
     private static $anonymousUserId = 10;
+
     private static $adminUserId = 10;
 
     final protected static function loadSchema(): void

--- a/src/contracts/Test/IbexaKernelTestTrait.php
+++ b/src/contracts/Test/IbexaKernelTestTrait.php
@@ -30,10 +30,6 @@ use RuntimeException;
  */
 trait IbexaKernelTestTrait
 {
-    private static $anonymousUserId = 10;
-
-    private static $adminUserId = 14;
-
     final protected static function loadSchema(): void
     {
         $schemaImporter = self::getContainer()->get(LegacySchemaImporter::class);
@@ -169,11 +165,13 @@ trait IbexaKernelTestTrait
 
     protected static function setAnonymousUser(): void
     {
-        self::getPermissionResolver()->setCurrentUserReference(new UserReference(self::$anonymousUserId));
+        $anonymousUserId = 10;
+        self::getPermissionResolver()->setCurrentUserReference(new UserReference($anonymousUserId));
     }
 
     protected static function setAdministratorUser(): void
     {
-        self::getPermissionResolver()->setCurrentUserReference(new UserReference(self::$adminUserId));
+        $adminUserId = 14;
+        self::getPermissionResolver()->setCurrentUserReference(new UserReference($adminUserId));
     }
 }

--- a/src/contracts/Test/IbexaKernelTestTrait.php
+++ b/src/contracts/Test/IbexaKernelTestTrait.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\Test;
+
+use Doctrine\DBAL\Connection;
+use eZ\Publish\API\Repository\ContentService;
+use eZ\Publish\API\Repository\ContentTypeService;
+use eZ\Publish\API\Repository\LanguageService;
+use eZ\Publish\API\Repository\LocationService;
+use eZ\Publish\API\Repository\ObjectStateService;
+use eZ\Publish\API\Repository\PermissionResolver;
+use eZ\Publish\API\Repository\RoleService;
+use eZ\Publish\API\Repository\SearchService;
+use eZ\Publish\API\Repository\SectionService;
+use eZ\Publish\API\Repository\Tests\LegacySchemaImporter;
+use eZ\Publish\API\Repository\UserService;
+use eZ\Publish\Core\Repository\Values\User\UserReference;
+use eZ\Publish\SPI\Persistence\TransactionHandler;
+use eZ\Publish\SPI\Tests\Persistence\FixtureImporter;
+use RuntimeException;
+
+/**
+ *  @experimental
+ */
+trait IbexaKernelTestTrait
+{
+    private static $anonymousUserId = 10;
+    private static $adminUserId = 10;
+
+    final protected static function loadSchema(): void
+    {
+        $schemaImporter = self::getContainer()->get(LegacySchemaImporter::class);
+        foreach (static::getSchemaFiles() as $schemaFile) {
+            $schemaImporter->importSchema($schemaFile);
+        }
+    }
+
+    /**
+     * @return iterable<string>
+     */
+    protected static function getSchemaFiles(): iterable
+    {
+        yield from self::$kernel->getSchemaFiles();
+    }
+
+    final protected static function loadFixtures(): void
+    {
+        $fixtureImporter = self::getContainer()->get(FixtureImporter::class);
+        foreach (static::getFixtures() as $fixture) {
+            $fixtureImporter->import($fixture);
+        }
+
+        static::postLoadFixtures();
+    }
+
+    protected static function postLoadFixtures(): void
+    {
+    }
+
+    /**
+     * @return iterable<\eZ\Publish\SPI\Tests\Persistence\Fixture>
+     */
+    protected static function getFixtures(): iterable
+    {
+        yield from self::$kernel->getFixtures();
+    }
+
+    /**
+     * @template T of object
+     * @phpstan-param class-string<T> $className
+     *
+     * @return T
+     */
+    final protected static function getServiceByClassName(string $className, ?string $id = null): object
+    {
+        if (!self::$booted) {
+            static::bootKernel();
+        }
+
+        $serviceId = self::getTestServiceId($id, $className);
+        $service = self::getContainer()->get($serviceId);
+        assert(is_object($service) && is_a($service, $className));
+
+        return $service;
+    }
+
+    protected static function getTestServiceId(?string $id, string $className): string
+    {
+        $kernel = self::$kernel;
+        if (!$kernel instanceof IbexaTestKernel) {
+            throw new RuntimeException(sprintf(
+                'Expected %s to be an instance of %s.',
+                get_class($kernel),
+                IbexaTestKernel::class,
+            ));
+        }
+
+        $id = $id ?? $className;
+
+        return $kernel->getAliasServiceId($id);
+    }
+
+    protected static function getDoctrineConnection(): Connection
+    {
+        return self::getServiceByClassName(Connection::class);
+    }
+
+    protected static function getContentTypeService(): ContentTypeService
+    {
+        return self::getServiceByClassName(ContentTypeService::class);
+    }
+
+    protected static function getContentService(): ContentService
+    {
+        return self::getServiceByClassName(ContentService::class);
+    }
+
+    protected static function getLocationService(): LocationService
+    {
+        return self::getServiceByClassName(LocationService::class);
+    }
+
+    protected static function getPermissionResolver(): PermissionResolver
+    {
+        return self::getServiceByClassName(PermissionResolver::class);
+    }
+
+    protected static function getRoleService(): RoleService
+    {
+        return self::getServiceByClassName(RoleService::class);
+    }
+
+    protected static function getSearchService(): SearchService
+    {
+        return self::getServiceByClassName(SearchService::class);
+    }
+
+    protected static function getTransactionHandler(): TransactionHandler
+    {
+        return self::getServiceByClassName(TransactionHandler::class);
+    }
+
+    protected static function getUserService(): UserService
+    {
+        return self::getServiceByClassName(UserService::class);
+    }
+
+    protected static function getObjectStateService(): ObjectStateService
+    {
+        return self::getServiceByClassName(ObjectStateService::class);
+    }
+
+    protected static function getLanguageService(): LanguageService
+    {
+        return self::getServiceByClassName(LanguageService::class);
+    }
+
+    protected static function getSectionService(): SectionService
+    {
+        return self::getServiceByClassName(SectionService::class);
+    }
+
+    protected static function setAnonymousUser(): void
+    {
+        self::getPermissionResolver()->setCurrentUserReference(new UserReference(self::$anonymousUserId));
+    }
+
+    protected static function setAdministratorUser(): void
+    {
+        self::getPermissionResolver()->setCurrentUserReference(new UserReference(self::$adminUserId));
+    }
+}

--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -229,27 +229,4 @@ class IbexaTestKernel extends Kernel
     {
         $container->setDefinition('logger', new Definition(NullLogger::class));
     }
-
-    /**
-     * Creates synthetic services in container, allowing compilation of container when some services are missing.
-     * Additionally, those services can be replaced with mock implementations at runtime, allowing integration testing.
-     *
-     * You can set them up in KernelTestCase by calling `self::getContainer()->set($id, $this->createMock($class));`
-     *
-     * @phpstan-param class-string $class
-     */
-    protected static function addSyntheticService(ContainerBuilder $container, string $class, ?string $id = null): void
-    {
-        $id = $id ?? $class;
-        if ($container->has($id)) {
-            throw new LogicException(sprintf(
-                'Expected test kernel to not contain "%s" service. A real service should not be overwritten by a mock',
-                $id,
-            ));
-        }
-
-        $definition = new Definition($class);
-        $definition->setSynthetic(true);
-        $container->setDefinition($id, $definition);
-    }
 }

--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -229,4 +229,27 @@ class IbexaTestKernel extends Kernel
     {
         $container->setDefinition('logger', new Definition(NullLogger::class));
     }
+
+    /**
+     * Creates synthetic services in container, allowing compilation of container when some services are missing.
+     * Additionally, those services can be replaced with mock implementations at runtime, allowing integration testing.
+     *
+     * You can set them up in KernelTestCase by calling `self::getContainer()->set($id, $this->createMock($class));`
+     *
+     * @phpstan-param class-string $class
+     */
+    protected static function addSyntheticService(ContainerBuilder $container, string $class, ?string $id = null): void
+    {
+        $id = $id ?? $class;
+        if ($container->has($id)) {
+            throw new LogicException(sprintf(
+                'Expected test kernel to not contain "%s" service. A real service should not be overwritten by a mock',
+                $id,
+            ));
+        }
+
+        $definition = new Definition($class);
+        $definition->setSynthetic(true);
+        $container->setDefinition($id, $definition);
+    }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR moves code from `Ibexa\Contracts\Core\Test\IbexaKernelTestCase` to a new trait, `Ibexa\Contracts\Core\Test\IbexaKernelTestTrait`.

This is done to remove code duplication in dependent packages, which happens when one want to use `Symfony\Bundle\FrameworkBundle\Test\WebTestCase` in combination with our Kernel testing features (which requires code from both abstract classes, which is obviously not possible in PHP).

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
