### PR TITLE
[Fast forward] Fixed extractTranslatable and testLoadUserGroupThrowsNotFoundException

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -131,7 +131,7 @@ class UserServiceTest extends BaseTest
      * Test for the loadUserGroup() method.
      *
      * @see \eZ\Publish\API\Repository\UserService::loadUserGroup()
-     * @depends eZ\Publish\API\Repository\Tests\UserServiceTest::testLoadUserGroup
+     * @depends testLoadUserGroup
      */
     public function testLoadUserGroupThrowsNotFoundException()
     {


### PR DESCRIPTION
This PR fixes some issues spotted in tests:
- [x] Missing array shape for `extractTranslatable(array $fieldErrors)` parameter, spotted in https://github.com/ibexa/core/pull/210#discussion_r1121696837
- [x] High complexity of "flattening" `$fieldErrors` array to extract `ValidationError` leaves (Replaced by Recursive iterators)
- [x] Erroneous `@depends` annotation for `UserServiceTest::testLoadUserGroupThrowsNotFoundException` - FQCN `@depends` cannot be prefixed with `\`. Otherwise it silently fails with
       ```
       This test depends on "\eZ\Publish\API\Repository\Tests\UserServiceTest::testLoadUserGroup" to pass.
       ```