### PR TITLE
IBX-5502: Added additional tag cleaning to limit down number of orphaned tag entries

### DIFF
--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -333,7 +333,7 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
         $locationTags = array_map(function (Content\Location $location): string {
             return $this->cacheIdentifierGenerator->generateTag(self::LOCATION_IDENTIFIER, [$location->id]);
         }, $locations);
-        $locationPathTags = array_map(function (Content\Location $location) {
+        $locationPathTags = array_map(function (Content\Location $location): string {
             return $this->cacheIdentifierGenerator->generateTag(self::LOCATION_PATH_IDENTIFIER, [$location->id]);
         }, $locations);
 

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -330,7 +330,7 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
         $content = $this->persistenceHandler->contentHandler()->updateContent($contentId, $versionNo, $struct);
         $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($contentId);
 
-        $locationTags = array_map(function (Content\Location $location) {
+        $locationTags = array_map(function (Content\Location $location): string {
             return $this->cacheIdentifierGenerator->generateTag(self::LOCATION_IDENTIFIER, [$location->id]);
         }, $locations);
         $locationPathTags = array_map(function (Content\Location $location) {

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -330,7 +330,6 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
         $content = $this->persistenceHandler->contentHandler()->updateContent($contentId, $versionNo, $struct);
         $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($contentId);
 
-
         $locationTags = array_map(function (Content\Location $location) {
             return $this->cacheIdentifierGenerator->generateTag(self::LOCATION_IDENTIFIER, [$location->id]);
         }, $locations);

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -328,12 +328,34 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
     {
         $this->logger->logCall(__METHOD__, ['content' => $contentId, 'version' => $versionNo, 'struct' => $struct]);
         $content = $this->persistenceHandler->contentHandler()->updateContent($contentId, $versionNo, $struct);
-        $this->cache->invalidateTags([
-            $this->cacheIdentifierGenerator->generateTag(
+        $locations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($contentId);
+
+
+        $locationTags = array_map(function (Content\Location $location) {
+            return $this->cacheIdentifierGenerator->generateTag(self::LOCATION_IDENTIFIER, [$location->id]);
+        }, $locations);
+        $locationPathTags = array_map(function (Content\Location $location) {
+            return $this->cacheIdentifierGenerator->generateTag(self::LOCATION_PATH_IDENTIFIER, [$location->id]);
+        }, $locations);
+
+        $versionTags = [];
+        $versionTags[] = $this->cacheIdentifierGenerator->generateTag(
+            self::CONTENT_VERSION_IDENTIFIER,
+            [$contentId, $versionNo]
+        );
+        if ($versionNo > 1) {
+            $versionTags[] = $this->cacheIdentifierGenerator->generateTag(
                 self::CONTENT_VERSION_IDENTIFIER,
-                [$contentId, $versionNo]
-            ),
-        ]);
+                [$contentId, $versionNo - 1]
+            );
+        }
+
+        $tags = array_merge(
+            $locationTags,
+            $locationPathTags,
+            $versionTags
+        );
+        $this->cache->invalidateTags($tags);
 
         return $content;
     }
@@ -350,6 +372,7 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
             $contentId,
             APIRelation::FIELD | APIRelation::ASSET
         );
+        $contentLocations = $this->persistenceHandler->locationHandler()->loadLocationsByContent($contentId);
 
         $return = $this->persistenceHandler->contentHandler()->deleteContent($contentId);
 
@@ -365,6 +388,9 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
             $tags = [];
         }
         $tags[] = $this->cacheIdentifierGenerator->generateTag(self::CONTENT_IDENTIFIER, [$contentId]);
+        foreach ($contentLocations as $location) {
+            $tags[] = $this->cacheIdentifierGenerator->generateTag(self::LOCATION_IDENTIFIER, [$location->id]);
+        }
         $this->cache->invalidateTags($tags);
 
         return $return;

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -49,7 +49,7 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
             ['setStatus', [2, 0, 1], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             ['setStatus', [2, 1, 1], [['content', [2], false]], null, ['c-2']],
             ['updateMetadata', [2, new MetadataUpdateStruct()], [['content', [2], false]], null, ['c-2']],
-            //['updateContent', [2, 1, new UpdateStruct()], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
+            ['updateContent', [2, 1, new UpdateStruct()], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             //['deleteContent', [2]], own tests for relations complexity
             ['deleteVersion', [2, 1], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             ['addRelation', [new RelationCreateStruct()]],
@@ -308,7 +308,7 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
     /**
      * @covers \eZ\Publish\Core\Persistence\Cache\ContentHandler::updateContent
      */
-    public function testUpdateContent()
+    public function testUpdateContent(): void
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
@@ -332,14 +332,15 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
         $this->cacheIdentifierGeneratorMock
             ->expects($this->exactly(5))
             ->method('generateTag')
-            ->withConsecutive(
-                ['location', [3], false],
-                ['location', [4], false],
-                ['location_path', [3], false],
-                ['location_path', [4], false],
-                ['content_version', [2, 1], false],
-            )
-            ->willReturnOnConsecutiveCalls('l-3', 'l-4', 'lp-3', 'lp-4', 'c-2-v-1');
+            ->will(
+                self::returnValueMap([
+                    ['location', [3], false, 'l-3'],
+                    ['location', [4], false, 'l-4'],
+                    ['location_path', [3], false, 'lp-3'],
+                    ['location_path', [4], false, 'lp-4'],
+                    ['content_version', [2, 1], false, 'c-2-v-1'],
+                ])
+            );
 
         $this->cacheMock
             ->expects($this->once())

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -49,7 +49,7 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
             ['setStatus', [2, 0, 1], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             ['setStatus', [2, 1, 1], [['content', [2], false]], null, ['c-2']],
             ['updateMetadata', [2, new MetadataUpdateStruct()], [['content', [2], false]], null, ['c-2']],
-            //updateContent has it own test now due relations complexity
+            //updateContent has its own test now due to relations complexity
             //['updateContent', [2, 1, new UpdateStruct()], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             //['deleteContent', [2]], own tests for relations complexity
             ['deleteVersion', [2, 1], [['content_version', [2, 1], false]], null, ['c-2-v-1']],

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -49,7 +49,8 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
             ['setStatus', [2, 0, 1], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             ['setStatus', [2, 1, 1], [['content', [2], false]], null, ['c-2']],
             ['updateMetadata', [2, new MetadataUpdateStruct()], [['content', [2], false]], null, ['c-2']],
-            ['updateContent', [2, 1, new UpdateStruct()], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
+            //updateContent has it own test now due relations complexity
+            //['updateContent', [2, 1, new UpdateStruct()], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             //['deleteContent', [2]], own tests for relations complexity
             ['deleteVersion', [2, 1], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             ['addRelation', [new RelationCreateStruct()]],

--- a/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/ContentHandlerTest.php
@@ -12,11 +12,13 @@ use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
 use eZ\Publish\SPI\Persistence\Content\CreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Handler as SPIContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Location\Handler as SPILocationHandler;
 use eZ\Publish\SPI\Persistence\Content\MetadataUpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Relation as SPIRelation;
 use eZ\Publish\SPI\Persistence\Content\Relation\CreateStruct as RelationCreateStruct;
 use eZ\Publish\SPI\Persistence\Content\UpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\VersionInfo;
+use PHPUnit\Framework\MockObject\MockObject;
 
 /**
  * Test case for Persistence\Cache\ContentHandler.
@@ -47,7 +49,7 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
             ['setStatus', [2, 0, 1], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             ['setStatus', [2, 1, 1], [['content', [2], false]], null, ['c-2']],
             ['updateMetadata', [2, new MetadataUpdateStruct()], [['content', [2], false]], null, ['c-2']],
-            ['updateContent', [2, 1, new UpdateStruct()], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
+            //['updateContent', [2, 1, new UpdateStruct()], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             //['deleteContent', [2]], own tests for relations complexity
             ['deleteVersion', [2, 1], [['content_version', [2, 1], false]], null, ['c-2-v-1']],
             ['addRelation', [new RelationCreateStruct()]],
@@ -304,29 +306,67 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
     }
 
     /**
+     * @covers \eZ\Publish\Core\Persistence\Cache\ContentHandler::updateContent
+     */
+    public function testUpdateContent()
+    {
+        $this->loggerMock->expects($this->once())->method('logCall');
+
+        $innerContentHandlerMock = $this->createMock(SPIContentHandler::class);
+        $innerLocationHandlerMock = $this->createMock(SPILocationHandler::class);
+
+        $this->prepareHandlerMocks(
+            $innerContentHandlerMock,
+            $innerLocationHandlerMock,
+            1,
+            1,
+            0
+        );
+
+        $innerContentHandlerMock
+            ->expects($this->once())
+            ->method('updateContent')
+            ->with(2, 1, new UpdateStruct())
+            ->willReturn(new Content());
+
+        $this->cacheIdentifierGeneratorMock
+            ->expects($this->exactly(5))
+            ->method('generateTag')
+            ->withConsecutive(
+                ['location', [3], false],
+                ['location', [4], false],
+                ['location_path', [3], false],
+                ['location_path', [4], false],
+                ['content_version', [2, 1], false],
+            )
+            ->willReturnOnConsecutiveCalls('l-3', 'l-4', 'lp-3', 'lp-4', 'c-2-v-1');
+
+        $this->cacheMock
+            ->expects($this->once())
+            ->method('invalidateTags')
+            ->with(['l-3', 'l-4', 'lp-3', 'lp-4', 'c-2-v-1']);
+
+        $handler = $this->persistenceCacheHandler->contentHandler();
+        $handler->updateContent(2, 1, new UpdateStruct());
+    }
+
+    /**
      * @covers \eZ\Publish\Core\Persistence\Cache\ContentHandler::deleteContent
      */
     public function testDeleteContent()
     {
         $this->loggerMock->expects($this->once())->method('logCall');
 
-        $innerHandlerMock = $this->createMock(SPIContentHandler::class);
-        $this->persistenceHandlerMock
-            ->expects($this->exactly(2))
-            ->method('contentHandler')
-            ->willReturn($innerHandlerMock);
+        $innerContentHandlerMock = $this->createMock(SPIContentHandler::class);
+        $innerLocationHandlerMock = $this->createMock(SPILocationHandler::class);
 
-        $innerHandlerMock
-            ->expects($this->once())
-            ->method('loadReverseRelations')
-            ->with(2, APIRelation::FIELD | APIRelation::ASSET)
-            ->willReturn(
-                [
-                    new SPIRelation(['sourceContentId' => 42]),
-                ]
-            );
+        $this->prepareHandlerMocks(
+            $innerContentHandlerMock,
+            $innerLocationHandlerMock,
+            2
+        );
 
-        $innerHandlerMock
+        $innerContentHandlerMock
             ->expects($this->once())
             ->method('deleteContent')
             ->with(2)
@@ -337,20 +377,62 @@ class ContentHandlerTest extends AbstractInMemoryCacheHandlerTest
             ->method('deleteItem');
 
         $this->cacheIdentifierGeneratorMock
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(4))
             ->method('generateTag')
             ->withConsecutive(
                 ['content', [42], false],
-                ['content', [2], false]
+                ['content', [2], false],
+                ['location', [3], false],
+                ['location', [4], false]
             )
-            ->willReturnOnConsecutiveCalls('c-42', 'c-2');
+            ->willReturnOnConsecutiveCalls('c-42', 'c-2', 'l-3', 'l-4');
 
         $this->cacheMock
             ->expects($this->once())
             ->method('invalidateTags')
-            ->with(['c-42', 'c-2']);
+            ->with(['c-42', 'c-2', 'l-3', 'l-4']);
 
         $handler = $this->persistenceCacheHandler->contentHandler();
         $handler->deleteContent(2);
+    }
+
+    private function prepareHandlerMocks(
+        MockObject $innerContentHandlerMock,
+        MockObject $innerLocationHandlerMock,
+        int $contentHandlerCount = 1,
+        int $locationHandlerCount = 1,
+        int $loadReverseRelationsCount = 1,
+        int $loadLocationsByContentCount = 1
+    ): void {
+        $this->persistenceHandlerMock
+            ->expects($this->exactly($contentHandlerCount))
+            ->method('contentHandler')
+            ->willReturn($innerContentHandlerMock);
+
+        $innerContentHandlerMock
+            ->expects($this->exactly($loadReverseRelationsCount))
+            ->method('loadReverseRelations')
+            ->with(2, APIRelation::FIELD | APIRelation::ASSET)
+            ->willReturn(
+                [
+                    new SPIRelation(['sourceContentId' => 42]),
+                ]
+            );
+
+        $this->persistenceHandlerMock
+            ->expects($this->exactly($locationHandlerCount))
+            ->method('locationHandler')
+            ->willReturn($innerLocationHandlerMock);
+
+        $innerLocationHandlerMock
+            ->expects($this->exactly($loadLocationsByContentCount))
+            ->method('loadLocationsByContent')
+            ->with(2)
+            ->willReturn(
+                [
+                    new Content\Location(['id' => 3]),
+                    new Content\Location(['id' => 4]),
+                ]
+            );
     }
 }

--- a/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
@@ -13,6 +13,7 @@ use eZ\Publish\SPI\Persistence\Content\Location;
 use eZ\Publish\SPI\Persistence\Content\Location\Trash\Handler as TrashHandler;
 use eZ\Publish\SPI\Persistence\Content\Location\Trashed;
 use eZ\Publish\SPI\Persistence\Content\Relation;
+use eZ\Publish\SPI\Persistence\Content\VersionInfo;
 
 /**
  * Test case for Persistence\Cache\SectionHandler.
@@ -118,10 +119,13 @@ class TrashHandlerTest extends AbstractCacheHandlerTest
     {
         $locationId = 6;
         $contentId = 42;
+        $versionNo = 1;
 
         $tags = [
-            'c-' . $contentId,
             'lp-' . $locationId,
+            'l-' . $locationId,
+            'c-' . $contentId . '-v-' . $versionNo,
+            'c-' . $contentId,
         ];
 
         $handlerMethodName = $this->getHandlerMethodName();
@@ -144,6 +148,16 @@ class TrashHandlerTest extends AbstractCacheHandlerTest
             ->method('locationHandler')
             ->willReturn($locationHandlerMock);
 
+        $contentHandlerMock
+            ->expects($this->once())
+            ->method('listVersions')
+            ->with($contentId)
+            ->willReturn(
+                [
+                    new VersionInfo(['versionNo' => $versionNo]),
+                ]
+            );
+
         $this->persistenceHandlerMock
             ->expects($this->once())
             ->method($handlerMethodName)
@@ -156,11 +170,13 @@ class TrashHandlerTest extends AbstractCacheHandlerTest
             ->willReturn(null);
 
         $this->cacheIdentifierGeneratorMock
-            ->expects($this->exactly(2))
+            ->expects($this->exactly(4))
             ->method('generateTag')
             ->withConsecutive(
+                ['content_version', [$contentId, $versionNo], false],
                 ['content', [$contentId], false],
-                ['location_path', [$locationId], false]
+                ['location_path', [$locationId], false],
+                ['location', [$locationId], false]
             )
             ->willReturnOnConsecutiveCalls(...$tags);
 

--- a/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Cache/Tests/TrashHandlerTest.php
@@ -122,10 +122,10 @@ class TrashHandlerTest extends AbstractCacheHandlerTest
         $versionNo = 1;
 
         $tags = [
-            'lp-' . $locationId,
-            'l-' . $locationId,
             'c-' . $contentId . '-v-' . $versionNo,
             'c-' . $contentId,
+            'lp-' . $locationId,
+            'l-' . $locationId,
         ];
 
         $handlerMethodName = $this->getHandlerMethodName();
@@ -168,7 +168,6 @@ class TrashHandlerTest extends AbstractCacheHandlerTest
             ->method('trashSubtree')
             ->with($locationId)
             ->willReturn(null);
-
         $this->cacheIdentifierGeneratorMock
             ->expects($this->exactly(4))
             ->method('generateTag')

--- a/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
@@ -41,8 +41,9 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
 
         $location = $this->persistenceHandler->locationHandler()->load($locationId);
         $contentId = $location->contentId;
-        $reverseRelations = $this->persistenceHandler->contentHandler()->loadRelations($contentId);
-        $versions = $this->persistenceHandler->contentHandler()->listVersions($contentId);
+        $contentHandler = $this->persistenceHandler->contentHandler();
+        $reverseRelations = $contentHandler->loadRelations($contentId);
+        $versions = $contentHandler->listVersions($contentId);
         $return = $this->persistenceHandler->trashHandler()->trashSubtree($locationId);
 
         $relationTags = [];
@@ -56,7 +57,7 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
         }
 
         $versionTags = array_map(function (VersionInfo $versionInfo) use ($contentId): string {
-            return  $this->cacheIdentifierGenerator->generateTag(
+            return $this->cacheIdentifierGenerator->generateTag(
                 self::CONTENT_VERSION_IDENTIFIER,
                 [$contentId, $versionInfo->versionNo]
             );

--- a/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
@@ -55,7 +55,7 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
             }, $reverseRelations);
         }
 
-        $versionTags = array_map(function (VersionInfo $versionInfo) use ($contentId) {
+        $versionTags = array_map(function (VersionInfo $versionInfo) use ($contentId): string {
             return  $this->cacheIdentifierGenerator->generateTag(
                 self::CONTENT_VERSION_IDENTIFIER,
                 [$contentId, $versionInfo->versionNo]

--- a/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
@@ -139,7 +139,6 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
 
                 $tags[$this->cacheIdentifierGenerator->generateTag(self::CONTENT_IDENTIFIER, [$trashedItem->contentId])] = true;
                 $tags[$this->cacheIdentifierGenerator->generateTag(self::LOCATION_PATH_IDENTIFIER, [$trashedItem->id])] = true;
-
             }
             $offset += self::EMPTY_TRASH_BULK_SIZE;
             // Once offset is larger than total count we can exit

--- a/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/TrashHandler.php
@@ -63,14 +63,15 @@ class TrashHandler extends AbstractHandler implements TrashHandlerInterface
         }, $versions);
 
         $tags = array_merge(
+            $versionTags,
+            $relationTags,
             [
                 $this->cacheIdentifierGenerator->generateTag(self::CONTENT_IDENTIFIER, [$contentId]),
                 $this->cacheIdentifierGenerator->generateTag(self::LOCATION_PATH_IDENTIFIER, [$locationId]),
                 $this->cacheIdentifierGenerator->generateTag(self::LOCATION_IDENTIFIER, [$locationId]),
             ],
-            $relationTags,
-            $versionTags
         );
+
         $this->cache->invalidateTags(array_values(array_unique($tags)));
 
         return $return;


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5502](https://issues.ibexa.co/browse/IBX-5502)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Due to the how cache is implemented in Symfony-based projects using the Redis adapter (and probably - not only Redis), entries (Members) inside a Tag (Set) are removed only when the tag is purged. Due to that, we can encounter on multiple occasions a situation, when a Tag is purged, resulting in cache items (Keys) being purged as well, but only the Tag that triggered a purge is cleaned up. All other tags that contain entries pointing to cache items that no longer exist will remain there until the affected tag is purged - which often is "never".

This results in orphaned entries in tags (or even in whole orphaned tags) filling up the memory. Memory allocated to tags in Redis is nonevictable, therefore it is freed only when purged on purpose (`maxmemory-policy` setting won't affect orphaned members/sets). On very big and/or constantly changing content structures, this unevictable memory allocated to orphaned tags and entries can significantly lower the amount of memory available for standard cache items to be stored.

Additional Tag purging added in this PR reduces this effect, but - unfortunately - it is not possible to resolve it fully with current Symfony's cache adapters implementation, due to the fact that there is no available interface to remove an entry from a Tag, without purging it whole - and that would result in purging cache items that were nor related to the original action performed on content.

Additional tag purging introduced by PR:
- `ContentHandler::updateContent`:
Multiple content-related entries (`ibx-c-<contentId>-<versionNo>-0`, `ibx-c-<contentId>-<versionNo>-<languageCode>`, `ibx-cvi-<contentId>`,  `ibx-cl-<contentId>-pfd` are orphaned in tags: `l-<locationId>`, `lp-<locationId>`, `c-<contentId>-v-<versionNo>`, `c-<contentId>-v-<prevVersionNo>`. Added purging of those tags to avoid it.

- `TrashHandler::trashSubtree`:
Multiple content-related entries are orphaned (`ibx-c-<contentId>-v<versionNumber>`, `ibx-cl-<contentId>`, `ibx-cvi-<contentId>`, `ibx-l-<locationId>-<languageCode>`, `ibx-c-<contentId>-<versionNo>-0`, `ibx-c-<contentId>-<versionNo>-<languageCode>`, `ibx-cvi-<contentId>` ... (many more) are orphaned in tags: `l-<locationId>`, `c-<contentId>-v-<versionNo>`.

Handling those two occurrences helps to limit greatly the number of orphaned members.

My tests show, that one of the biggest culprits here is `lp-<locationIdOfParent>` tag, which can have multiple orphaned entries - therefore it might be a good idea to purge it as well, to avoid blocked memory in cost of potentially small performance loss - up for discussion.

This PR won't resolve the issue fully but limits the scope of it using available tools. To resolve this fully, we will need (in my opinion):
- an interface to remove entries from sets
- a garbage collector, as entries in tags might become orphaned as well when a key is evicted by Redis when maxmemory limit is reached.
But those two are out of this PR scope.


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
