### PR TITLE
IBX-6484: Added check if $row is empty to prevent error

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -911,6 +911,11 @@ class Handler implements BaseContentHandler
     public function loadVersionInfoList(array $contentIds): array
     {
         $rows = $this->contentGateway->loadVersionInfoList($contentIds);
+
+        if (empty($rows)) {
+            return [];
+        }
+
         $mappedRows = array_map(
             static function (array $row): array {
                 return [

--- a/tests/integration/Core/Repository/ContentService/LoadVersionInfoTest.php
+++ b/tests/integration/Core/Repository/ContentService/LoadVersionInfoTest.php
@@ -42,4 +42,18 @@ final class LoadVersionInfoTest extends RepositoryTestCase
             self::assertEquals($loadedVersionInfo, $versionInfo);
         }
     }
+
+    public function testLoadVersionInfoListByContentInfoForTopLevelNode(): void
+    {
+        $contentService = self::getContentService();
+        $locationService = self::getLocationService();
+
+        $location = $locationService->loadLocation(1);
+
+        $versionInfoList = $contentService->loadVersionInfoListByContentInfo(
+            [$location->getContentInfo()]
+        );
+
+        self::assertCount(0, $versionInfoList);
+    }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6484](https://issues.ibexa.co/browse/IBX-6484)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

we already have the same mechanism in many places, it protects against errors with the lack or inconsistency of the content version, such as for location 1


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
