### PR TITLE
IBX-4461: Fixed handling trailing slash for isUriPrefixExcluded

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Generator/UrlAliasGenerator.php
@@ -143,7 +143,7 @@ class UrlAliasGenerator extends Generator
     public function isUriPrefixExcluded($uri)
     {
         foreach ($this->excludedUriPrefixes as $excludedPrefix) {
-            $excludedPrefix = '/' . trim($excludedPrefix, '/');
+            $excludedPrefix = '/' . ltrim($excludedPrefix, '/');
             if (mb_stripos($uri, $excludedPrefix) === 0) {
                 return true;
             }

--- a/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Routing/Tests/UrlAliasGeneratorTest.php
@@ -145,6 +145,7 @@ class UrlAliasGeneratorTest extends TestCase
             ['/SHARED/contenT/bar', true],
             ['/SomeThing/bidule/chose', false],
             ['/SomeThing/in-the-way/truc/', true],
+            ['/SomeThing/in-the-way-suffixed/', false],
             ['/CMS/eZ-Publish', false],
             ['/Lyon/Best/city', false],
         ];


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4461](https://issues.ibexa.co/browse/IBX-4461)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          |  no

Take into account  trailing slash for ```excluded_uri_prefixes``` settings.
Behaviour without PR:
 `
 excluded_uri_prefixes: [ /media/images-foo/ ]
`
--> excludes all URIs prefixed with  ```/media/images-foo```

Behaviour with PR:
 `
 excluded_uri_prefixes: [ /media/images-foo/ ]
`
--> excludes all URIs prefixed with  ```/media/images-foo/```


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
