### PR TITLE
[Composer] Added RepositoryTestCase to explicit classmap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,8 @@
             "Ibexa\\Bundle\\LegacySearchEngine\\": "src/bundle/LegacySearchEngine",
             "Ibexa\\Contracts\\Core\\": "src/contracts",
             "Ibexa\\Core\\": "src/lib"
-        }
+        },
+        "classmap": ["tests/integration/Core/RepositoryTestCase.php"]
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | n/a
| **Required by** | ezsystems/ezplatform-solr-search-engine#246
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`+
| **BC breaks**                          | no

When adding `RepositoryTestCase` to forward-compatible Ibexa namespace I forgot that those namespaces need to be available for external packages, like Ibexa Solr Bundle, because CI there executes these tests directly. Placing it in the new structure `./tests` directory made it available to kernel only as it belongs to `autoload-dev` section.

As a quick workaround I added this class to composer `autoload.classmap`. For Ibexa 4.x we already have ibexa/test-core package which seems to be more appropriate place. I recommend that we spend some time to refactor Solr Bundle tests so they don't rely on test classes from core. We need more common search test shared base.

### TODO

- [x] Solr fix PR (ezsystems/ezplatform-solr-search-engine#247).

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly.
- [ ] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review.
