### PR TITLE
EZP-29574: [Tests] Moved testLoadUserByTokenThrowsNotFoundException after tests depending of testLoadUserByToken

### DIFF
--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -2972,29 +2972,6 @@ class UserServiceTest extends BaseTest
     }
 
     /**
-     * Test trying to load User by invalid Token.
-     *
-     * @covers \eZ\Publish\API\Repository\UserService::loadUserByToken
-     */
-    public function testLoadUserByTokenThrowsNotFoundException()
-    {
-        $this->expectException(NotFoundException::class);
-
-        $repository = $this->getRepository();
-        $userService = $repository->getUserService();
-
-        $user = $this->createUserVersion1();
-
-        $userTokenUpdateStruct = new UserTokenUpdateStruct();
-        $userTokenUpdateStruct->hashKey = md5('hash');
-        $userTokenUpdateStruct->time = new DateTime();
-
-        $userService->updateUserToken($user, $userTokenUpdateStruct);
-
-        $userService->loadUserByToken('not_existing_token');
-    }
-
-    /**
      * Test updating User Token.
      *
      * @covers \eZ\Publish\API\Repository\UserService::updateUserToken()
@@ -3043,6 +3020,21 @@ class UserServiceTest extends BaseTest
 
         // should throw NotFoundException now
         $userService->loadUserByToken($userToken);
+    }
+
+    /**
+     * Test trying to load User by invalid Token.
+     *
+     * @covers \eZ\Publish\API\Repository\UserService::loadUserByToken
+     */
+    public function testLoadUserByTokenThrowsNotFoundException()
+    {
+        $this->expectException(NotFoundException::class);
+
+        $repository = $this->getRepository();
+        $userService = $repository->getUserService();
+
+        $userService->loadUserByToken('not_existing_token');
     }
 
     /**

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -3029,11 +3029,10 @@ class UserServiceTest extends BaseTest
      */
     public function testLoadUserByTokenThrowsNotFoundException()
     {
-        $this->expectException(NotFoundException::class);
-
         $repository = $this->getRepository();
         $userService = $repository->getUserService();
 
+        $this->expectException(NotFoundException::class);
         $userService->loadUserByToken('not_existing_token');
     }
 

--- a/eZ/Publish/API/Repository/Tests/UserServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/UserServiceTest.php
@@ -3027,7 +3027,7 @@ class UserServiceTest extends BaseTest
      *
      * @covers \eZ\Publish\API\Repository\UserService::loadUserByToken
      */
-    public function testLoadUserByTokenThrowsNotFoundException()
+    public function testLoadUserByTokenThrowsNotFoundException(): void
     {
         $repository = $this->getRepository();
         $userService = $repository->getUserService();


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [EZP-29574](https://issues.ibexa.co/browse/EZP-29574)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

After re-analyzing the tests that sometimes throw the problem, I probably found the cause. `testLoadUserByTokenThrowsNotFoundException` was fired right after `testLoadUserByToken` and has `$repository = $this->getRepository();` which clears the database. In `testLoadUserByTokenThrowsNotFoundException`, we also created a user token with a time set to the current time that is not needed for this test. Therefore the exception about not finding the token was thrown randomly if the seconds changed between `testLoadUserByTokenThrowsNotFoundException` and `testUpdateUserToken`

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
