### PR TITLE
IBX-4877: Allow Location-based Content preview

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/services.yml
@@ -103,12 +103,13 @@ services:
     ezpublish.controller.content.preview.core:
         class: eZ\Publish\Core\MVC\Symfony\Controller\Content\PreviewController
         arguments:
-            - "@ezpublish.api.service.content"
-            - "@http_kernel"
-            - "@ezpublish.content_preview_helper"
-            - "@security.authorization_checker"
-            - "@ezpublish.content_preview.location_provider"
-            - "@ezpublish.view.custom_location_controller_checker"
+            $contentService: '@ezpublish.api.service.content'
+            $locationService: '@ezpublish.api.service.location'
+            $kernel: '@http_kernel'
+            $previewHelper: '@ezpublish.content_preview_helper'
+            $authorizationChecker: '@security.authorization_checker'
+            $locationProvider: '@ezpublish.content_preview.location_provider'
+            $controllerChecker: '@ezpublish.view.custom_location_controller_checker'
         tags:
             - { name: controller.service_arguments }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/pagelayout.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/pagelayout.html.twig
@@ -7,7 +7,9 @@
     {% endif %}
     <title>{{ title|default( 'Home' ) }}</title>
     <meta name="generator" content="Ibexa DXP"/>
-    {% if content is defined and content.contentInfo.mainLocationId %}
+    {% if content is defined and location is defined and location is not null %}
+        <link rel="canonical" href="{{ ez_path(location) }}" />
+    {% elseif content is defined and content.contentInfo.mainLocationId %}
         <link rel="canonical" href="{{ ez_path(content) }}" />
     {% endif %}
 </head>

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/views/pagelayout.html.twig
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/views/pagelayout.html.twig
@@ -7,7 +7,7 @@
     {% endif %}
     <title>{{ title|default( 'Home' ) }}</title>
     <meta name="generator" content="Ibexa DXP"/>
-    {% if content is defined and location is defined and location is not null %}
+    {% if content is defined and location is defined and location is not null and location.id is not null %}
         <link rel="canonical" href="{{ ez_path(location) }}" />
     {% elseif content is defined and content.contentInfo.mainLocationId %}
         <link rel="canonical" href="{{ ez_path(content) }}" />

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -10,6 +10,7 @@ use Exception;
 use eZ\Publish\API\Repository\ContentService;
 use eZ\Publish\API\Repository\Exceptions\NotImplementedException;
 use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\LocationService;
 use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\Core\Helper\ContentPreviewHelper;
@@ -33,6 +34,12 @@ class PreviewController
     /** @var \eZ\Publish\API\Repository\ContentService */
     private $contentService;
 
+    /** @var \eZ\Publish\API\Repository\LocationService */
+    private $locationService;
+
+    /** @var \eZ\Publish\Core\Helper\PreviewLocationProvider */
+    private $locationProvider;
+
     /** @var \Symfony\Component\HttpKernel\HttpKernelInterface */
     private $kernel;
 
@@ -47,6 +54,7 @@ class PreviewController
 
     public function __construct(
         ContentService $contentService,
+        LocationService $locationService,
         HttpKernelInterface $kernel,
         ContentPreviewHelper $previewHelper,
         AuthorizationCheckerInterface $authorizationChecker,
@@ -54,6 +62,7 @@ class PreviewController
         CustomLocationControllerChecker $controllerChecker
     ) {
         $this->contentService = $contentService;
+        $this->locationService = $locationService;
         $this->kernel = $kernel;
         $this->previewHelper = $previewHelper;
         $this->authorizationChecker = $authorizationChecker;
@@ -63,14 +72,24 @@ class PreviewController
 
     /**
      * @throws \eZ\Publish\API\Repository\Exceptions\NotImplementedException If Content is missing location as this is not supported in current version
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
      */
-    public function previewContentAction(Request $request, $contentId, $versionNo, $language, $siteAccessName = null)
-    {
+    public function previewContentAction(
+        Request $request,
+        $contentId,
+        $versionNo,
+        $language,
+        $siteAccessName = null,
+        ?int $locationId = null
+    ) {
         $this->previewHelper->setPreviewActive(true);
 
         try {
             $content = $this->contentService->loadContent($contentId, [$language], $versionNo);
-            $location = $this->locationProvider->loadMainLocationByContent($content);
+            $location = $locationId !== null
+                ? $this->locationService->loadLocation($locationId)
+                : $this->locationProvider->loadMainLocationByContent($content);
 
             if (!$location instanceof Location) {
                 throw new NotImplementedException('Preview for content without Locations');
@@ -157,9 +176,9 @@ EOF;
 
         if ($this->controllerChecker->usesCustomController($content, $location)) {
             $forwardRequestParameters = [
-                '_controller' => 'ez_content:viewAction',
-                '_route' => self::CONTENT_VIEW_ROUTE,
-            ] + $forwardRequestParameters;
+                    '_controller' => 'ez_content:viewAction',
+                    '_route' => self::CONTENT_VIEW_ROUTE,
+                ] + $forwardRequestParameters;
         }
 
         return $request->duplicate(

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -176,9 +176,9 @@ EOF;
 
         if ($this->controllerChecker->usesCustomController($content, $location)) {
             $forwardRequestParameters = [
-                    '_controller' => 'ez_content:viewAction',
-                    '_route' => self::CONTENT_VIEW_ROUTE,
-                ] + $forwardRequestParameters;
+                '_controller' => 'ez_content:viewAction',
+                '_route' => self::CONTENT_VIEW_ROUTE,
+            ] + $forwardRequestParameters;
         }
 
         return $request->duplicate(

--- a/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Tests/Controller/Content/PreviewControllerTest.php
@@ -42,7 +42,7 @@ class PreviewControllerTest extends TestCase
     /** @var \Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface|\PHPUnit\Framework\MockObject\MockObject */
     protected $authorizationChecker;
 
-    /** @var \eZ\Publish\Core\Helper\PreviewLocationProvider|\PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\MVC\Symfony\View\CustomLocationControllerChecker */
+    /** @var \eZ\Publish\Core\Helper\PreviewLocationProvider|\PHPUnit\Framework\MockObject\MockObject */
     protected $locationProvider;
 
     /** @var \eZ\Publish\Core\MVC\Symfony\View\CustomLocationControllerChecker|\PHPUnit\Framework\MockObject\MockObject */

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -416,11 +416,6 @@ parameters:
 			path: eZ/Publish/Core/FieldType/User/UserStorage.php
 
 		-
-			message: "#^Access to an undefined property eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\Controller\\\\Content\\\\PreviewController\\:\\:\\$locationProvider\\.$#"
-			count: 2
-			path: eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
-
-		-
 			message: "#^Method eZ\\\\Publish\\\\Core\\\\MVC\\\\Symfony\\\\Matcher\\\\ContentBased\\\\Id\\\\LocationRemote\\:\\:matchContentInfo\\(\\) should return bool but return statement is missing\\.$#"
 			count: 1
 			path: eZ/Publish/Core/MVC/Symfony/Matcher/ContentBased/Id/LocationRemote.php


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4877](https://issues.ibexa.co/browse/IBX-4877)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

As the title suggests. Using only main Location for preview would prevent certain users without access to main Location but with access to secondary Location from previewing such content.

Related PRs:
- https://github.com/ezsystems/ezplatform-page-fieldtype/pull/239
- https://github.com/ezsystems/ezplatform-page-builder/pull/973

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
