### PR TITLE
IBX-3957: Made NOP URL aliases not reusable and original

### DIFF
--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
@@ -1603,7 +1603,6 @@ class URLAliasServiceTest extends BaseTest
     public function testRenamingParentContentDoesntBreakChildAlias(): void
     {
         $repository = $this->getRepository();
-        $locationService = $repository->getLocationService();
         $urlAliasService = $repository->getURLAliasService();
         $contentService = $repository->getContentService();
 

--- a/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/URLAliasServiceTest.php
@@ -1615,8 +1615,8 @@ class URLAliasServiceTest extends BaseTest
 
         // 2. Create child folder
         $child = $this->createFolder([$languageCode => 'b'], $folderLocationId);
-        $childLocationId = $child->contentInfo->getMainLocationId();
-        $childLocation = $locationService->loadLocation($childLocationId);
+        $childLocation = $child->getVersionInfo()->getContentInfo()->getMainLocation();
+        $childLocationId = $childLocation->id;
 
         // 3. Create custom URL alias for child folder
         $urlAliasService->createUrlAlias($childLocation, '/c/b', $languageCode);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Gateway/DoctrineDatabase.php
@@ -603,7 +603,7 @@ final class DoctrineDatabase extends Gateway
             $values['is_original'] = 1;
         }
         if ($values['action'] === self::NOP_ACTION) {
-            $values['is_original'] = 0;
+            $values['is_original'] = 1;
         }
 
         $query = $this->connection->createQueryBuilder();

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -234,7 +234,6 @@ class Handler implements UrlAliasHandlerInterface
             // 2. existing location or custom alias entry
             // 3. history entry
             if (
-                $row['action'] === Gateway::NOP_ACTION ||
                 $row['action'] === $action ||
                 (int)$row['is_original'] === 0
             ) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/UrlAlias/Handler.php
@@ -230,9 +230,8 @@ class Handler implements UrlAliasHandlerInterface
             }
 
             // Row exists, check if it is reusable. There are 3 cases when this is possible:
-            // 1. NOP entry
-            // 2. existing location or custom alias entry
-            // 3. history entry
+            // 1. existing location or custom alias entry
+            // 2. history entry
             if (
                 $row['action'] === $action ||
                 (int)$row['is_original'] === 0


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-3957](https://issues.ibexa.co/browse/IBX-3957)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | ?

Reasoning: because `nop` aliases are **not** original and they are reusable creating another alias with the same name will break such an alias, however, imo it should be incremented instead. This will prevent creating exactly the same alias with the same parent and as a result, breaking the old one.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
