### PR TITLE
IBX-4477: Added LocationService::getSubtreeSize method

### DIFF
--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -126,6 +126,13 @@ interface LocationService
     public function getLocationChildCount(Location $location): int;
 
     /**
+     * Return the subtree size of a given location.
+     *
+     * Warning! This method is not permission aware by design.
+     */
+    public function getSubtreeSize(Location $location): int;
+
+    /**
      * Creates the new $location in the content repository for the given content.
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException If the current user user is not allowed to create this location

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -3471,6 +3471,23 @@ class LocationServiceTest extends BaseTest
         }
     }
 
+    public function testGetSubtreeSize(): Location
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $folder = $this->createFolder(['eng-GB' => 'Parent Folder'], 2);
+        $location = $folder->getVersionInfo()->getContentInfo()->getMainLocation();
+        self::assertSame(1, $locationService->getSubtreeSize($location));
+
+        $this->createFolder(['eng-GB' => 'Child 1'], $location->id);
+        $this->createFolder(['eng-GB' => 'Child 2'], $location->id);
+
+        self::assertSame(3, $locationService->getSubtreeSize($location));
+
+        return $location;
+    }
+
     /**
      * Loads properties from all locations in the $location's subtree.
      *

--- a/eZ/Publish/API/Repository/Values/Content/Location.php
+++ b/eZ/Publish/API/Repository/Values/Content/Location.php
@@ -24,7 +24,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read bool $explicitlyHidden Indicates that the Location entity has been explicitly marked as hidden.
  * @property-read string $remoteId a global unique id of the content object
  * @property-read int $parentLocationId the id of the parent location
- * @property-read string $pathString the path to this location e.g. /1/2/4/23 where 23 is current id.
+ * @property-read string $pathString @deprecated use {@see Location::getPathString()} instead.
  * @property-read array $path Same as $pathString but as array, e.g. [ 1, 2, 4, 23 ]
  * @property-read int $depth Depth location has in the location tree
  * @property-read int $sortField Specifies which property the child locations should be sorted on. Valid values are found at {@link Location::SORT_FIELD_*}
@@ -238,5 +238,14 @@ abstract class Location extends ValueObject
         $sortClause->direction = self::SORT_ORDER_MAP[$this->sortOrder];
 
         return [$sortClause];
+    }
+
+    /**
+     * The path to the Location represented by the current instance,
+     * e.g. /1/2/4/23 where 23 is current id.
+     */
+    public function getPathString(): string
+    {
+        return $this->pathString;
     }
 }

--- a/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
+++ b/eZ/Publish/API/Repository/Values/ContentType/ContentType.php
@@ -27,7 +27,7 @@ use eZ\Publish\SPI\Repository\Values\MultiLanguageName;
  * @property-read string $remoteId a global unique id of the content object
  * @property-read string $urlAliasSchema URL alias schema. If nothing is provided, $nameSchema will be used instead.
  * @property-read string $nameSchema  The name schema.
- * @property-read bool $isContainer This flag hints to UIs if type may have children or not.
+ * @property-read bool $isContainer @deprecated use strict getter {@see ContentType::isContainer} instead.
  * @property-read string $mainLanguageCode the main language of the content type names and description used for fallback.
  * @property-read bool $defaultAlwaysAvailable if an instance of a content type is created the always available flag is set by default this this value.
  * @property-read string[] $languageCodes array of language codes used by content type translations.
@@ -227,5 +227,10 @@ abstract class ContentType extends ValueObject implements MultiLanguageName, Mul
         }
 
         return null;
+    }
+
+    public function isContainer(): bool
+    {
+        return $this->isContainer;
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -259,6 +259,15 @@ class LocationHandler extends AbstractInMemoryPersistenceHandler implements Loca
         return $this->persistenceHandler->locationHandler()->copySubtree($sourceId, $destinationParentId, $newOwnerId);
     }
 
+    public function getSubtreeSize(string $path): int
+    {
+        $this->logger->logCall(__METHOD__, [
+            'path' => $path,
+        ]);
+
+        return $this->persistenceHandler->locationHandler()->getSubtreeSize($path);
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -111,6 +111,8 @@ abstract class Gateway
      */
     abstract public function getSubtreeContent(int $sourceId, bool $onlyIds = false): array;
 
+    abstract public function getSubtreeSize(string $path): int;
+
     /**
      * Returns data for the first level children of the location identified by given $locationId.
      */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -237,6 +237,21 @@ final class DoctrineDatabase extends Gateway
             : $results;
     }
 
+    public function getSubtreeSize(string $path): int
+    {
+        $query = $this->createNodeQueryBuilder([$this->dbPlatform->getCountExpression('node_id')]);
+        $query->andWhere(
+            $query->expr()->like(
+                't.path_string',
+                $query->createPositionalParameter(
+                    $path . '%',
+                )
+            )
+        );
+
+        return (int) $query->execute()->fetchOne();
+    }
+
     /**
      * Return constraint which limits the given $query to the subtree starting at $rootLocationId.
      */

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -106,6 +106,15 @@ final class ExceptionConversion extends Gateway
         }
     }
 
+    public function getSubtreeSize(string $path): int
+    {
+        try {
+            return $this->innerGateway->getSubtreeSize($path);
+        } catch (DBALException | PDOException $e) {
+            throw DatabaseException::wrap($e);
+        }
+    }
+
     public function getChildren(int $locationId): array
     {
         try {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -346,6 +346,11 @@ class Handler implements BaseLocationHandler
         return $copiedSubtreeRootLocation;
     }
 
+    public function getSubtreeSize(string $path): int
+    {
+        return $this->locationGateway->getSubtreeSize($path);
+    }
+
     /**
      * Retrieves section ID of the location's content.
      *

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -379,6 +379,13 @@ class LocationService implements LocationServiceInterface
         return $this->count($filter);
     }
 
+    public function getSubtreeSize(APILocation $location): int
+    {
+        return $this->persistenceHandler->locationHandler()->getSubtreeSize(
+            $location->getPathString()
+        );
+    }
+
     protected function buildLocationChildrenFilter(APILocation $location): Filter
     {
         $filter = new Filter();

--- a/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
@@ -109,6 +109,11 @@ class LocationService implements LocationServiceInterface
         return $this->service->getLocationChildCount($location);
     }
 
+    public function getSubtreeSize(Location $location): int
+    {
+        return $this->service->getSubtreeSize($location);
+    }
+
     public function createLocation(ContentInfo $contentInfo, LocationCreateStruct $locationCreateStruct): Location
     {
         return $this->service->createLocation($contentInfo, $locationCreateStruct);

--- a/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LocationServiceTest.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/Tests/LocationServiceTest.php
@@ -42,6 +42,8 @@ class LocationServiceTest extends AbstractServiceTest
 
             ['getLocationChildCount', [$location], 100],
 
+            ['getSubtreeSize', [$location], 100],
+
             ['createLocation', [$contentInfo, $locationCreateStruct], $location],
 
             ['updateLocation', [$location, $locationUpdateStruct], $location],

--- a/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
@@ -110,6 +110,8 @@ interface Handler
      */
     public function copySubtree($sourceId, $destinationParentId);
 
+    public function getSubtreeSize(string $path): int;
+
     /**
      * Moves location identified by $sourceId into new parent identified by $destinationParentId.
      *

--- a/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
@@ -87,6 +87,11 @@ abstract class LocationServiceDecorator implements LocationService
         return $this->innerService->getLocationChildCount($location);
     }
 
+    public function getSubtreeSize(Location $location): int
+    {
+        return $this->innerService->getSubtreeSize($location);
+    }
+
     public function createLocation(
         ContentInfo $contentInfo,
         LocationCreateStruct $locationCreateStruct


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-4477](https://issues.ibexa.co/browse/IBX-4477)
| **Required by**                        | ezsystems/ezplatform-admin-ui#2085
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no
| **Regression build**         | https://github.com/ibexa/commerce/pull/214

Added dedicated method to retrieve subtree size

```php
interface LocationService {
    # ...

    /**
     * Return the subtree size of a given location.
     *
     * Warning! This method is not permission aware by design.
     */
    public function getSubtreeSize(Location $location): int;

    # ...
}
```

#### Checklist:
- [X] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
