### PR TITLE
IBX-5827: Replaced deprecated string interpolation (PHP 8.2+)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "symfony/mime": "^5.3.0",
         "symfony/translation": "^5.3.0",
         "symfony/yaml": "^5.3.0",
+        "symfony/runtime": "^5.3.0",
         "symfony/security-core": "^5.3.0",
         "symfony/security-http": "^5.3.0",
         "symfony/security-bundle": "^5.3.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "symfony/mime": "^5.3.0",
         "symfony/translation": "^5.3.0",
         "symfony/yaml": "^5.3.0",
-        "symfony/runtime": "^5.3.0",
         "symfony/security-core": "^5.3.0",
         "symfony/security-http": "^5.3.0",
         "symfony/security-bundle": "^5.3.0",
@@ -70,7 +69,8 @@
         "matthiasnoback/symfony-dependency-injection-test": "^4.1",
         "symfony/phpunit-bridge": "^5.1",
         "symfony/proxy-manager-bridge": "^5.3",
-        "phpstan/phpstan": "^1.2"
+        "phpstan/phpstan": "^1.2",
+        "symfony/runtime": "^5.3.0"
     },
     "conflict": {
         "friendsofphp/php-cs-fixer": "3.5.0",

--- a/eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
+++ b/eZ/Bundle/EzPublishCoreBundle/Features/Context/UserContext.php
@@ -544,7 +544,7 @@ class UserContext implements Context
      */
     private function findNonExistingUserEmail($username = 'User')
     {
-        $email = "${username}@ez.no";
+        $email = "{$username}@ez.no";
         if ($this->checkUserExistenceByEmail($email)) {
             return $email;
         }

--- a/eZ/Publish/API/Repository/Tests/BaseTest.php
+++ b/eZ/Publish/API/Repository/Tests/BaseTest.php
@@ -171,7 +171,7 @@ abstract class BaseTest extends TestCase
         if (null === $this->setupFactory) {
             if (false === ($setupClass = getenv('setupFactory'))) {
                 $setupClass = LegacySetupFactory::class;
-                putenv("setupFactory=${setupClass}");
+                putenv("setupFactory={$setupClass}");
             }
 
             if (false === getenv('fixtureDir')) {

--- a/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/ContentTypeServiceTest.php
@@ -841,7 +841,7 @@ class ContentTypeServiceTest extends BaseContentTypeServiceTest
                     $this->assertEquals(
                         $typeCreate->$propertyName,
                         $contentType->$propertyName,
-                        "Did not assert that property '${propertyName}' is equal on struct and resulting value object"
+                        "Did not assert that property '{$propertyName}' is equal on struct and resulting value object"
                     );
                     break;
             }

--- a/eZ/Publish/Core/FieldType/GatewayBasedStorage.php
+++ b/eZ/Publish/Core/FieldType/GatewayBasedStorage.php
@@ -87,7 +87,7 @@ abstract class GatewayBasedStorage implements FieldStorage
         );
 
         if (!isset($this->gateways[$context['identifier']])) {
-            throw new \OutOfBoundsException("No gateway for ${context['identifier']} available.");
+            throw new \OutOfBoundsException("No gateway for {$context['identifier']} available.");
         }
 
         $gateway = $this->gateways[$context['identifier']];

--- a/eZ/Publish/Core/Persistence/Cache/AbstractHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractHandler.php
@@ -66,11 +66,11 @@ abstract class AbstractHandler
     /**
      * Helper for getting multiple cache items in one call and do the id extraction for you.
      *
-     * Cache items must be stored with a key in the following format "${keyPrefix}${id}", like "ez-content-info-${id}",
+     * Cache items must be stored with a key in the following format "{$keyPrefix}{$id}", like "ez-content-info-{$id}",
      * in order for this method to be able to prefix key on id's and also extract key prefix afterwards.
      *
      * It also optionally supports a key suffixs, for use on a variable argument that affects all lookups,
-     * like translations, i.e. "ez-content-${id}-${translationKey}" where $keySuffixes = [$id => "-${translationKey}"].
+     * like translations, i.e. "ez-content-{$id}-{$translationKey}" where $keySuffixes = [$id => "-{$translationKey}"].
      *
      * @param array $ids
      * @param string $keyPrefix E.g "ez-content-"

--- a/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/AbstractInMemoryHandler.php
@@ -183,7 +183,7 @@ abstract class AbstractInMemoryHandler
      * Load items from in-memory cache, symfony cache pool or backend in that order.
      * If not cached the returned objects will be placed in cache.
      *
-     * Cache items must be stored with a key in the following format "${keyPrefix}${id}", like "ez-content-info-${id}",
+     * Cache items must be stored with a key in the following format "{$keyPrefix}{$id}", like "ez-content-info-{$id}",
      * in order for this method to be able to prefix key on id's and also extract key prefix afterwards.
      *
      * @param array $ids

--- a/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/ContentHandler.php
@@ -128,7 +128,7 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
      */
     public function load($contentId, $versionNo = null, array $translations = null)
     {
-        $keySuffix = $versionNo ? "-${versionNo}-" : '-';
+        $keySuffix = $versionNo ? "-{$versionNo}-" : '-';
         $keySuffix .= empty($translations) ? self::ALL_TRANSLATIONS_KEY : implode('|', $translations);
 
         return $this->getCacheValue(
@@ -235,7 +235,7 @@ class ContentHandler extends AbstractInMemoryPersistenceHandler implements Conte
      */
     public function loadVersionInfo($contentId, $versionNo = null)
     {
-        $keySuffix = $versionNo ? "-${versionNo}" : '';
+        $keySuffix = $versionNo ? "-{$versionNo}" : '';
         $cacheItem = $this->cache->getItem(
             $this->cacheIdentifierGenerator->generateKey(
                 self::CONTENT_VERSION_INFO_IDENTIFIER,

--- a/src/contracts/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandler.php
+++ b/src/contracts/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandler.php
@@ -4,16 +4,18 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
-namespace Ibexa\Core\MVC\Symfony\ErrorHandler;
+declare(strict_types=1);
+
+namespace Ibexa\Contracts\Core\MVC\Symfony\ErrorHandler;
 
 use const PHP_VERSION_ID;
 use Symfony\Component\Runtime\Internal\BasicErrorHandler;
 
-final class Php82HideDeprecationsErrorHandler extends BasicErrorHandler
+final class Php82HideDeprecationsErrorHandler
 {
     public static function register(bool $debug): void
     {
-        parent::register($debug);
+        BasicErrorHandler::register($debug);
 
         if (PHP_VERSION_ID > 80200) {
             error_reporting(E_ALL & ~E_DEPRECATED);

--- a/src/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandler.php
+++ b/src/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandler.php
@@ -1,0 +1,22 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Core\MVC\Symfony\ErrorHandler;
+
+use Symfony\Component\Runtime\Internal\BasicErrorHandler;
+use const PHP_VERSION_ID;
+
+final class Php82HideDeprecationsErrorHandler extends BasicErrorHandler
+{
+    public static function register(bool $debug): void
+    {
+        parent::register($debug);
+
+        if (PHP_VERSION_ID > 80200) {
+            error_reporting(E_ALL & ~E_DEPRECATED);
+        }
+    }
+}

--- a/src/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandler.php
+++ b/src/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandler.php
@@ -6,8 +6,8 @@
  */
 namespace Ibexa\Core\MVC\Symfony\ErrorHandler;
 
-use Symfony\Component\Runtime\Internal\BasicErrorHandler;
 use const PHP_VERSION_ID;
+use Symfony\Component\Runtime\Internal\BasicErrorHandler;
 
 final class Php82HideDeprecationsErrorHandler extends BasicErrorHandler
 {

--- a/tests/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandlerTest.php
+++ b/tests/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandlerTest.php
@@ -14,40 +14,38 @@ final class Php82HideDeprecationsErrorHandlerTest extends TestCase
 {
     private int $originalErrorReporting;
 
-    /** @var callable|null */
-    private $originalErrorHandler;
-
     protected function setUp(): void
     {
         $this->originalErrorReporting = error_reporting();
-        set_error_handler(
-            $this->originalErrorHandler = set_error_handler(
-                static function () {}
-            )
-        );
     }
 
     protected function tearDown(): void
     {
         error_reporting($this->originalErrorReporting);
-        set_error_handler($this->originalErrorHandler);
+        restore_error_handler();
     }
 
-    public function testRegister(): void
+    public function testRegisterDebug(): void
     {
         if (PHP_VERSION_ID < 80200) {
             $this->markTestSkipped('Does not affect versions below PHP 8.2.0');
         }
 
-        $errorHandler = new Php82HideDeprecationsErrorHandler();
+        Php82HideDeprecationsErrorHandler::register(true);
+        $errorReporting = error_reporting();
 
-        $errorHandler::register(true);
-        $debugErrorReporting = error_reporting();
+        $this->assertSame(E_ALL & ~E_DEPRECATED, $errorReporting);
+    }
 
-        $errorHandler::register(false);
-        $noDebugErrorReporting = error_reporting();
+    public function testRegisterNoDebug(): void
+    {
+        if (PHP_VERSION_ID < 80200) {
+            $this->markTestSkipped('Does not affect versions below PHP 8.2.0');
+        }
 
-        $this->assertSame(E_ALL & ~E_DEPRECATED, $debugErrorReporting);
-        $this->assertSame(E_ALL & ~E_DEPRECATED, $noDebugErrorReporting);
+        Php82HideDeprecationsErrorHandler::register(false);
+        $errorReporting = error_reporting();
+
+        $this->assertSame(E_ALL & ~E_DEPRECATED, $errorReporting);
     }
 }

--- a/tests/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandlerTest.php
+++ b/tests/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandlerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+namespace Ibexa\Tests\Core\MVC\Symfony\ErrorHandler;
+
+use Ibexa\Core\MVC\Symfony\ErrorHandler\Php82HideDeprecationsErrorHandler;
+use PHPUnit\Framework\TestCase;
+use const PHP_VERSION_ID;
+
+final class Php82HideDeprecationsErrorHandlerTest extends TestCase
+{
+    private int $originalErrorReporting;
+
+    /** @var callable|null */
+    private $originalErrorHandler;
+
+    protected function setUp(): void
+    {
+        $this->originalErrorReporting = error_reporting();
+        set_error_handler(
+            $this->originalErrorHandler = set_error_handler(
+                static function () {}
+            )
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        error_reporting($this->originalErrorReporting);
+        set_error_handler($this->originalErrorHandler);
+    }
+
+    public function testRegister(): void
+    {
+        if (PHP_VERSION_ID < 80200) {
+            $this->markTestSkipped('Does not affect versions below PHP 8.2.0');
+        }
+
+        $errorHandler = new Php82HideDeprecationsErrorHandler();
+
+        $errorHandler::register(true);
+        $debugErrorReporting = error_reporting();
+
+        $errorHandler::register(false);
+        $noDebugErrorReporting = error_reporting();
+
+        $this->assertSame(E_ALL & ~E_DEPRECATED, $debugErrorReporting);
+        $this->assertSame(E_ALL & ~E_DEPRECATED, $noDebugErrorReporting);
+    }
+}

--- a/tests/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandlerTest.php
+++ b/tests/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandlerTest.php
@@ -4,12 +4,16 @@
  * @copyright Copyright (C) Ibexa AS. All rights reserved.
  * @license For full copyright and license information view LICENSE file distributed with this source code.
  */
+declare(strict_types=1);
+
 namespace Ibexa\Tests\Core\MVC\Symfony\ErrorHandler;
 
-use Ibexa\Core\MVC\Symfony\ErrorHandler\Php82HideDeprecationsErrorHandler;
-use const PHP_VERSION_ID;
+use Ibexa\Contracts\Core\MVC\Symfony\ErrorHandler\Php82HideDeprecationsErrorHandler;
 use PHPUnit\Framework\TestCase;
 
+/**
+ * @requires PHP >= 8.2.0
+ */
 final class Php82HideDeprecationsErrorHandlerTest extends TestCase
 {
     /** @var int */
@@ -28,10 +32,6 @@ final class Php82HideDeprecationsErrorHandlerTest extends TestCase
 
     public function testRegisterDebug(): void
     {
-        if (PHP_VERSION_ID < 80200) {
-            $this->markTestSkipped('Does not affect versions below PHP 8.2.0');
-        }
-
         Php82HideDeprecationsErrorHandler::register(true);
         $errorReporting = error_reporting();
 
@@ -40,10 +40,6 @@ final class Php82HideDeprecationsErrorHandlerTest extends TestCase
 
     public function testRegisterNoDebug(): void
     {
-        if (PHP_VERSION_ID < 80200) {
-            $this->markTestSkipped('Does not affect versions below PHP 8.2.0');
-        }
-
         Php82HideDeprecationsErrorHandler::register(false);
         $errorReporting = error_reporting();
 

--- a/tests/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandlerTest.php
+++ b/tests/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandlerTest.php
@@ -7,8 +7,8 @@
 namespace Ibexa\Tests\Core\MVC\Symfony\ErrorHandler;
 
 use Ibexa\Core\MVC\Symfony\ErrorHandler\Php82HideDeprecationsErrorHandler;
-use PHPUnit\Framework\TestCase;
 use const PHP_VERSION_ID;
+use PHPUnit\Framework\TestCase;
 
 final class Php82HideDeprecationsErrorHandlerTest extends TestCase
 {

--- a/tests/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandlerTest.php
+++ b/tests/lib/MVC/Symfony/ErrorHandler/Php82HideDeprecationsErrorHandlerTest.php
@@ -12,7 +12,8 @@ use const PHP_VERSION_ID;
 
 final class Php82HideDeprecationsErrorHandlerTest extends TestCase
 {
-    private int $originalErrorReporting;
+    /** @var int */
+    private $originalErrorReporting;
 
     protected function setUp(): void
     {


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-5827

Usage:

Add this to your main `composer.json` after you install the project (`ibexa/core` must exists):
```
    "runtime": {
      "error_handler": "\\Ibexa\\Contracts\\Core\\MVC\\Symfony\\ErrorHandler\\Php82HideDeprecationsErrorHandler"
    }
```
Requires `composer dump-autoload` after that.