### PR TITLE
IBX-6185: Add more PHP file types to default upload blocklist (#3153)

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/default_settings.yml
@@ -109,6 +109,9 @@ parameters:
     ezsettings.default.io.file_storage.file_type_blacklist:
         - php
         - php3
+        - php4
+        - php5
+        - phps
         - phar
         - phpt
         - pht


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6185](https://issues.ibexa.co/browse/IBX-6185)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no (debatable)

Cherry-pick to v3.3 of original v2.5 commit, ref: https://github.com/ezsystems/ezpublish-kernel/pull/3153

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually. (on v4.5)
- [x] ~Provided automated test coverage.~ (pre-existing)
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] ~Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).~
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
