### PR TITLE
IBX-146: Fixed `languageCode` resolving for embedded content

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -124,9 +124,7 @@ class ContentViewBuilder implements ViewBuilder
                 throw new InvalidArgumentException('Content', 'Could not load any content from the parameters');
             }
 
-            $mainRequest = $this->requestStack->getMainRequest();
-            $requestLanguageCode = $mainRequest === null ? null : $mainRequest->attributes->get('languageCode');
-            $languageCode = $parameters['languageCode'] ?? $requestLanguageCode;
+            $languageCode = $parameters['languageCode'] ?? $this->resolveMainRequestLanguageCode();
 
             $content = $view->isEmbed() ? $this->loadEmbeddedContent($contentId, $location, $languageCode) : $this->loadContent($contentId, $languageCode);
         }
@@ -168,6 +166,13 @@ class ContentViewBuilder implements ViewBuilder
         $this->viewConfigurator->configure($view);
 
         return $view;
+    }
+
+    private function resolveMainRequestLanguageCode(): ?string
+    {
+        $mainRequest = $this->requestStack->getMainRequest();
+
+        return $mainRequest === null ? null : $mainRequest->attributes->get('languageCode');
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -125,7 +125,7 @@ class ContentViewBuilder implements ViewBuilder
             }
 
             $mainRequest = $this->requestStack->getMainRequest();
-            $requestLanguageCode = $mainRequest === null ? null : $mainRequest->get('languageCode');
+            $requestLanguageCode = $mainRequest === null ? null : $mainRequest->attributes->get('languageCode');
             $languageCode = $parameters['languageCode'] ?? $requestLanguageCode;
 
             $content = $view->isEmbed() ? $this->loadEmbeddedContent($contentId, $location, $languageCode) : $this->loadContent($contentId, $languageCode);

--- a/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Builder/ContentViewBuilder.php
@@ -124,7 +124,9 @@ class ContentViewBuilder implements ViewBuilder
                 throw new InvalidArgumentException('Content', 'Could not load any content from the parameters');
             }
 
-            $languageCode = $parameters['languageCode'] ?? null;
+            $mainRequest = $this->requestStack->getMainRequest();
+            $requestLanguageCode = $mainRequest === null ? null : $mainRequest->get('languageCode');
+            $languageCode = $parameters['languageCode'] ?? $requestLanguageCode;
 
             $content = $view->isEmbed() ? $this->loadEmbeddedContent($contentId, $location, $languageCode) : $this->loadContent($contentId, $languageCode);
         }

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/ContentViewBuilderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/ContentViewBuilderTest.php
@@ -251,7 +251,7 @@ class ContentViewBuilderTest extends TestCase
             ->willReturn($content);
 
         $this->permissionResolver
-            ->expects(self::any())
+            ->expects(self::exactly(3))
             ->method('canUser')
             ->willReturn(true);
 
@@ -299,7 +299,7 @@ class ContentViewBuilderTest extends TestCase
             ->willReturn($content);
 
         $this->permissionResolver
-            ->expects(self::any())
+            ->expects(self::exactly(3))
             ->method('canUser')
             ->willReturn(true);
 

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/ContentViewBuilderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/ContentViewBuilderTest.php
@@ -26,6 +26,8 @@ use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -274,12 +276,17 @@ class ContentViewBuilderTest extends TestCase
             'contentId' => $contentId,
         ];
 
-        $request = $this->createMock(Request::class);
-        $request
+        $attributes = $this->createMock(ParameterBag::class);
+        $attributes
             ->expects(self::once())
             ->method('get')
             ->with('languageCode')
             ->willReturn($languageCode);
+
+        $request = new Request();
+        $reflectionClass = new ReflectionClass($request);
+        $reflectionProperty = $reflectionClass->getProperty('attributes');
+        $reflectionProperty->setValue($request, $attributes);
 
         $this->requestStack
             ->expects(self::once())

--- a/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/ContentViewBuilderTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/View/Tests/Builder/ContentViewBuilderTest.php
@@ -26,6 +26,7 @@ use eZ\Publish\Core\Repository\Values\Content\Content;
 use eZ\Publish\Core\Repository\Values\Content\Location;
 use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
@@ -221,7 +222,84 @@ class ContentViewBuilderTest extends TestCase
         $this->contentViewBuilder->buildView($parameters);
     }
 
-    public function testBuildViewWithContentWhichDoesNotBelongsToLocation(): void
+    public function testBuildEmbedViewWithNullMainRequest(): void
+    {
+        $contentId = 120;
+        $content = new Content([
+            'versionInfo' => new VersionInfo([
+                'contentInfo' => new ContentInfo(['id' => $contentId]),
+                'status' => VersionInfo::STATUS_PUBLISHED,
+            ]),
+        ]);
+
+        $parameters = [
+            'viewType' => 'embed',
+            '_controller' => 'ez_content:embedAction',
+            'contentId' => $contentId,
+        ];
+
+        $this->requestStack
+            ->expects(self::once())
+            ->method('getMainRequest')
+            ->willReturn(null);
+
+        $this->repository
+            ->expects(self::once())
+            ->method('sudo')
+            ->willReturn($content);
+
+        $this->permissionResolver
+            ->expects(self::any())
+            ->method('canUser')
+            ->willReturn(true);
+
+        $this->contentViewBuilder->buildView($parameters);
+    }
+
+    public function testBuildEmbedViewWithNotNullMainRequest(): void
+    {
+        $contentId = 120;
+        $languageCode = 'ger-DE';
+
+        $content = new Content([
+            'versionInfo' => new VersionInfo([
+                'contentInfo' => new ContentInfo(['id' => $contentId]),
+                'status' => VersionInfo::STATUS_PUBLISHED,
+            ]),
+        ]);
+
+        $parameters = [
+            'viewType' => 'embed',
+            '_controller' => 'ez_content:embedAction',
+            'contentId' => $contentId,
+        ];
+
+        $request = $this->createMock(Request::class);
+        $request
+            ->expects(self::once())
+            ->method('get')
+            ->with('languageCode')
+            ->willReturn($languageCode);
+
+        $this->requestStack
+            ->expects(self::once())
+            ->method('getMainRequest')
+            ->willReturn($request);
+
+        $this->repository
+            ->expects(self::once())
+            ->method('sudo')
+            ->willReturn($content);
+
+        $this->permissionResolver
+            ->expects(self::any())
+            ->method('canUser')
+            ->willReturn(true);
+
+        $this->contentViewBuilder->buildView($parameters);
+    }
+
+    public function testBuildViewWithContentWhichDoesNotBelongToLocation(): void
     {
         $location = new Location(
             [
@@ -295,8 +373,6 @@ class ContentViewBuilderTest extends TestCase
         $this->repository
             ->method('getContentService')
             ->willReturn($contentServiceMock);
-
-        $this->contentViewBuilder->buildView($parameters);
 
         $expectedView = new ContentView(null, [], 'full');
         $expectedView->setContent($content);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-146](https://issues.ibexa.co/browse/IBX-146)
| **Type**                                   |bug
| **Target Ibexa version** | `v3.3`, `v4.2`, `v4.3`
| **BC breaks**                          | no

This issue presents itself only in AdminUI (frontend rendering is not affected) for embedded images and ImageAsset. It seems we don't operate in the context of content for embeds, so `languageCode` is resolved to `null`. It can be easily fetched from `mainRequest` attributes though.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
