### PR TITLE
IBX-6880: Skipped normalizing directories in the `normalizePath` method

### DIFF
--- a/eZ/Publish/Core/IO/FilePathNormalizer/Flysystem.php
+++ b/eZ/Publish/Core/IO/FilePathNormalizer/Flysystem.php
@@ -35,8 +35,9 @@ final class Flysystem implements FilePathNormalizerInterface
             ? (preg_match(self::HASH_PATTERN, $fileName) ? '' : bin2hex(random_bytes(6)) . '-')
             : '';
 
-        $filePath = $directory . \DIRECTORY_SEPARATOR . $hash . $fileName;
+        $filePath = $directory . \DIRECTORY_SEPARATOR . $hash;
+        $normalizedFileName = Util::normalizePath($fileName);
 
-        return Util::normalizePath($filePath);
+        return $filePath . $normalizedFileName;
     }
 }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6880](https://issues.ibexa.co/browse/IBX-6880)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

We cannot normalize `var_dir` as it won't update .yaml config, so perhaps, we should normalize images' filenames only.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
