### PR TITLE
[Composer] Disallowed every not specified Composer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
         "process-timeout": 3000,
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
-            "php-http/discovery": true
+            "*/*": false
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,7 @@
         "process-timeout": 3000,
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
-            "*/*": false
+            "*": false
         }
     },
     "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -114,7 +114,8 @@
     "config": {
         "process-timeout": 3000,
         "allow-plugins": {
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "php-http/discovery": true
         }
     },
     "scripts": {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no

Seems indirect dependency `php-http/discovery` introduces Composer plugin for discovering proper HTTPlug client
```
$ composer why php-http/discovery
friendsofsymfony/http-cache       2.15.0 requires php-http/discovery (^1.12) 
knplabs/github-api                v3.9.0 requires php-http/discovery (^1.12) 
php-http/multipart-stream-builder 1.2.0  requires php-http/discovery (^1.7)
```

This needs to be handled in composer.json so CI test jobs won't fail unlike [this one](https://github.com/ezsystems/ezplatform-kernel/actions/runs/4135434711/jobs/7147881743#step:4:242).

Given risky approach by 3rd party vendors to Composer plugins, causing BC breaks, we've discovered that we can use either
```json
"config": {
        "allow-plugins": {
            "*": false
        }
    }
```
to disallow everything except what is already allowed, or simpler:
```json
"config": {
        "allow-plugins": false
    }
```
if there's no such key yet in `composer.json`

to avoid such issues in the future. If a plugin is needed then it can be explicitly enabled.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review
