### PR TITLE
IBX-5505: Preview response should have Cache-Control header set to private

### DIFF
--- a/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
+++ b/eZ/Publish/Core/MVC/Symfony/Controller/Content/PreviewController.php
@@ -130,8 +130,7 @@ EOF;
                 throw $e;
             }
         }
-        $response->headers->remove('cache-control');
-        $response->headers->remove('expires');
+        $response->setPrivate();
 
         $this->previewHelper->restoreConfigScope();
         $this->previewHelper->setPreviewActive(false);


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5505](https://issues.ibexa.co/browse/IBX-5505)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3+`
| **BC breaks**                          | no

In `PreviewController` we remove `Cache-Control` and `Expires` headers from the response - which is bad, as it leads to the situation that Varnish/Fastly will treat this response as catchable and will store it in the cache.
Preview - by definition - allows previewing the current state of the draft, which implies that we want to see change. As the URL used for previewing is always the same for a single version, previewing it multiple times will result in the first preview being cached, and all next previews will not show the current state of the draft, but the one that was cached first.

This PR makes `Response` for preview private, so it won't be cached and - by extension - fixing the issue.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
