### PR TITLE
IBX-4384: Handled sort clauses in `loadLocationChildren`

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1250,6 +1250,54 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
+     * @covers \eZ\Publish\API\Repository\LocationService::loadLocationChildren
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     */
+    public function testLoadLocationChildrenDataWithSortingClause(): void
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $parentLocation = $locationService->loadLocation(5);
+
+        // Update Location in order to change sort clauses to Name DESC
+        $locationUpdateStruct = $locationService->newLocationUpdateStruct();
+        $locationUpdateStruct->sortField = Location::SORT_FIELD_NAME;
+        $locationUpdateStruct->sortOrder = Location::SORT_ORDER_DESC;
+        $parentLocation = $locationService->updateLocation(
+            $parentLocation,
+            $locationUpdateStruct
+        );
+
+        $children = $locationService->loadLocationChildren($parentLocation);
+        $namesWithDefaultSorting = [];
+        foreach ($children as $child) {
+            $namesWithDefaultSorting[] = $child->getContentInfo()->name;
+        }
+
+        // Update Location in order to change sort clauses to NAME ASC
+        $locationUpdateStruct = $locationService->newLocationUpdateStruct();
+        $locationUpdateStruct->sortField = Location::SORT_FIELD_NAME;
+        $locationUpdateStruct->sortOrder = Location::SORT_ORDER_ASC;
+        $parentLocation = $locationService->updateLocation(
+            $parentLocation,
+            $locationUpdateStruct
+        );
+
+        $children = $locationService->loadLocationChildren($parentLocation);
+
+        $namesWithContentSorting = [];
+        foreach ($children as $child) {
+            $namesWithContentSorting[] = $child->getContentInfo()->name;
+        }
+
+        self::assertNotEquals($namesWithDefaultSorting, $namesWithContentSorting);
+    }
+
+    /**
      * Test for the newLocationUpdateStruct() method.
      *
      * @covers \eZ\Publish\API\Repository\LocationService::newLocationUpdateStruct

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1256,7 +1256,7 @@ class LocationServiceTest extends BaseTest
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function testLoadLocationChildrenDataWithSortingClause(): void
+    public function testLoadLocationChildrenRespectsParentSortingClauses(): void
     {
         $repository = $this->getRepository();
         $locationService = $repository->getLocationService();

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1289,12 +1289,7 @@ class LocationServiceTest extends BaseTest
     }
 
     /**
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\Exception
      */
     private function createStructureForTestLoadLocationChildrenRespectsParentSortingClauses(): Location
     {
@@ -1353,12 +1348,7 @@ class LocationServiceTest extends BaseTest
      *
      * @dataProvider providerForLoadLocationChildrenRespectsParentSortingClauses
      *
-     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
-     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
-     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
-     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\Exception
      */
     public function testLoadLocationChildrenRespectsParentSortingClauses(
         int $sortField,

--- a/eZ/Publish/API/Repository/Values/Content/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Location.php
@@ -219,7 +219,7 @@ abstract class Location extends ValueObject
     }
 
     /**
-     * Get SortClause objects built from Locations's sort options.
+     * Get SortClause objects built from Locations' sort options.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException If sort field has a deprecated/unsupported value which does not have a Sort Clause.
      *

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -42,6 +42,7 @@ use eZ\Publish\SPI\Persistence\Content\Location\UpdateStruct;
 use eZ\Publish\SPI\Persistence\Filter\Location\Handler as LocationFilteringHandler;
 use eZ\Publish\SPI\Persistence\Handler;
 use eZ\Publish\SPI\Repository\Values\Filter\FilteringCriterion;
+use eZ\Publish\SPI\Repository\Values\Filter\FilteringSortClause;
 use Ibexa\Contracts\Core\Limitation\Target\DestinationLocation as DestinationLocationTarget;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -283,6 +284,10 @@ class LocationService implements LocationServiceInterface
         return $locations;
     }
 
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException
+     */
     public function loadLocationChildren(
         APILocation $location,
         int $offset = 0,
@@ -309,6 +314,13 @@ class LocationService implements LocationServiceInterface
         $filter
             ->withLimit($limit)
             ->withOffset($offset);
+
+        $sortClauses = $location->getSortClauses();
+        foreach ($sortClauses as $sortClause) {
+            if ($sortClause instanceof FilteringSortClause) {
+                $filter->withSortClause($sortClause);
+            }
+        }
 
         return $this->find($filter, $prioritizedLanguages);
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4384](https://issues.ibexa.co/browse/IBX-4384)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

The `loadLocationChildren` method in `LocationService` was enhanced by Location's sort clauses.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
