### PR TITLE
Added `admin_group` group declaration to default test settings

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/config/ezpublish.yaml
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/Resources/config/ezpublish.yaml
@@ -11,6 +11,8 @@ ezpublish:
               'eng': 'eng'
               'ku6"H': 'ku6"H'
           match: ~
+          groups:
+              admin_group: []
     repositories:
         default:
             storage: ~


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR adds `admin_group` setting to site access configuration. This setting is expected to exist by multiple request listeners in Admin UI.

Parameter is set here: 
https://github.com/ezsystems/ezplatform-kernel/blob/2a7479958584a15ee046dfa886d6bfeb4ebfa2f6/eZ/Bundle/EzPublishCoreBundle/DependencyInjection/EzPublishCoreExtension.php#L246

And subsequently used here: 
https://github.com/ezsystems/ezplatform-admin-ui/blob/e9f2b07f26a47f0158417ea0e2ddf4f0ea5436b7/src/lib/Specification/SiteAccess/IsAdmin.php#L42

Where the array key is expected to exist.

#### Checklist:
- [ ] Provided PR description.
- [ ] Tested the solution manually.
- [ ] Provided automated test coverage.
- [ ] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
