### PR TITLE
IBX-4581: Added missing groups setup when siteaccess is matched

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SiteAccessListener.php
@@ -42,6 +42,7 @@ class SiteAccessListener implements EventSubscriberInterface
         $siteAccess->name = $matchedSiteAccess->name;
         $siteAccess->matchingType = $matchedSiteAccess->matchingType;
         $siteAccess->matcher = $matchedSiteAccess->matcher;
+        $siteAccess->groups = $matchedSiteAccess->groups;
 
         // We already have semanticPathinfo (sub-request)
         if ($request->attributes->has('semanticPathinfo')) {

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SiteAccessListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SiteAccessListenerTest.php
@@ -7,27 +7,16 @@
 namespace eZ\Bundle\EzPublishCoreBundle\Tests\EventListener;
 
 use eZ\Bundle\EzPublishCoreBundle\EventListener\SiteAccessListener;
-use eZ\Bundle\EzPublishCoreBundle\Routing\DefaultRouter;
 use eZ\Publish\Core\MVC\Symfony\Event\PostSiteAccessMatchEvent;
 use eZ\Publish\Core\MVC\Symfony\MVCEvents;
-use eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
+use eZ\Publish\Core\MVC\Symfony\SiteAccessGroup;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
 class SiteAccessListenerTest extends TestCase
 {
-    /** @var \Symfony\Component\DependencyInjection\ContainerInterface|\PHPUnit\Framework\MockObject\MockObject */
-    private $container;
-
-    /** @var \eZ\Bundle\EzPublishCoreBundle\Routing\DefaultRouter|\PHPUnit\Framework\MockObject\MockObject */
-    private $router;
-
-    /** @var \eZ\Publish\Core\MVC\Symfony\Routing\Generator\UrlAliasGenerator|\PHPUnit\Framework\MockObject\MockObject */
-    private $generator;
-
     /** @var \eZ\Bundle\EzPublishCoreBundle\EventListener\SiteAccessListener */
     private $listener;
 
@@ -38,9 +27,7 @@ class SiteAccessListenerTest extends TestCase
     {
         parent::setUp();
         $this->defaultSiteaccess = new SiteAccess('default');
-        $this->container = $this->createMock(ContainerInterface::class);
-        $this->router = $this->createMock(DefaultRouter::class);
-        $this->generator = $this->createMock(UrlAliasGenerator::class);
+        $this->defaultSiteaccess->groups = [new SiteAccessGroup('test_group')];
         $this->listener = new SiteAccessListener($this->defaultSiteaccess);
     }
 
@@ -100,12 +87,13 @@ class SiteAccessListenerTest extends TestCase
         $event = new PostSiteAccessMatchEvent($siteAccess, $request, HttpKernelInterface::MASTER_REQUEST);
 
         $this->listener->onSiteAccessMatch($event);
-        $this->assertSame($expectedSemanticPathinfo, $request->attributes->get('semanticPathinfo'));
-        $this->assertSame($expectedVPArray, $request->attributes->get('viewParameters'));
-        $this->assertSame($expectedVPString, $request->attributes->get('viewParametersString'));
-        $this->assertSame($this->defaultSiteaccess->name, $siteAccess->name);
-        $this->assertSame($this->defaultSiteaccess->matchingType, $siteAccess->matchingType);
-        $this->assertSame($this->defaultSiteaccess->matcher, $siteAccess->matcher);
+        self::assertSame($expectedSemanticPathinfo, $request->attributes->get('semanticPathinfo'));
+        self::assertSame($expectedVPArray, $request->attributes->get('viewParameters'));
+        self::assertSame($expectedVPString, $request->attributes->get('viewParametersString'));
+        self::assertSame($this->defaultSiteaccess->name, $siteAccess->name);
+        self::assertSame($this->defaultSiteaccess->matchingType, $siteAccess->matchingType);
+        self::assertSame($this->defaultSiteaccess->matcher, $siteAccess->matcher);
+        self::assertSame($this->defaultSiteaccess->groups, $siteAccess->groups);
     }
 
     /**
@@ -122,11 +110,12 @@ class SiteAccessListenerTest extends TestCase
         $event = new PostSiteAccessMatchEvent($siteAccess, $request, HttpKernelInterface::SUB_REQUEST);
 
         $this->listener->onSiteAccessMatch($event);
-        $this->assertSame($semanticPathinfo, $request->attributes->get('semanticPathinfo'));
-        $this->assertSame($expectedViewParameters, $request->attributes->get('viewParameters'));
-        $this->assertSame($vpString, $request->attributes->get('viewParametersString'));
-        $this->assertSame($this->defaultSiteaccess->name, $siteAccess->name);
-        $this->assertSame($this->defaultSiteaccess->matchingType, $siteAccess->matchingType);
-        $this->assertSame($this->defaultSiteaccess->matcher, $siteAccess->matcher);
+        self::assertSame($semanticPathinfo, $request->attributes->get('semanticPathinfo'));
+        self::assertSame($expectedViewParameters, $request->attributes->get('viewParameters'));
+        self::assertSame($vpString, $request->attributes->get('viewParametersString'));
+        self::assertSame($this->defaultSiteaccess->name, $siteAccess->name);
+        self::assertSame($this->defaultSiteaccess->matchingType, $siteAccess->matchingType);
+        self::assertSame($this->defaultSiteaccess->matcher, $siteAccess->matcher);
+        self::assertSame($this->defaultSiteaccess->groups, $siteAccess->groups);
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -15,6 +15,7 @@ use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router as SiteAccessRouter;
+use eZ\Publish\Core\MVC\Symfony\SiteAccessGroup;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -80,7 +81,9 @@ class SiteAccessMatchListener implements EventSubscriberInterface
                     $request->attributes->get('serialized_siteaccess_sub_matchers')
                 );
             }
-
+            $siteAccess->groups = $this->buildGroups(
+                $siteAccess->groups
+            );
             $request->attributes->set(
                 'siteaccess',
                 $siteAccess
@@ -164,6 +167,20 @@ class SiteAccessMatchListener implements EventSubscriberInterface
         }
 
         return $matcher;
+    }
+
+    /**
+     * @return \eZ\Publish\Core\MVC\Symfony\SiteAccessGroup[]
+     */
+    private function buildGroups(
+        array $serializedGroups
+    ): array {
+        return array_map(
+            static function (array $serializedGroup): SiteAccessGroup {
+                return new SiteAccessGroup($serializedGroup['name']);
+            },
+            $serializedGroups
+        );
     }
 
     /**

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/SiteAccessMatchListener.php
@@ -170,6 +170,8 @@ class SiteAccessMatchListener implements EventSubscriberInterface
     }
 
     /**
+     * @param array<array{'name': string}> $serializedGroups
+     *
      * @return \eZ\Publish\Core\MVC\Symfony\SiteAccessGroup[]
      */
     private function buildGroups(

--- a/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/EventListener/Tests/SiteAccessMatchListenerTest.php
@@ -14,6 +14,7 @@ use eZ\Publish\Core\MVC\Symfony\MVCEvents;
 use eZ\Publish\Core\MVC\Symfony\Routing\SimplifiedRequest;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess;
 use eZ\Publish\Core\MVC\Symfony\SiteAccess\Router;
+use eZ\Publish\Core\MVC\Symfony\SiteAccessGroup;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -63,7 +64,9 @@ class SiteAccessMatchListenerTest extends TestCase
         $siteAccess = new SiteAccess(
             'test',
             'matching_type',
-            $matcher
+            $matcher,
+            null,
+            [new SiteAccessGroup('test_group')]
         );
         $request = new Request();
         $request->attributes->set('serialized_siteaccess', json_encode($siteAccess));

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess.php
@@ -52,12 +52,14 @@ class SiteAccess extends ValueObject implements JsonSerializable
         string $name,
         string $matchingType = self::DEFAULT_MATCHING_TYPE,
         $matcher = null,
-        ?string $provider = null
+        ?string $provider = null,
+        array $groups = []
     ) {
         $this->name = $name;
         $this->matchingType = $matchingType;
         $this->matcher = $matcher;
         $this->provider = $provider;
+        $this->groups = $groups;
     }
 
     public function __toString()
@@ -74,6 +76,7 @@ class SiteAccess extends ValueObject implements JsonSerializable
             'matchingType' => $this->matchingType,
             'matcher' => $matcher,
             'provider' => $this->provider,
+            'groups' => $this->groups,
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Router.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Router.php
@@ -196,8 +196,7 @@ class Router implements SiteAccessRouterInterface, SiteAccessAware
         }
 
         $this->logger->notice('Siteaccess not matched against configuration, returning default siteaccess.');
-        $this->siteAccess = new $this->siteAccessClass($this->defaultSiteAccess);
-        $this->siteAccess->matchingType = SiteAccess::DEFAULT_MATCHING_TYPE;
+        $this->siteAccess = $this->siteAccessProvider->getSiteAccess($this->defaultSiteAccess);
 
         return $this->siteAccess;
     }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterBaseTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterBaseTest.php
@@ -20,6 +20,8 @@ abstract class RouterBaseTest extends TestCase
     protected const ENV_SA_NAME = 'env_sa';
     protected const HEADERBASED_SA_NAME = 'headerbased_sa';
 
+    protected const DEFAULT_SA_NAME = 'default_sa';
+
     /** @var \eZ\Publish\Core\MVC\Symfony\SiteAccess\MatcherBuilder */
     protected $matcherBuilder;
 

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostElementTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostElementTest.php
@@ -159,6 +159,7 @@ class RouterHostElementTest extends RouterBaseTest
             new SiteAccessSetting('fourth_sa', true),
             new SiteAccessSetting('fifth_sa', true),
             new SiteAccessSetting('example', true),
+            new SiteAccessSetting(self::DEFAULT_SA_NAME, true),
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostPortURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostPortURITest.php
@@ -195,6 +195,7 @@ class RouterHostPortURITest extends RouterBaseTest
             new SiteAccessSetting('third_sa', true),
             new SiteAccessSetting('fourth_sa', true),
             new SiteAccessSetting('fifth_sa', true),
+            new SiteAccessSetting(self::DEFAULT_SA_NAME, true),
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostRegexTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostRegexTest.php
@@ -115,6 +115,7 @@ class RouterHostRegexTest extends RouterBaseTest
             new SiteAccessSetting('fourth_sa', true),
             new SiteAccessSetting('fifth_sa', true),
             new SiteAccessSetting('example', true),
+            new SiteAccessSetting(self::DEFAULT_SA_NAME, true),
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostTextTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterHostTextTest.php
@@ -130,6 +130,7 @@ class RouterHostTextTest extends RouterBaseTest
             new SiteAccessSetting('fourth_sa', true),
             new SiteAccessSetting('fifth_sa', true),
             new SiteAccessSetting('example', true),
+            new SiteAccessSetting(self::DEFAULT_SA_NAME, true),
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterPortHostURITest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterPortHostURITest.php
@@ -120,6 +120,7 @@ class RouterPortHostURITest extends RouterBaseTest
             new SiteAccessSetting('third_sa', true),
             new SiteAccessSetting('fourth_sa', true),
             new SiteAccessSetting('fifth_sa', true),
+            new SiteAccessSetting(self::DEFAULT_SA_NAME, true),
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterSpecialPortsTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterSpecialPortsTest.php
@@ -120,6 +120,7 @@ class RouterSpecialPortsTest extends RouterBaseTest
             new SiteAccessSetting('third_sa', true),
             new SiteAccessSetting('fourth_sa', true),
             new SiteAccessSetting('fifth_sa', true),
+            new SiteAccessSetting(self::DEFAULT_SA_NAME, true),
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterTest.php
@@ -320,6 +320,7 @@ class RouterTest extends RouterBaseTest
             new SiteAccessSetting(self::HEADERBASED_SA_NAME, true),
             new SiteAccessSetting(self::ENV_SA_NAME, true),
             new SiteAccessSetting(self::UNDEFINED_SA_NAME, false),
+            new SiteAccessSetting(self::DEFAULT_SA_NAME, true),
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElement2Test.php
@@ -214,6 +214,7 @@ class RouterURIElement2Test extends RouterBaseTest
             new SiteAccessSetting('first_sa_foo', true),
             new SiteAccessSetting('second_sa_foo', true),
             new SiteAccessSetting('foo_baz', true),
+            new SiteAccessSetting(self::DEFAULT_SA_NAME, true),
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElementTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIElementTest.php
@@ -184,7 +184,7 @@ class RouterURIElementTest extends RouterBaseTest
             new SiteAccessSetting('first_sa.foo', true),
             new SiteAccessSetting('test', true),
             new SiteAccessSetting('foo', true),
-            new SiteAccessSetting('default_sa', true),
+            new SiteAccessSetting(self::DEFAULT_SA_NAME, true),
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIRegexTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURIRegexTest.php
@@ -131,6 +131,7 @@ class RouterURIRegexTest extends RouterBaseTest
             new SiteAccessSetting('fourth_sa', true),
             new SiteAccessSetting('fifth_sa', true),
             new SiteAccessSetting('test', true),
+            new SiteAccessSetting(self::DEFAULT_SA_NAME, true),
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURITextTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccess/Tests/RouterURITextTest.php
@@ -162,6 +162,7 @@ class RouterURITextTest extends RouterBaseTest
             new SiteAccessSetting('fourth_sa', true),
             new SiteAccessSetting('fifth_sa', true),
             new SiteAccessSetting('test', true),
+            new SiteAccessSetting(self::DEFAULT_SA_NAME, true),
         ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccessGroup.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccessGroup.php
@@ -8,7 +8,9 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\MVC\Symfony;
 
-final class SiteAccessGroup
+use JsonSerializable;
+
+final class SiteAccessGroup implements JsonSerializable
 {
     /** @var string */
     private $name;
@@ -26,5 +28,12 @@ final class SiteAccessGroup
     public function __toString()
     {
         return $this->name;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'name' => $this->name,
+        ];
     }
 }

--- a/eZ/Publish/Core/MVC/Symfony/SiteAccessGroup.php
+++ b/eZ/Publish/Core/MVC/Symfony/SiteAccessGroup.php
@@ -30,6 +30,9 @@ final class SiteAccessGroup implements JsonSerializable
         return $this->name;
     }
 
+    /**
+     * @return array{'name': string}
+     */
     public function jsonSerialize(): array
     {
         return [


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4581](https://issues.ibexa.co/browse/IBX-4581)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

I also fixed/added groups serialization, it was no related to problem with `getCurrent()` itself, but it seemed related and could save as a problem in the future.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
