### PR TITLE
IBX-6833: Copying empty fields during translation copying shouldn't be skipped

### DIFF
--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1294,7 +1294,8 @@ class ContentService implements ContentServiceInterface
     protected function internalUpdateContent(
         APIVersionInfo $versionInfo,
         APIContentUpdateStruct $contentUpdateStruct,
-        ?array $fieldIdentifiersToValidate = null
+        ?array $fieldIdentifiersToValidate = null,
+        bool $doAddEmpty = false
     ): Content {
         $contentUpdateStruct = clone $contentUpdateStruct;
 
@@ -1385,7 +1386,7 @@ class ContentService implements ContentServiceInterface
                 );
                 $fieldValues[$fieldDefinition->identifier][$languageCode] = $fieldValue;
 
-                if ($isRetained || $isCopied || ($isLanguageNew && $isEmpty) || $isProcessed) {
+                if ($isRetained || $isCopied || ($isLanguageNew && $isEmpty && !$doAddEmpty) || $isProcessed) {
                     continue;
                 }
 
@@ -1692,7 +1693,7 @@ class ContentService implements ContentServiceInterface
             $updateStruct->setField($fallbackField->fieldDefIdentifier, $fallbackField->value, $fallbackField->languageCode);
         }
 
-        $this->internalUpdateContent($versionInfo, $updateStruct);
+        $this->internalUpdateContent($versionInfo, $updateStruct, null, true);
     }
 
     protected function fieldValuesAreEqual(FieldType $fieldType, Value $value1, Value $value2): bool

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1295,7 +1295,7 @@ class ContentService implements ContentServiceInterface
         APIVersionInfo $versionInfo,
         APIContentUpdateStruct $contentUpdateStruct,
         ?array $fieldIdentifiersToValidate = null,
-        bool $doAddEmpty = false
+        bool $copyEmptyField = false
     ): Content {
         $contentUpdateStruct = clone $contentUpdateStruct;
 
@@ -1386,7 +1386,7 @@ class ContentService implements ContentServiceInterface
                 );
                 $fieldValues[$fieldDefinition->identifier][$languageCode] = $fieldValue;
 
-                if ($isRetained || $isCopied || ($isLanguageNew && $isEmpty && !$doAddEmpty) || $isProcessed) {
+                if ($isRetained || $isCopied || ($isLanguageNew && $isEmpty && !$copyEmptyField) || $isProcessed) {
                     continue;
                 }
 

--- a/tests/integration/Core/Repository/ContentService/CopyTranslationsFromPublishedVersionTest.php
+++ b/tests/integration/Core/Repository/ContentService/CopyTranslationsFromPublishedVersionTest.php
@@ -1,0 +1,115 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\Repository\ContentService;
+
+use DateTime;
+use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
+use eZ\Publish\Core\Repository\Values\Content\ContentUpdateStruct;
+use Ibexa\Tests\Integration\Core\RepositoryTestCase;
+
+/**
+ * @covers \eZ\Publish\API\Repository\ContentService
+ */
+final class CopyTranslationsFromPublishedVersionTest extends RepositoryTestCase
+{
+    private const ENG_LANGUAGE_CODE = 'eng-GB';
+    private const GER_LANGUAGE_CODE = 'ger-DE';
+    private const US_LANGUAGE_CODE = 'eng-US';
+    private const CONTENT_TYPE_IDENTIFIER = 'custom';
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\Exception
+     */
+    public function testCopyTranslationsFromPublishedVersionCopiesEmptyValues(): void
+    {
+        $this->createContentType();
+
+        $contentService = self::getContentService();
+        $contentTypeService = self::getContentTypeService();
+        $locationService = self::getLocationService();
+
+        // Creating and publishing content in eng-GB language
+        $contentType = $contentTypeService->loadContentTypeByIdentifier(self::CONTENT_TYPE_IDENTIFIER);
+        $mainLanguageCode = self::ENG_LANGUAGE_CODE;
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, $mainLanguageCode);
+        $contentCreateStruct->setField('title', 'Test title');
+
+        $contentDraft = $contentService->createContent(
+            $contentCreateStruct,
+            [
+                $locationService->newLocationCreateStruct(2),
+            ],
+        );
+        $publishedContent = $contentService->publishVersion($contentDraft->getVersionInfo());
+
+        // Creating a draft and publishing in ger-DE language with empty 'title' field
+        $gerDraft = $contentService->createContentDraft($publishedContent->contentInfo);
+        $usDraft = $contentService->createContentDraft($publishedContent->contentInfo);
+
+        $contentUpdateStruct = new ContentUpdateStruct([
+            'initialLanguageCode' => self::GER_LANGUAGE_CODE,
+        ]);
+        $contentUpdateStruct->setField('title', null);
+        $gerContent = $contentService->updateContent($gerDraft->getVersionInfo(), $contentUpdateStruct);
+        $contentService->publishVersion($gerContent->getVersionInfo(), [self::GER_LANGUAGE_CODE]);
+
+        // Creating a draft and publishing in eng-US language with empty 'title' field
+        $contentUpdateStruct = new ContentUpdateStruct([
+            'initialLanguageCode' => self::US_LANGUAGE_CODE,
+        ]);
+        $contentUpdateStruct->setField('title', null);
+        $usContent = $contentService->updateContent($usDraft->getVersionInfo(), $contentUpdateStruct);
+        $publishedUsContent = $contentService->publishVersion($usContent->getVersionInfo(), [self::US_LANGUAGE_CODE]);
+
+        $gerFieldValueInUsContent = $publishedUsContent->getField('title', self::GER_LANGUAGE_CODE)
+            ->getValue()
+            ->text;
+
+        self::assertSame('', $gerFieldValueInUsContent);
+    }
+
+    private function createContentType(): void
+    {
+        $permissionResolver = self::getPermissionResolver();
+        $contentTypeService = self::getContentTypeService();
+
+        $typeCreate = $contentTypeService->newContentTypeCreateStruct(self::CONTENT_TYPE_IDENTIFIER);
+
+        $typeCreate->mainLanguageCode = 'eng-GB';
+        $typeCreate->remoteId = '1234567890abcdef';
+        $typeCreate->urlAliasSchema = '<title>';
+        $typeCreate->nameSchema = '<title>';
+        $typeCreate->names = [
+            self::ENG_LANGUAGE_CODE => 'Some content type',
+        ];
+        $typeCreate->descriptions = [
+            self::ENG_LANGUAGE_CODE => '',
+        ];
+        $typeCreate->creatorId = $permissionResolver->getCurrentUserReference()->getUserId();
+        $typeCreate->creationDate = new DateTime();
+
+        $typeCreate->addFieldDefinition(
+            new FieldDefinitionCreateStruct(
+                [
+                    'fieldTypeIdentifier' => 'ezstring',
+                    'identifier' => 'title',
+                    'names' => ['eng-GB' => 'Title'],
+                    'isRequired' => false,
+                    'isTranslatable' => true,
+                ],
+            )
+        );
+
+        $contentTypeDraft = $contentTypeService->createContentType(
+            $typeCreate,
+            [$contentTypeService->loadContentTypeGroupByIdentifier('Content')],
+        );
+        $contentTypeService->publishContentTypeDraft($contentTypeDraft);
+    }
+}

--- a/tests/integration/Core/Repository/ContentService/CopyTranslationsFromPublishedVersionTest.php
+++ b/tests/integration/Core/Repository/ContentService/CopyTranslationsFromPublishedVersionTest.php
@@ -10,6 +10,7 @@ namespace Ibexa\Tests\Integration\Core\Repository\ContentService;
 
 use DateTime;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
+use eZ\Publish\Core\FieldType\TextLine;
 use eZ\Publish\Core\Repository\Values\Content\ContentUpdateStruct;
 use Ibexa\Tests\Integration\Core\RepositoryTestCase;
 
@@ -67,11 +68,13 @@ final class CopyTranslationsFromPublishedVersionTest extends RepositoryTestCase
         $usContent = $contentService->updateContent($usDraft->getVersionInfo(), $contentUpdateStruct);
         $publishedUsContent = $contentService->publishVersion($usContent->getVersionInfo(), [self::US_LANGUAGE_CODE]);
 
-        $gerFieldValueInUsContent = $publishedUsContent->getField('title', self::GER_LANGUAGE_CODE)
-            ->getValue()
-            ->text;
+        $usFieldValueInUsContent = $publishedUsContent->getField('title', self::US_LANGUAGE_CODE)->getValue();
+        self::assertInstanceOf(TextLine\Value::class, $usFieldValueInUsContent);
+        self::assertSame('', $usFieldValueInUsContent->text);
 
-        self::assertSame('', $gerFieldValueInUsContent);
+        $gerFieldValueInUsContent = $publishedUsContent->getField('title', self::GER_LANGUAGE_CODE)->getValue();
+        self::assertInstanceOf(TextLine\Value::class, $gerFieldValueInUsContent);
+        self::assertSame('', $gerFieldValueInUsContent->text);
     }
 
     private function createContentType(): void


### PR DESCRIPTION
| :ticket: Issue |  [IBX-6833](https://issues.ibexa.co/browse/IBX-6833) |
|----------------|-----------|

#### Description:

When one is copying translations using the `copyTranslationsFromPublishedVersion` method during publishing empty values are left out and not stored in the database which could result in entries not appearing in `ezcontentobject_attribute` table resulting in missing translations and broken language masks.

#### For QA:

_Maintainer note:_

Requires extensive multilingual content updating testing, ideally in multiple tabs or even by at least 2 separate editors at the same time (though for that unrelated bugs might occur). Possible regressions: [EZEE-2661](https://issues.ibexa.co/browse/EZEE-2661) but doesn't really require scheduler interaction, rather checking if translations were copied properly.