### PR TITLE
IBX-5026: Allowed user to move subtree if he doesn't have access to second content's location

### DIFF
--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -3487,7 +3487,6 @@ class LocationServiceTest extends BaseTest
     {
         $repository = $this->getRepository();
         $locationService = $repository->getLocationService();
-        $contentService = $repository->getContentService();
         $permissionResolver = $repository->getPermissionResolver();
 
         $folder = $this->publishContentWithParentLocation('Parent folder', 2);

--- a/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
+++ b/eZ/Publish/API/Repository/Values/Content/ContentInfo.php
@@ -15,7 +15,7 @@ use eZ\Publish\API\Repository\Values\ValueObject;
 /**
  * This class provides all version independent information of the Content object.
  *
- * @property-read int $id The unique id of the Content object
+ * @property-read int $id @deprecated Use {@see ContentInfo::getId} instead. The unique id of the Content object
  * @property-read int $contentTypeId The unique id of the Content Type object the Content object is an instance of
  * @property-read string $name the computed name (via name schema) in the main language of the Content object
  * @property-read int $sectionId the section to which the Content object is assigned
@@ -213,5 +213,10 @@ class ContentInfo extends ValueObject
     public function getOwner(): User
     {
         return $this->owner;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
     }
 }

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -966,8 +966,17 @@ class LocationService implements LocationServiceInterface
         return $this->locationFilteringHandler->count($filter);
     }
 
-    private function checkCreatePermissionOnSubtreeTarget(APILocation $targetParentLocation, APILocation $loadedSubtree, APILocation $loadedTargetLocation): void
-    {
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException
+     * @throws \eZ\Publish\API\Repository\Exceptions\BadStateException
+     * @throws \Ibexa\Contracts\Core\Repository\Exceptions\InvalidCriterionArgumentException
+     * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException
+     */
+    private function checkCreatePermissionOnSubtreeTarget(
+        APILocation $targetParentLocation,
+        APILocation $loadedSubtree,
+        APILocation $loadedTargetLocation
+    ): void {
         $locationTarget = (new DestinationLocationTarget($targetParentLocation->id, $loadedSubtree->contentInfo));
         if (!$this->permissionResolver->canUser(
             'content',
@@ -1000,6 +1009,8 @@ class LocationService implements LocationServiceInterface
                         [
                             new CriterionSubtree($loadedSubtree->pathString),
                             new CriterionLogicalNot($contentReadCriterion),
+                            // Do not take the same content into consideration as it can have more than one location
+                            new CriterionLogicalNot(new Criterion\ContentId($loadedSubtree->contentId)),
                         ]
                     ),
                 ]

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -1007,10 +1007,10 @@ class LocationService implements LocationServiceInterface
                     'limit' => 0,
                     'filter' => new CriterionLogicalAnd(
                         [
-                            new CriterionSubtree($loadedSubtree->pathString),
+                            new CriterionSubtree($loadedSubtree->getPathString()),
                             new CriterionLogicalNot($contentReadCriterion),
                             // Do not take the same content into consideration as it can have more than one location
-                            new CriterionLogicalNot(new Criterion\ContentId($loadedSubtree->contentId)),
+                            new CriterionLogicalNot(new Criterion\ContentId($loadedSubtree->getContentInfo()->getId())),
                         ]
                     ),
                 ]


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5026](https://issues.ibexa.co/browse/IBX-5026)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Currently, a user is unable to move content if he doesn't have access to its other location but he has access to a location that he wants to move. This PR fixes this.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
