### PR TITLE
IBX-5388: Added index on `contentclassattribute_id` in the `ezcontentobject_link` table

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/storage/legacy/schema.yaml
@@ -261,6 +261,7 @@ tables:
         indexes:
             ezco_link_to_co_id: { fields: [to_contentobject_id] }
             ezco_link_from: { fields: [from_contentobject_id, from_contentobject_version, contentclassattribute_id] }
+            ezco_link_cca_id: { fields: [contentclassattribute_id] }
         id:
             id: { type: integer, nullable: false, options: { autoincrement: true } }
         fields:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-5388](https://issues.ibexa.co/browse/IBX-5388)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This change is meant to improve performance when performing multiple deletes on the ezcontentobject_link table. 
Charts/screenshots of performance upgrades are available in the public ticket.

Related PR: https://github.com/ibexa/installer/pull/114

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x]  Asked for a review (ping `@ezsystems/engineering-team`).
