### PR TITLE
IBX-6207: Requests containing front controller script causes session-not-found exception

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionInitByPostListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionInitByPostListener.php
@@ -27,7 +27,10 @@ class SessionInitByPostListener implements EventSubscriberInterface
     public function onSiteAccessMatch(PostSiteAccessMatchEvent $event)
     {
         $request = $event->getRequest();
-        $request->hasSession() ? $session = $request->getSession() : $session = false;
+        $session = null;
+        if ($request->hasSession()) {
+            $session = $request->getSession();
+        }
 
         if (!$session || $event->getRequestType() !== HttpKernelInterface::MAIN_REQUEST) {
             return;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionInitByPostListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionInitByPostListener.php
@@ -27,7 +27,7 @@ class SessionInitByPostListener implements EventSubscriberInterface
     public function onSiteAccessMatch(PostSiteAccessMatchEvent $event)
     {
         $request = $event->getRequest();
-        $session = $request->getSession();
+        $request->hasSession() ? $session = $request->getSession() : $session = false;
 
         if (!$session || $event->getRequestType() !== HttpKernelInterface::MAIN_REQUEST) {
             return;

--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionInitByPostListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/SessionInitByPostListener.php
@@ -32,7 +32,7 @@ class SessionInitByPostListener implements EventSubscriberInterface
             $session = $request->getSession();
         }
 
-        if (!$session || $event->getRequestType() !== HttpKernelInterface::MAIN_REQUEST) {
+        if (null === $session || $event->getRequestType() !== HttpKernelInterface::MAIN_REQUEST) {
             return;
         }
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionInitByPostListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionInitByPostListenerTest.php
@@ -118,7 +118,7 @@ class SessionInitByPostListenerTest extends TestCase
         $this->listener->onSiteAccessMatch($event);
     }
 
-    public function testOnSiteAccessMatchNoSession()
+    public function testOnSiteAccessMatchNoSession(): void
     {
         $request = new Request();
 

--- a/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionInitByPostListenerTest.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Tests/EventListener/SessionInitByPostListenerTest.php
@@ -117,4 +117,12 @@ class SessionInitByPostListenerTest extends TestCase
 
         $this->listener->onSiteAccessMatch($event);
     }
+
+    public function testOnSiteAccessMatchNoSession()
+    {
+        $request = new Request();
+
+        $event = new PostSiteAccessMatchEvent(new SiteAccess('test'), $request, HttpKernelInterface::MAIN_REQUEST);
+        $this->listener->onSiteAccessMatch($event);
+    }
 }


### PR DESCRIPTION

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6207](https://issues.ibexa.co/browse/IBX-6207)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Provide the front controller script in the url ( ie http://localhost/index.php or http://localhost/foobar/index.php ) will cause SessionNotFoundException exception.

Expected behavior : RejectExplicitFrontControllerRequestsListener should kick in ensure a 404 is returned without filling up logs.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
