### PR TITLE
IBX-5385: Add option content-type to reindex command

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -148,7 +148,7 @@ class ReindexCommand extends Command implements BackwardCompatibleCommand
             )->addOption(
                 'content-type',
                 null,
-                InputOption::VALUE_OPTIONAL,
+                InputOption::VALUE_REQUIRED,
                 'Content type identifier to refresh (deleted/updated/added). Implies "no-purge", cannot be combined with "since", "subtree" or "content-ids"'
             )->setHelp(
                 <<<EOT

--- a/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Command/ReindexCommand.php
@@ -128,23 +128,28 @@ class ReindexCommand extends Command implements BackwardCompatibleCommand
                 'since',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Refresh changes since a time provided in any format understood by DateTime. Implies "no-purge", cannot be combined with "content-ids" or "subtree"'
+                'Refresh changes since a time provided in any format understood by DateTime. Implies "no-purge", cannot be combined with "content-ids", "subtree" or "content-type"'
             )->addOption(
                 'content-ids',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Comma-separated list of content ID\'s to refresh (deleted/updated/added). Implies "no-purge", cannot be combined with "since" or "subtree"'
+                'Comma-separated list of content ID\'s to refresh (deleted/updated/added). Implies "no-purge", cannot be combined with "since", "subtree" or "content-type"'
             )->addOption(
                 'subtree',
                 null,
                 InputOption::VALUE_OPTIONAL,
-                'Location ID whose subtree will be indexed (including the Location itself). Implies "no-purge", cannot be combined with "since" or "content-ids"'
+                'Location ID whose subtree will be indexed (including the Location itself). Implies "no-purge", cannot be combined with "since", "content-ids" or "content-type"'
             )->addOption(
                 'processes',
                 null,
                 InputOption::VALUE_OPTIONAL,
                 'Number of child processes to run in parallel for iterations, if set to "auto" it will set to number of CPU cores -1, set to "1" or "0" to disable',
                 'auto'
+            )->addOption(
+                'content-type',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Content type identifier to refresh (deleted/updated/added). Implies "no-purge", cannot be combined with "since", "subtree" or "content-ids"'
             )->setHelp(
                 <<<EOT
                     The command <info>%command.name%</info> indexes the current configured database in the configured search engine index.
@@ -255,6 +260,10 @@ class ReindexCommand extends Command implements BackwardCompatibleCommand
             $location = $this->locationHandler->load($locationId);
             $count = $this->gateway->countContentInSubtree($location->pathString);
             $generator = $this->gateway->getContentInSubtree($location->pathString, $iterationCount);
+            $purge = false;
+        } elseif ($contentType = $input->getOption('content-type')) {
+            $count = $this->gateway->countContentWithContentTypeIdentifier($contentType);
+            $generator = $this->gateway->getContentWithContentTypeIdentifier($contentType, $iterationCount);
             $purge = false;
         } else {
             $count = $this->gateway->countAllContent();

--- a/eZ/Publish/SPI/Search/Content/IndexerGateway.php
+++ b/eZ/Publish/SPI/Search/Content/IndexerGateway.php
@@ -45,6 +45,18 @@ interface IndexerGateway
      *
      * @return \Generator list of Content IDs for each iteration
      */
+    public function getContentWithContentTypeIdentifier(string $contentTypeIdentifier, int $iterationCount): Generator;
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     */
+    public function countContentWithContentTypeIdentifier(string $contentTypeIdentifier): int;
+
+    /**
+     * @throws \Doctrine\DBAL\Exception
+     *
+     * @return \Generator list of Content IDs for each iteration
+     */
     public function getAllContent(int $iterationCount): Generator;
 
     /**

--- a/eZ/Publish/SPI/Search/Content/IndexerGateway.php
+++ b/eZ/Publish/SPI/Search/Content/IndexerGateway.php
@@ -43,9 +43,9 @@ interface IndexerGateway
     /**
      * @throws \Doctrine\DBAL\Exception
      *
-     * @return \Generator list of Content IDs for each iteration
+     * @return iterable<int> list of Content IDs for each iteration
      */
-    public function getContentWithContentTypeIdentifier(string $contentTypeIdentifier, int $iterationCount): Generator;
+    public function getContentWithContentTypeIdentifier(string $contentTypeIdentifier, int $iterationCount): iterable;
 
     /**
      * @throws \Doctrine\DBAL\Exception


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5385](https://issues.ibexa.co/browse/IBX-5385)
| **Type**                                   | bug/improvement
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no



#### Checklist:
- [ ] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [ ] Asked for a review (ping `@ezsystems/engineering-team`).
