### PR TITLE
IBX-5119: Added logging for invalid content's locations setup

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
@@ -214,4 +214,9 @@ class ContentInfo extends ValueObject
     {
         return $this->owner;
     }
+
+    public function getMainLocationId(): ?int
+    {
+        return $this->mainLocationId;
+    }
 }

--- a/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
@@ -27,7 +27,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
  * @property-read bool $alwaysAvailable Indicates if the Content object is shown in the mainlanguage if its not present in an other requested language
  * @property-read string $remoteId a global unique id of the Content object
  * @property-read string $mainLanguageCode The main language code of the Content object. If the available flag is set to true the Content is shown in this language if the requested language does not exist.
- * @property-read int|null $mainLocationId Identifier of the main location.
+ * @property-read int|null $mainLocationId @deprecated Use {@see ContentInfo::getMainLocationId} instead
  * @property-read int $status status of the Content object
  * @property-read bool $isHidden status of the Content object
  */

--- a/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
@@ -219,7 +219,7 @@ class ContentInfo extends ValueObject
     {
         return $this->mainLocationId;
     }
-    
+
     public function getId(): int
     {
         return $this->id;

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -503,9 +503,6 @@ class LocationHandler extends AbstractInMemoryPersistenceHandler implements Loca
         return implode('|', $translations) . '|' . (int)$useAlwaysAvailable;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function countLocationsByContent(int $contentId): int
     {
         $this->logger->logCall(__METHOD__, ['contentId' => $contentId]);

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -502,4 +502,14 @@ class LocationHandler extends AbstractInMemoryPersistenceHandler implements Loca
 
         return implode('|', $translations) . '|' . (int)$useAlwaysAvailable;
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function countLocationsByContent(int $contentId): int
+    {
+        $this->logger->logCall(__METHOD__, ['contentId' => $contentId]);
+
+        return $this->persistenceHandler->locationHandler()->countLocationsByContent($contentId);
+    }
 }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/LocationHandlerTest.php
@@ -69,6 +69,7 @@ class LocationHandlerTest extends AbstractInMemoryCacheHandlerTest
             ['removeSubtree', [12], [['location_path', [12], false]], null, ['lp-12']],
             ['setSectionForSubtree', [12, 2], [['location_path', [12], false]], null, ['lp-12']],
             ['changeMainLocation', [4, 12], [['content', [4], false]], null, ['c-4']],
+            ['countLocationsByContent', [4]],
         ];
     }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -608,4 +608,12 @@ class Handler implements BaseLocationHandler
 
         return $this->locationMapper->createLocationsFromRows($rows);
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function countLocationsByContent(int $contentId): int
+    {
+        return $this->locationGateway->countLocationsByContentId($contentId);
+    }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/LocationHandlerTest.php
@@ -678,6 +678,23 @@ class LocationHandlerTest extends TestCase
     }
 
     /**
+     * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Location::countLocationsByContent
+     */
+    public function testCountLocationsByContent(): void
+    {
+        $handler = $this->getLocationHandler();
+
+        $contentId = 41;
+
+        $this->locationGateway
+            ->expects(self::once())
+            ->method('countLocationsByContentId')
+            ->with($contentId);
+
+        $handler->countLocationsByContent($contentId);
+    }
+
+    /**
      * Returns the handler to test with $methods mocked.
      *
      * @param string[] $methods

--- a/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
@@ -131,7 +131,7 @@ class ContentDomainMapper extends ProxyAwareDomainMapper implements LoggerAwareI
         $mainLocation = $contentInfo->getMainLocation();
 
         // For performance reasons 'countLocationsByContent' is moved to if
-        if ($mainLocation === null && $this->locationHandler->countLocationsByContent($contentInfo->id) > 0) {
+        if ($mainLocation === null && $this->locationHandler->countLocationsByContent($contentInfo->getId()) > 0) {
             $this->logger->error(
                 sprintf(
                     'Main location for content of ID = %d doesn\'t exist yet this content has locations assigned.',

--- a/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
@@ -135,7 +135,7 @@ class ContentDomainMapper extends ProxyAwareDomainMapper implements LoggerAwareI
             $this->logger->error(
                 sprintf(
                     'Main location for content of ID = %d doesn\'t exist yet this content has locations assigned.',
-                    $contentInfo->id
+                    $contentInfo->getId()
                 )
             );
         }

--- a/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
@@ -82,8 +82,8 @@ class ContentDomainMapper extends ProxyAwareDomainMapper implements LoggerAwareI
         LanguageHandler $contentLanguageHandler,
         FieldTypeRegistry $fieldTypeRegistry,
         ThumbnailStrategy $thumbnailStrategy,
-        ?ProxyDomainMapperInterface $proxyFactory = null,
-        ?LoggerInterface $logger = null
+        ?LoggerInterface $logger = null,
+        ?ProxyDomainMapperInterface $proxyFactory = null
     ) {
         $this->contentHandler = $contentHandler;
         $this->locationHandler = $locationHandler;
@@ -129,12 +129,12 @@ class ContentDomainMapper extends ProxyAwareDomainMapper implements LoggerAwareI
 
         $contentInfo = $versionInfo->getContentInfo();
         $mainLocation = $contentInfo->getMainLocation();
-        $contentLocations = $this->locationHandler->loadLocationsByContent($contentInfo->id);
 
-        if ($mainLocation === null && count($contentLocations) > 0) {
+        // For performance reasons 'countLocationsByContent' is moved to if
+        if ($mainLocation === null && $this->locationHandler->countLocationsByContent($contentInfo->id) > 0) {
             $this->logger->error(
                 sprintf(
-                    'Main location for content of ID = %d doesn\'t exist yet it has locations assigned.',
+                    'Main location for content of ID = %d doesn\'t exist yet this content has locations assigned.',
                     $contentInfo->id
                 )
             );

--- a/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentDomainMapper.php
@@ -129,7 +129,9 @@ class ContentDomainMapper extends ProxyAwareDomainMapper implements LoggerAwareI
 
         $contentInfo = $versionInfo->getContentInfo();
         $mainLocation = $contentInfo->getMainLocation();
-        if ($mainLocation === null && $this->locationHandler->countAllLocations() > 0) {
+        $contentLocations = $this->locationHandler->loadLocationsByContent($contentInfo->id);
+
+        if ($mainLocation === null && count($contentLocations) > 0) {
             $this->logger->error(
                 sprintf(
                     'Main location for content of ID = %d doesn\'t exist yet it has locations assigned.',

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/DomainMapperTest.php
@@ -21,6 +21,7 @@ use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo as SPIContentInfo;
 use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo as SPIVersionInfo;
+use Psr\Log\LoggerInterface;
 
 /**
  * Mock test case for internal ContentDomainMapper.
@@ -276,6 +277,7 @@ class DomainMapperTest extends BaseServiceMockTest
             $this->getLanguageHandlerMock(),
             $this->getFieldTypeRegistryMock(),
             $this->getThumbnailStrategy(),
+            $this->getLoggerMock(),
             $this->getProxyFactoryMock()
         );
     }
@@ -307,5 +309,10 @@ class DomainMapperTest extends BaseServiceMockTest
     protected function getProxyFactoryMock(): ProxyDomainMapperInterface
     {
         return $this->createMock(ProxyDomainMapperInterface::class);
+    }
+
+    protected function getLoggerMock(): LoggerInterface
+    {
+        return $this->createMock(LoggerInterface::class);
     }
 }

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -190,6 +190,8 @@ services:
             $contentLanguageHandler: '@ezpublish.spi.persistence.language_handler'
             $fieldTypeRegistry: '@eZ\Publish\Core\FieldType\FieldTypeRegistry'
             $thumbnailStrategy: '@eZ\Publish\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'
+        calls:
+            - [setLogger, ['@?logger']]
 
     eZ\Publish\Core\Repository\Mapper\RoleDomainMapper:
         arguments:

--- a/eZ/Publish/Core/settings/repository/inner.yml
+++ b/eZ/Publish/Core/settings/repository/inner.yml
@@ -192,6 +192,8 @@ services:
             $thumbnailStrategy: '@eZ\Publish\Core\Repository\Strategy\ContentThumbnail\ThumbnailChainStrategy'
         calls:
             - [setLogger, ['@?logger']]
+        tags:
+            - { name: 'monolog.logger', channel: 'ibexa.core' }
 
     eZ\Publish\Core\Repository\Mapper\RoleDomainMapper:
         arguments:

--- a/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
@@ -252,4 +252,9 @@ interface Handler
      * @return \eZ\Publish\SPI\Persistence\Content\Location[]
      */
     public function loadAllLocations($offset, $limit);
+
+    /**
+     * Counts locations for a given content represented by its id.
+     */
+    public function countLocationsByContent(int $contentId): int;
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5119](https://issues.ibexa.co/browse/IBX-5119)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Added logging when a main location for content doesn't exist but that content has locations assigned according to https://github.com/ezsystems/ezplatform-rest/pull/100#pullrequestreview-1310926719.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
