### PR TITLE
IBX-4326: Custom URL aliases reparenting

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/ExceptionContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/ExceptionContext.php
@@ -61,6 +61,6 @@ class ExceptionContext extends RawMinkContext implements Context, SnippetAccepti
      */
     public function anAccessDeniedExceptionIsThrown($exceptionString)
     {
-        $this->assertSession()->elementExists('css', "abbr[title='$exceptionString']");
+        $this->assertSession()->elementExists('xpath', "//abbr[@title='$exceptionString']");
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -534,17 +534,11 @@ final class DoctrineDatabase extends Gateway
             'parent',
             $query->createPositionalParameter($newParentId, ParameterType::INTEGER)
         )->where(
-            $query->expr()->andX(
-                $query->expr()->eq(
-                    'is_alias',
-                    $query->createPositionalParameter(0, ParameterType::INTEGER)
-                ),
-                $query->expr()->eq(
-                    'parent',
-                    $query->createPositionalParameter(
-                        $oldParentId,
-                        ParameterType::INTEGER
-                    )
+            $query->expr()->eq(
+                'parent',
+                $query->createPositionalParameter(
+                    $oldParentId,
+                    ParameterType::INTEGER
                 )
             )
         );


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4326](https://issues.ibexa.co/browse/IBX-4326)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Custom aliases were not reparented previously and simply were breaking when a parent was moved.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
