### PR TITLE
Separated `security` settings for IbexaTestKernel

### DIFF
--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -150,6 +150,7 @@ class IbexaTestKernel extends Kernel
         });
 
         $this->loadConfiguration($loader);
+        $this->loadSecurity($loader);
         $this->loadServices($loader);
 
         $loader->load(static function (ContainerBuilder $container): void {
@@ -167,7 +168,6 @@ class IbexaTestKernel extends Kernel
         $loader->load(self::getResourcesPath() . '/config/doctrine.php');
         $loader->load(self::getResourcesPath() . '/config/ezpublish.yaml');
         $loader->load(self::getResourcesPath() . '/config/framework.yaml');
-        $loader->load(self::getResourcesPath() . '/config/security.yaml');
     }
 
     /**
@@ -176,6 +176,14 @@ class IbexaTestKernel extends Kernel
     protected function loadServices(LoaderInterface $loader): void
     {
         $loader->load(self::getResourcesPath() . '/services/fixture-services.yaml');
+    }
+
+    /**
+     * @throws \Exception
+     */
+    protected function loadSecurity(LoaderInterface $loader): void
+    {
+        $loader->load(self::getResourcesPath() . '/config/security.yaml');
     }
 
     /**

--- a/src/contracts/Test/IbexaTestKernel.php
+++ b/src/contracts/Test/IbexaTestKernel.php
@@ -150,7 +150,6 @@ class IbexaTestKernel extends Kernel
         });
 
         $this->loadConfiguration($loader);
-        $this->loadSecurity($loader);
         $this->loadServices($loader);
 
         $loader->load(static function (ContainerBuilder $container): void {
@@ -168,6 +167,7 @@ class IbexaTestKernel extends Kernel
         $loader->load(self::getResourcesPath() . '/config/doctrine.php');
         $loader->load(self::getResourcesPath() . '/config/ezpublish.yaml');
         $loader->load(self::getResourcesPath() . '/config/framework.yaml');
+        $this->loadSecurity($loader);
     }
 
     /**


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | N/A
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR moves loading of `security.yaml` to a separate method, so it can be overriden more easily.

This allows manipulating security features for tests (for example, for REST package) and prevents this error:

> PHP Fatal error:  Uncaught Symfony\Component\Config\Definition\Exception\InvalidConfigurationException: You are not allowed to define new elements for path "security.firewalls". Please define all elements for this path in one config file. in ...

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
