### PR TITLE
Added `IbexaTestKernel::addSyntheticService` to reduce duplication

### DIFF
--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -229,4 +229,27 @@ class IbexaTestKernel extends Kernel
     {
         $container->setDefinition('logger', new Definition(NullLogger::class));
     }
+
+    /**
+     * Creates synthetic services in container, allowing compilation of container when some services are missing.
+     * Additionally, those services can be replaced with mock implementations at runtime, allowing integration testing.
+     *
+     * You can set them up in KernelTestCase by calling `self::getContainer()->set($id, $this->createMock($class));`
+     *
+     * @phpstan-param class-string $class
+     */
+    protected static function addSyntheticService(ContainerBuilder $container, string $class, ?string $id = null): void
+    {
+        $id = $id ?? $class;
+        if ($container->has($id)) {
+            throw new LogicException(sprintf(
+                'Expected test kernel to not contain "%s" service. A real service should not be overwritten by a mock',
+                $id,
+            ));
+        }
+
+        $definition = new Definition($class);
+        $definition->setSynthetic(true);
+        $container->setDefinition($id, $definition);
+    }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

`IbexaTestKernel::createSyntheticService()` is available inside multiple of our packages, and seems to be a common thing when a service replacement is necessary due to bundle dependency - and we don't actually need a particular package.

While best solution would be of course to not have those dependencies (or make them optional, but that's personal opinion and goes against our code practices) that's obviously not happening.

To prevent conflict with existing methods I'm adding it with a slightly changed naming, which accidentally also describes a little bit more what is happening, i.e. that a synthetic service definition is actually added do `ContainerBuilder`.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
