### PR TITLE
IBX-3972: Fixed password validation for UserService::updateUserPassword

### DIFF
--- a/eZ/Publish/API/Repository/Tests/PHPUnitConstraint/AllValidationErrorsOccur.php
+++ b/eZ/Publish/API/Repository/Tests/PHPUnitConstraint/AllValidationErrorsOccur.php
@@ -9,11 +9,10 @@ declare(strict_types=1);
 namespace eZ\Publish\API\Repository\Tests\PHPUnitConstraint;
 
 use eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException;
-use eZ\Publish\API\Repository\Translatable;
 use PHPUnit\Framework\Constraint\Constraint as AbstractPHPUnitConstraint;
 
 /**
- * PHPUnit constraint checking that all the given validation error messages occur in the asserted
+ * PHPUnit's constraint checking that all the given validation error messages occur in the asserted
  * ContentFieldValidationException.
  *
  * @see \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException
@@ -61,22 +60,17 @@ class AllValidationErrorsOccur extends AbstractPHPUnitConstraint
      */
     private function extractAllFieldErrorMessages(ContentFieldValidationException $exception): array
     {
-        $allFieldErrors = [];
-        foreach ($exception->getFieldErrors() as $errors) {
-            foreach ($errors as $fieldErrors) {
-                $allFieldErrors = array_merge(
-                    $allFieldErrors,
-                    array_map(
-                        static function (Translatable $translatableFieldError) {
-                            return $translatableFieldError->getTranslatableMessage()->message;
-                        },
-                        $fieldErrors
-                    )
-                );
+        return iterator_to_array($this->extractTranslatable($exception->getFieldErrors()));
+    }
+
+    private function extractTranslatable(array $fieldErrors): \Traversable
+    {
+        // structure: [<fieldId> => [<languageCode> => array<ValidationError>]]
+        foreach (array_merge(...$fieldErrors) as $errorsPerTranslation) {
+            foreach ($errorsPerTranslation as $fieldError) {
+                yield (string)$fieldError->getTranslatableMessage();
             }
         }
-
-        return $allFieldErrors;
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -1098,7 +1098,7 @@ class UserServiceTest extends BaseTest
             /* END: Use Case */
         } catch (ContentFieldValidationException $e) {
             // Exception is caught, as there is no other way to check exception properties.
-            $this->assertValidationErrorOccurs($e, 'The user login \'%login%\' is used by another user. You must enter a unique login.');
+            $this->assertValidationErrorOccurs($e, 'The user login \'admin\' is used by another user. You must enter a unique login.');
 
             /* END: Use Case */
             return;
@@ -1156,7 +1156,7 @@ class UserServiceTest extends BaseTest
             $userService->createUser($userCreate, [$group]);
         } catch (ContentFieldValidationException $e) {
             // Exception is caught, as there is no other way to check exception properties.
-            $this->assertValidationErrorOccurs($e, 'Email \'%email%\' is used by another user. You must enter a unique email.');
+            $this->assertValidationErrorOccurs($e, 'Email \'unique@email.com\' is used by another user. You must enter a unique email.');
 
             return;
         }
@@ -1305,7 +1305,7 @@ class UserServiceTest extends BaseTest
                 $e,
                 [
                     'User password must include at least one special character',
-                    'User password must be at least %length% characters long',
+                    'User password must be at least 8 characters long',
                     'User password must include at least one upper case letter',
                     'User password must include at least one number',
                 ]
@@ -2021,7 +2021,7 @@ class UserServiceTest extends BaseTest
         } catch (ContentFieldValidationException $e) {
             // Exception is caught, as there is no other way to check exception properties.
             $this->assertValidationErrorOccurs($e, 'User password must include at least one special character');
-            $this->assertValidationErrorOccurs($e, 'User password must be at least %length% characters long');
+            $this->assertValidationErrorOccurs($e, 'User password must be at least 8 characters long');
             $this->assertValidationErrorOccurs($e, 'User password must include at least one upper case letter');
             $this->assertValidationErrorOccurs($e, 'User password must include at least one number');
 

--- a/eZ/Publish/API/Repository/UserService.php
+++ b/eZ/Publish/API/Repository/UserService.php
@@ -247,10 +247,14 @@ interface UserService
     public function updateUser(User $user, UserUpdateStruct $userUpdateStruct): User;
 
     /**
-     * Updates user's password.
+     * Validates and updates just the user's password.
      *
+     * @throws \eZ\Publish\API\Repository\Exceptions\ContentValidationException
      * @throws \eZ\Publish\API\Repository\Exceptions\ContentFieldValidationException if new password does not pass validation
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the authenticated user is not allowed to update the user
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
+     * @throws \Exception
      */
     public function updateUserPassword(User $user, string $newPassword): User;
 

--- a/eZ/Publish/Core/Repository/User/PasswordValidator.php
+++ b/eZ/Publish/Core/Repository/User/PasswordValidator.php
@@ -8,7 +8,15 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Repository\User;
 
+use DateInterval;
+use DateTime;
+use DateTimeImmutable;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\API\Repository\Values\User\PasswordInfo;
+use eZ\Publish\API\Repository\Values\User\User;
+use eZ\Publish\API\Repository\Values\User\User as APIUser;
+use eZ\Publish\Core\FieldType\User\Type as UserType;
+use eZ\Publish\Core\FieldType\ValidationError;
 use eZ\Publish\Core\Repository\Validator\UserPasswordValidator;
 
 /**
@@ -16,16 +24,93 @@ use eZ\Publish\Core\Repository\Validator\UserPasswordValidator;
  */
 final class PasswordValidator implements PasswordValidatorInterface
 {
+    /** @var \eZ\Publish\API\Repository\PasswordHashService */
+    private $passwordHashService;
+
+    public function __construct(PasswordHashService $passwordHashService)
+    {
+        $this->passwordHashService = $passwordHashService;
+    }
+
     /**
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validatePassword(string $password, FieldDefinition $userFieldDefinition): array
-    {
+    public function validatePassword(
+        string $password,
+        FieldDefinition $userFieldDefinition,
+        ?User $user = null
+    ): array {
         $configuration = $userFieldDefinition->getValidatorConfiguration();
         if (!isset($configuration['PasswordValueValidator'])) {
             return [];
         }
 
-        return (new UserPasswordValidator($configuration['PasswordValueValidator']))->validate($password);
+        $userPasswordValidator = new UserPasswordValidator(
+            $configuration['PasswordValueValidator']
+        );
+
+        $errors = $userPasswordValidator->validate($password);
+
+        if ($user !== null) {
+            $isPasswordTTLEnabled = $this
+                ->getPasswordInfo($user, $userFieldDefinition)
+                ->hasExpirationDate();
+
+            $isNewPasswordRequired = $configuration['PasswordValueValidator']['requireNewPassword'] ?? false;
+
+            if (
+                ($isPasswordTTLEnabled || $isNewPasswordRequired)
+                && $this->userPasswordIsTheSame($password, $user)
+            ) {
+                $errors[] = new ValidationError(
+                    'New password cannot be the same as old password',
+                    null,
+                    [],
+                    'password'
+                );
+            }
+        }
+
+        return $errors;
+    }
+
+    public function getPasswordInfo(APIUser $user, FieldDefinition $fieldDefinition): PasswordInfo
+    {
+        $passwordUpdatedAt = $user->passwordUpdatedAt;
+        if ($passwordUpdatedAt === null) {
+            return new PasswordInfo();
+        }
+
+        $expirationDate = null;
+        $expirationWarningDate = null;
+
+        $passwordTTL = (int)$fieldDefinition->fieldSettings[UserType::PASSWORD_TTL_SETTING];
+        if ($passwordTTL > 0) {
+            if ($passwordUpdatedAt instanceof DateTime) {
+                $passwordUpdatedAt = DateTimeImmutable::createFromMutable($passwordUpdatedAt);
+            }
+
+            $expirationDate = $passwordUpdatedAt->add(
+                new DateInterval(sprintf('P%dD', $passwordTTL))
+            );
+
+            $passwordTTLWarning = (int)$fieldDefinition->fieldSettings[UserType::PASSWORD_TTL_WARNING_SETTING];
+            if ($passwordTTLWarning > 0) {
+                $expirationWarningDate = $expirationDate->sub(
+                    new DateInterval(sprintf('P%dD', $passwordTTLWarning))
+                );
+            }
+        }
+
+        return new PasswordInfo($expirationDate, $expirationWarningDate);
+    }
+
+    private function userPasswordIsTheSame(string $password, APIUser $user): bool
+    {
+        return $this->passwordHashService->isValidPassword(
+            $password,
+            $user->passwordHash,
+            $user->hashAlgorithm
+        );
     }
 }

--- a/eZ/Publish/Core/Repository/User/PasswordValidatorInterface.php
+++ b/eZ/Publish/Core/Repository/User/PasswordValidatorInterface.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 namespace eZ\Publish\Core\Repository\User;
 
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\API\Repository\Values\User\PasswordInfo;
+use eZ\Publish\API\Repository\Values\User\User;
 
 /**
  * @internal
@@ -18,5 +20,11 @@ interface PasswordValidatorInterface
     /**
      * @return \eZ\Publish\SPI\FieldType\ValidationError[]
      */
-    public function validatePassword(string $password, FieldDefinition $userFieldDefinition): array;
+    public function validatePassword(
+        string $password,
+        FieldDefinition $userFieldDefinition,
+        ?User $user = null
+    ): array;
+
+    public function getPasswordInfo(User $user, FieldDefinition $fieldDefinition): PasswordInfo;
 }

--- a/eZ/Publish/Core/settings/fieldtype_services.yml
+++ b/eZ/Publish/Core/settings/fieldtype_services.yml
@@ -65,7 +65,9 @@ services:
     eZ\Publish\API\Repository\PasswordHashService:
         alias: eZ\Publish\Core\Repository\User\PasswordHashService
 
-    eZ\Publish\Core\Repository\User\PasswordValidator: ~
+    eZ\Publish\Core\Repository\User\PasswordValidator:
+        arguments:
+            $passwordHashService: '@eZ\Publish\Core\Repository\User\PasswordHashService'
 
     eZ\Publish\Core\Repository\User\PasswordValidatorInterface:
         alias: eZ\Publish\Core\Repository\User\PasswordValidator


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3972](https://issues.ibexa.co/browse/IBX-3972)
| **Related PRs**                         | ezsystems/ezplatform-user#113, ezsystems/ezplatform-admin-ui#2094
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no

This PR refactors `PasswordValidator` service to use all validators, including the one which determines if old password was re-used. The responsibility of password validation has been moved from `UserService` to `PasswordValidator` itself. `UserService` now entirely delegates password validation to `PasswordValidator`.

`UserService::getPasswordInfo` method has also been delegated to `PasswordValidator`. The method relies on `FieldDefinition::$fieldSettings`, but it contains mostly validation logic.

It needs to be pointed out that `UserService::updateUserPassword` currently throws `ContentFieldValidationException` while in the context of the user account password itself some more specific wrapper containing `ValidationError` list would be more appropriate. `ContentFieldValidationException` expects `ValidationError` list in the format
`[<fieldId> => [<laguageCode> => array<ValidationError>]]` which doesn't make much sense in the context. Due to BC this however cannot be simply changed. What was fixed was the format of `$errors` array so it follows that API specification. It might be worth to mention in the release notes.

The PR also introduces alignment of tests and fix for processing `ContentFieldValidationException` by test setup.

## Documentation

`UserService::updateUserPassword` PHP API throws now `ContentFieldValidationException` with proper Field Errors array format accessible via `ContentFieldValidationException::getFieldErrors` method. The format of the returned array should always be
```
array<<int fieldId>, array<<string language code>, array<ValidationError>>
```
This is BC break on behavior, but it fixes promise on API specification. It doesn't undergo BC policy, but we definitely should mention this in Release Notes and/or upgrade instruction. Keep in mind this is a bugfix so it's gonna be a part of next patch release (3.3.x), not minor release.

## QA

For the part related to kernel and PHP API `UserService::updateUserPassword` should now correctly throw `ContentFieldValidationException` for the case when reusing old password was forbidden but old password was reused.

For the CR fix part see ezsystems/ezplatform-user#113.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
