### PR TITLE
IBX-5068: Fixed mapping fields for update to account for language

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Field.php
+++ b/eZ/Publish/API/Repository/Values/Content/Field.php
@@ -47,7 +47,7 @@ class Field extends ValueObject
     /**
      * the language code.
      *
-     * @var string
+     * @var string|null
      */
     protected $languageCode;
 
@@ -76,7 +76,7 @@ class Field extends ValueObject
         return $this->value;
     }
 
-    public function getLanguageCode(): string
+    public function getLanguageCode(): ?string
     {
         return $this->languageCode;
     }

--- a/eZ/Publish/Core/Repository/Mapper/ContentMapper.php
+++ b/eZ/Publish/Core/Repository/Mapper/ContentMapper.php
@@ -300,7 +300,7 @@ class ContentMapper
 
             $fieldType = $this->fieldTypeRegistry->getFieldType($fieldDefinition->fieldTypeIdentifier);
 
-            $field = $content->getField($updatedField->fieldDefIdentifier);
+            $field = $content->getField($updatedField->fieldDefIdentifier, $updatedField->getLanguageCode());
             $updatedFieldValue = $this->getFieldValueForUpdate(
                 $updatedField,
                 $field,

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -1030,7 +1030,7 @@ class ContentTest extends BaseServiceMockTest
             ->with(42)
             ->will($this->returnValue(['version']));
 
-        /* @var APIVersionInfo $versionInfo */
+        /* @var \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo */
         $contentService->deleteVersion($versionInfo);
     }
 
@@ -5849,7 +5849,7 @@ class ContentTest extends BaseServiceMockTest
             ->with($spiVersionInfo)
             ->will($this->returnValue($versionInfoMock));
 
-        /* @var APIVersionInfo $versionInfoMock */
+        /* @var \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfoMock */
         $content = $this->mockPublishVersion(123456, 126666, true);
         $locationServiceMock->expects($this->once())
             ->method('createLocation')

--- a/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
+++ b/eZ/Publish/Core/Repository/Tests/Service/Mock/ContentTest.php
@@ -27,6 +27,8 @@ use eZ\Publish\API\Repository\Values\ContentType\FieldDefinition as APIFieldDefi
 use eZ\Publish\Core\Base\Exceptions\ContentFieldValidationException;
 use eZ\Publish\Core\Base\Exceptions\ContentValidationException;
 use eZ\Publish\Core\Base\Exceptions\NotFoundException;
+use eZ\Publish\Core\FieldType\TextLine\Type;
+use eZ\Publish\Core\FieldType\TextLine\Value as TextLineValue;
 use eZ\Publish\Core\FieldType\ValidationError;
 use eZ\Publish\Core\FieldType\Value;
 use eZ\Publish\Core\Repository\ContentService;
@@ -45,6 +47,7 @@ use eZ\Publish\Core\Repository\Values\User\UserReference;
 use eZ\Publish\SPI\FieldType\FieldType;
 use eZ\Publish\SPI\FieldType\FieldType as SPIFieldType;
 use eZ\Publish\SPI\FieldType\Value as SPIValue;
+use eZ\Publish\SPI\Limitation\Target\Builder\VersionBuilder;
 use eZ\Publish\SPI\Persistence\Content as SPIContent;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo as SPIContentInfo;
 use eZ\Publish\SPI\Persistence\Content\CreateStruct as SPIContentCreateStruct;
@@ -1027,7 +1030,7 @@ class ContentTest extends BaseServiceMockTest
             ->with(42)
             ->will($this->returnValue(['version']));
 
-        /* @var \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfo */
+        /* @var APIVersionInfo $versionInfo */
         $contentService->deleteVersion($versionInfo);
     }
 
@@ -3166,6 +3169,109 @@ class ContentTest extends BaseServiceMockTest
                 $this->equalTo($content),
                 $this->isType('array')
             )->will($this->returnValue(false));
+
+        $mockedService->updateContent($versionInfo, $contentUpdateStruct);
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     */
+    public function testUpdateContentGetsProperFieldsToUpdate(): void
+    {
+        $mockedService = $this->getPartlyMockedContentService(['loadContent']);
+        $permissionResolverMock = $this->getPermissionResolverMock();
+
+        $contentId = 42;
+        $versionNo = 7;
+
+        $updatedField = new Field(
+            [
+                'value' => new TextLineValue('updated one'),
+                'languageCode' => 'fre-FR',
+                'fieldDefIdentifier' => 'name',
+                'fieldTypeIdentifier' => 'ezstring',
+            ]
+        );
+        $updatedField2 = new Field(
+            [
+                'value' => new TextLineValue('two'),
+                'languageCode' => 'fre-FR',
+                'fieldDefIdentifier' => 'name',
+                'fieldTypeIdentifier' => 'ezstring',
+            ]
+        );
+
+        $contentUpdateStruct = new ContentUpdateStruct([
+            'initialLanguageCode' => 'fre-FR',
+            'fields' => [
+                $updatedField,
+                $updatedField2,
+            ],
+        ]);
+
+        $versionInfo = new VersionInfo(
+            [
+                'contentInfo' => new ContentInfo(['id' => $contentId, 'mainLanguageCode' => 'eng-GB']),
+                'versionNo' => $versionNo,
+                'status' => APIVersionInfo::STATUS_DRAFT,
+            ]
+        );
+
+        $content = new Content(
+            [
+                'versionInfo' => $versionInfo,
+                'internalFields' => [
+                    new Field(
+                        [
+                            'value' => new TextLineValue('one'),
+                            'languageCode' => 'eng-GB',
+                            'fieldDefIdentifier' => 'name',
+                            'fieldTypeIdentifier' => 'ezstring',
+                        ]
+                    ),
+                    $updatedField2,
+                ],
+                'contentType' => new ContentType([
+                    'fieldDefinitions' => new FieldDefinitionCollection([
+                        new FieldDefinition([
+                            'identifier' => 'name',
+                            'fieldTypeIdentifier' => 'ezstring',
+                        ]),
+                    ]),
+                ]),
+            ]
+        );
+
+        $mockedService->expects(self::once())
+            ->method('loadContent')
+            ->with($contentId, null, $versionNo)
+            ->willReturn($content);
+
+        $this->getFieldTypeRegistryMock()->expects(self::any())
+            ->method('getFieldType')
+            ->willReturn(new Type());
+
+        $permissionResolverMock->expects(self::once())
+            ->method('canUser')
+            ->with(
+                'content',
+                'edit',
+                $content,
+                [
+                    (new VersionBuilder())
+                        ->updateFields([
+                            $updatedField,
+                        ])
+                        ->updateFieldsTo(
+                            $contentUpdateStruct->initialLanguageCode,
+                            $contentUpdateStruct->fields
+                        )
+                        ->build(),
+                ]
+            )
+            ->willReturn(false);
+
+        $this->expectException(UnauthorizedException::class);
 
         $mockedService->updateContent($versionInfo, $contentUpdateStruct);
     }
@@ -5743,7 +5849,7 @@ class ContentTest extends BaseServiceMockTest
             ->with($spiVersionInfo)
             ->will($this->returnValue($versionInfoMock));
 
-        /* @var \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfoMock */
+        /* @var APIVersionInfo $versionInfoMock */
         $content = $this->mockPublishVersion(123456, 126666, true);
         $locationServiceMock->expects($this->once())
             ->method('createLocation')
@@ -5875,7 +5981,7 @@ class ContentTest extends BaseServiceMockTest
             ->with($spiVersionInfo)
             ->will($this->returnValue($versionInfoMock));
 
-        /* @var \eZ\Publish\API\Repository\Values\Content\VersionInfo $versionInfoMock */
+        /* @var APIVersionInfo $versionInfoMock */
         $content = $this->mockPublishVersion(123456, 126666, true);
         $locationServiceMock->expects($this->once())
             ->method('createLocation')

--- a/tests/lib/Repository/Mapper/ContentMapperTest.php
+++ b/tests/lib/Repository/Mapper/ContentMapperTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Repository\Mapper;
+
+use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Field;
+use eZ\Publish\API\Repository\Values\Content\VersionInfo as APIVersionInfo;
+use eZ\Publish\Core\FieldType\FieldTypeRegistry;
+use eZ\Publish\Core\FieldType\TextLine;
+use eZ\Publish\Core\Persistence\Cache\ContentLanguageHandler;
+use eZ\Publish\Core\Repository\Mapper\ContentMapper;
+use eZ\Publish\Core\Repository\Values\Content\Content;
+use eZ\Publish\Core\Repository\Values\Content\VersionInfo;
+use eZ\Publish\Core\Repository\Values\ContentType\ContentType;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinition;
+use eZ\Publish\Core\Repository\Values\ContentType\FieldDefinitionCollection;
+use PHPUnit\Framework\TestCase;
+
+final class ContentMapperTest extends TestCase
+{
+    /** @var \eZ\Publish\Core\Persistence\Legacy\Content\Language\Handler|\PHPUnit\Framework\MockObject\MockObject */
+    private $contentLanguageHandler;
+
+    /** @var \eZ\Publish\Core\FieldType\FieldTypeRegistry|\PHPUnit\Framework\MockObject\MockObject */
+    private $fieldTypeRegistry;
+
+    /** @var \eZ\Publish\Core\Repository\Mapper\ContentMapper */
+    private $contentMapper;
+
+    protected function setUp(): void
+    {
+        $this->contentLanguageHandler = $this->createMock(ContentLanguageHandler::class);
+        $this->fieldTypeRegistry = $this->createMock(FieldTypeRegistry::class);
+
+        $this->contentMapper = new ContentMapper(
+            $this->contentLanguageHandler,
+            $this->fieldTypeRegistry
+        );
+    }
+
+    /**
+     * @covers \eZ\Publish\Core\Repository\ContentService::updateContent
+     *
+     * @throws \eZ\Publish\Core\Base\Exceptions\ContentValidationException
+     */
+    public function testUpdateContentGetsProperFieldsToUpdate(): void
+    {
+        $updatedField = new Field(
+            [
+                'id' => 1234,
+                'value' => new TextLine\Value('updated one'),
+                'languageCode' => 'fre-FR',
+                'fieldDefIdentifier' => 'name',
+                'fieldTypeIdentifier' => 'ezstring',
+            ]
+        );
+        $updatedField2 = new Field(
+            [
+                'id' => 1235,
+                'value' => new TextLine\Value('two'),
+                'languageCode' => 'fre-FR',
+                'fieldDefIdentifier' => 'name',
+                'fieldTypeIdentifier' => 'ezstring',
+            ]
+        );
+        $updatedFields = [$updatedField, $updatedField2];
+
+        $versionInfo = new VersionInfo(
+            [
+                'contentInfo' => new ContentInfo(['id' => 422, 'mainLanguageCode' => 'eng-GB']),
+                'versionNo' => 7,
+                'status' => APIVersionInfo::STATUS_DRAFT,
+            ]
+        );
+
+        $content = new Content(
+            [
+                'versionInfo' => $versionInfo,
+                'internalFields' => [
+                    new Field(
+                        [
+                            'value' => new TextLine\Value('one'),
+                            'languageCode' => 'eng-GB',
+                            'fieldDefIdentifier' => 'name',
+                            'fieldTypeIdentifier' => 'ezstring',
+                        ]
+                    ),
+                    $updatedField2,
+                ],
+                'contentType' => new ContentType([
+                    'fieldDefinitions' => new FieldDefinitionCollection([
+                        new FieldDefinition([
+                            'identifier' => 'name',
+                            'fieldTypeIdentifier' => 'ezstring',
+                        ]),
+                    ]),
+                ]),
+            ]
+        );
+
+        $this->fieldTypeRegistry
+            ->expects(self::any())
+            ->method('getFieldType')
+            ->willReturn(new TextLine\Type());
+
+        $fieldForUpdate = $this->contentMapper->getFieldsForUpdate($updatedFields, $content);
+
+        self::assertSame([$updatedField], $fieldForUpdate);
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5068](https://issues.ibexa.co/browse/IBX-5068)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Before this PR fields were fetched in a main language - that was the cause for adding an additional field to update even if values in concurrent languages were the same.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
