### PR TITLE
IBX-6592: Content Object State assignment should rely on `Location` instead of `ContentInfo`

### DIFF
--- a/eZ/Publish/API/Repository/ObjectStateService.php
+++ b/eZ/Publish/API/Repository/ObjectStateService.php
@@ -7,6 +7,7 @@
 namespace eZ\Publish\API\Repository;
 
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateCreateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
@@ -172,12 +173,13 @@ interface ObjectStateService
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the object state does not belong to the given group
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to change the object state
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
-     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectState $objectState
      */
-    public function setContentState(ContentInfo $contentInfo, ObjectStateGroup $objectStateGroup, ObjectState $objectState): void;
+    public function setContentState(
+        ContentInfo $contentInfo,
+        ObjectStateGroup $objectStateGroup,
+        ObjectState $objectState,
+        ?Location $location = null
+    ): void;
 
     /**
      * Gets the object-state of object identified by $contentId.

--- a/eZ/Publish/Core/Event/ObjectStateService.php
+++ b/eZ/Publish/Core/Event/ObjectStateService.php
@@ -26,6 +26,7 @@ use eZ\Publish\API\Repository\Events\ObjectState\UpdateObjectStateEvent;
 use eZ\Publish\API\Repository\Events\ObjectState\UpdateObjectStateGroupEvent;
 use eZ\Publish\API\Repository\ObjectStateService as ObjectStateServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateCreateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
@@ -214,7 +215,8 @@ class ObjectStateService extends ObjectStateServiceDecorator
     public function setContentState(
         ContentInfo $contentInfo,
         ObjectStateGroup $objectStateGroup,
-        ObjectState $objectState
+        ObjectState $objectState,
+        ?Location $location = null
     ): void {
         $eventData = [
             $contentInfo,
@@ -229,7 +231,7 @@ class ObjectStateService extends ObjectStateServiceDecorator
             return;
         }
 
-        $this->innerService->setContentState($contentInfo, $objectStateGroup, $objectState);
+        $this->innerService->setContentState($contentInfo, $objectStateGroup, $objectState, $location);
 
         $this->eventDispatcher->dispatch(
             new SetContentStateEvent(...$eventData)

--- a/eZ/Publish/Core/Limitation/NewObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/NewObjectStateLimitationType.php
@@ -127,11 +127,11 @@ class NewObjectStateLimitationType extends AbstractPersistenceLimitationType imp
             return false;
         }
 
-        foreach ($targets as $target) {
-            if (!$target instanceof ObjectState && !$target instanceof SPIObjectState) {
-                throw new InvalidArgumentException('$targets', 'Must contain ObjectState objects');
-            }
+        $targets = array_filter($targets, static function ($target) {
+            return $target instanceof ObjectState || $target instanceof SPIObjectState;
+        });
 
+        foreach ($targets as $target) {
             if (!in_array($target->id, $value->limitationValues)) {
                 return false;
             }

--- a/eZ/Publish/Core/Repository/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/ObjectStateService.php
@@ -12,6 +12,7 @@ use eZ\Publish\API\Repository\ObjectStateService as ObjectStateServiceInterface;
 use eZ\Publish\API\Repository\PermissionResolver;
 use eZ\Publish\API\Repository\Repository as RepositoryInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState as APIObjectState;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateCreateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup as APIObjectStateGroup;
@@ -463,14 +464,15 @@ class ObjectStateService implements ObjectStateServiceInterface
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\InvalidArgumentException if the object state does not belong to the given group
      * @throws \eZ\Publish\API\Repository\Exceptions\UnauthorizedException if the user is not allowed to change the object state
-     *
-     * @param \eZ\Publish\API\Repository\Values\Content\ContentInfo $contentInfo
-     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup $objectStateGroup
-     * @param \eZ\Publish\API\Repository\Values\ObjectState\ObjectState $objectState
      */
-    public function setContentState(ContentInfo $contentInfo, APIObjectStateGroup $objectStateGroup, APIObjectState $objectState): void
-    {
-        if (!$this->permissionResolver->canUser('state', 'assign', $contentInfo, [$objectState])) {
+    public function setContentState(
+        ContentInfo $contentInfo,
+        APIObjectStateGroup $objectStateGroup,
+        APIObjectState $objectState,
+        ?Location $location = null
+    ): void {
+        $targets = $location !== null ? [$location, $objectState] : [$objectState];
+        if (!$this->permissionResolver->canUser('state', 'assign', $contentInfo, $targets)) {
             throw new UnauthorizedException('state', 'assign', ['contentId' => $contentInfo->id]);
         }
 

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ObjectStateService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ObjectStateService.php
@@ -9,6 +9,7 @@ namespace eZ\Publish\Core\Repository\SiteAccessAware;
 use eZ\Publish\API\Repository\LanguageResolver;
 use eZ\Publish\API\Repository\ObjectStateService as ObjectStateServiceInterface;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateCreateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
@@ -127,9 +128,13 @@ class ObjectStateService implements ObjectStateServiceInterface
         $this->service->deleteObjectState($objectState);
     }
 
-    public function setContentState(ContentInfo $contentInfo, ObjectStateGroup $objectStateGroup, ObjectState $objectState): void
-    {
-        $this->service->setContentState($contentInfo, $objectStateGroup, $objectState);
+    public function setContentState(
+        ContentInfo $contentInfo,
+        ObjectStateGroup $objectStateGroup,
+        ObjectState $objectState,
+        ?Location $location = null
+    ): void {
+        $this->service->setContentState($contentInfo, $objectStateGroup, $objectState, $location);
     }
 
     public function getContentState(ContentInfo $contentInfo, ObjectStateGroup $objectStateGroup): ObjectState

--- a/eZ/Publish/SPI/Repository/Decorator/ObjectStateServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/ObjectStateServiceDecorator.php
@@ -10,6 +10,7 @@ namespace eZ\Publish\SPI\Repository\Decorator;
 
 use eZ\Publish\API\Repository\ObjectStateService;
 use eZ\Publish\API\Repository\Values\Content\ContentInfo;
+use eZ\Publish\API\Repository\Values\Content\Location;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectState;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateCreateStruct;
 use eZ\Publish\API\Repository\Values\ObjectState\ObjectStateGroup;
@@ -121,9 +122,10 @@ abstract class ObjectStateServiceDecorator implements ObjectStateService
     public function setContentState(
         ContentInfo $contentInfo,
         ObjectStateGroup $objectStateGroup,
-        ObjectState $objectState
+        ObjectState $objectState,
+        ?Location $location = null
     ): void {
-        $this->innerService->setContentState($contentInfo, $objectStateGroup, $objectState);
+        $this->innerService->setContentState($contentInfo, $objectStateGroup, $objectState, $location);
     }
 
     public function getContentState(

--- a/tests/integration/Core/Repository/ObjectStateService/SetContentStateTest.php
+++ b/tests/integration/Core/Repository/ObjectStateService/SetContentStateTest.php
@@ -1,0 +1,91 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Integration\Core\Repository\ObjectStateService;
+
+use eZ\Publish\API\Repository\Exceptions\UnauthorizedException;
+use eZ\Publish\API\Repository\Values\User\Limitation\ObjectStateLimitation;
+use eZ\Publish\API\Repository\Values\User\Limitation\SubtreeLimitation;
+use Ibexa\Tests\Integration\Core\RepositoryTestCase;
+
+/**
+ * @covers \eZ\Publish\API\Repository\ObjectStateService
+ */
+final class SetContentStateTest extends RepositoryTestCase
+{
+    /**
+     * @dataProvider dataProviderForTestSetContentObjectStateWithSubtreeLimitation
+     */
+    public function testSetContentObjectStateWithSubtreeLimitation(
+        ?string $subtreeLimitationValue,
+        bool $isInsideLimitation
+    ): void {
+        $permissionResolver = self::getPermissionResolver();
+        $objectStateService = self::getObjectStateService();
+
+        $objectState = $objectStateService->loadObjectState(2);
+
+        $subtreeLimitationFolder = $this->createFolder(['eng-GB' => 'Subtree limitation type'], 2);
+        $contentInfo = $subtreeLimitationFolder->getVersionInfo()->getContentInfo();
+        $mainLocation = $contentInfo->getMainLocation();
+
+        $limitations = [
+            new SubtreeLimitation(
+                [
+                    'limitationValues' => [$subtreeLimitationValue ?? $mainLocation->getPathString()],
+                ],
+            ),
+            new ObjectStateLimitation(
+                [
+                    'limitationValues' => [1, 2],
+                ],
+            ),
+        ];
+
+        $user = $this->createUserWithPolicies(
+            'object_state_user',
+            [
+                ['module' => 'content', 'function' => '*'],
+                ['module' => 'state', 'function' => 'assign', 'limitations' => $limitations],
+            ]
+        );
+
+        $permissionResolver->setCurrentUserReference($user);
+
+        $childFolder = $this->createFolder(['eng-GB' => 'Child folder'], $mainLocation->id);
+        $childContentInfo = $childFolder->getVersionInfo()->getContentInfo();
+
+        if (!$isInsideLimitation) {
+            self::expectException(UnauthorizedException::class);
+        }
+
+        $objectStateService->setContentState(
+            $childContentInfo,
+            $objectState->getObjectStateGroup(),
+            $objectState,
+            $childContentInfo->getMainLocation(),
+        );
+
+        $contentState = $objectStateService->getContentState($childContentInfo, $objectState->getObjectStateGroup());
+
+        self::assertSame($objectState->identifier, $contentState->identifier);
+    }
+
+    public function dataProviderForTestSetContentObjectStateWithSubtreeLimitation(): iterable
+    {
+        yield 'inside subtree limitation' => [
+            null,
+            true,
+        ];
+
+        yield 'outside limitation passes' => [
+            '/1/43',
+            false,
+        ];
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6592](https://issues.ibexa.co/browse/IBX-6592)
| **Type**                                   |bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Currently, Content Object State assignment is validated, as permissions go, utilizing `ContentInfo` which in my opinion is wrong, as that leaves Subtree Limitation pretty much useless, and yet, this limitation is available for a choosing when we are dealing with the `state/assign` policy. 

To keep BC I've provided a new argument that is `?Location = null`. This `Location` would be later checked against Subtree Limitation when assigning an Object State to a certain Content.

Related PR: https://github.com/ezsystems/ezplatform-admin-ui/pull/2112

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
