### PR TITLE
IBX-6494: Fixed copying of non-translatable fields to later versions

### DIFF
--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1517,10 +1517,7 @@ class ContentService implements ContentServiceInterface
         $publishedContent = $this->internalLoadContentById($versionInfo->getContentInfo()->getId());
         $publishedVersionInfo = $publishedContent->getVersionInfo();
 
-        if (
-            !$publishedVersionInfo->isPublished()
-            || ($versionInfo->versionNo >= $publishedVersionInfo->versionNo)
-        ) {
+        if (!$publishedVersionInfo->isPublished()) {
             return;
         }
 

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -1521,9 +1521,8 @@ class ContentService implements ContentServiceInterface
             return;
         }
 
-        $publishedContentFieldsInMainLanguage = $publishedContent->getFieldsByLanguage(
-            $publishedContent->getVersionInfo()->getContentInfo()->getMainLanguageCode()
-        );
+        $mainLanguageCode = $publishedContent->getVersionInfo()->getContentInfo()->getMainLanguageCode();
+        $publishedContentFieldsInMainLanguage = $publishedContent->getFieldsByLanguage($mainLanguageCode);
 
         $fieldValues = [];
         $persistenceFields = [];
@@ -1542,7 +1541,13 @@ class ContentService implements ContentServiceInterface
                 $fieldDefinition->fieldTypeIdentifier
             );
 
-            $newValue = $publishedContentFieldsInMainLanguage[$field->fieldDefIdentifier]->getValue();
+            $newValue = (
+                $versionInfo->versionNo >= $publishedVersionInfo->versionNo
+                && $versionInfo->initialLanguageCode === $mainLanguageCode
+            )
+                ? $field->getValue()
+                : $publishedContentFieldsInMainLanguage[$field->fieldDefIdentifier]->getValue();
+
             $fieldValues[$fieldDefinition->identifier][$field->languageCode] = $newValue;
 
             $persistenceFields[] = new SPIField(

--- a/tests/integration/Core/Repository/ContentService/CopyNonTranslatableFieldsFromPublishedVersionTest.php
+++ b/tests/integration/Core/Repository/ContentService/CopyNonTranslatableFieldsFromPublishedVersionTest.php
@@ -84,6 +84,62 @@ final class CopyNonTranslatableFieldsFromPublishedVersionTest extends Repository
         self::assertSame($expectedBodyValue, $bodyFieldValue->text);
     }
 
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\Exception
+     */
+    public function testCopyNonTranslatableFieldsFromPublishedVersionToLatestVersion(): void
+    {
+        $this->createNonTranslatableContentType();
+
+        $contentService = self::getContentService();
+        $contentTypeService = self::getContentTypeService();
+        $locationService = self::getLocationService();
+
+        // Creating start content in eng-US language
+        $contentType = $contentTypeService->loadContentTypeByIdentifier(self::CONTENT_TYPE_IDENTIFIER);
+        $mainLanguageCode = self::ENG_US;
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, $mainLanguageCode);
+        $contentCreateStruct->setField('title', 'Test title');
+        $contentCreateStruct->setField('body', 'Nontranslatable body');
+
+        $contentDraft = $contentService->createContent(
+            $contentCreateStruct,
+            [
+                $locationService->newLocationCreateStruct(2),
+            ]
+        );
+        $publishedContent = $contentService->publishVersion($contentDraft->getVersionInfo());
+
+        // Creating two drafts at the same time
+        $usDraft = $contentService->createContentDraft($publishedContent->contentInfo);
+        $gerDraft = $contentService->createContentDraft($publishedContent->contentInfo);
+
+        // Publishing the draft in eng-US language
+        $contentUpdateStruct = new ContentUpdateStruct([
+            'initialLanguageCode' => self::ENG_US,
+            'fields' => $usDraft->getFields(),
+        ]);
+        $contentUpdateStruct->setField('title', 'Title v2', self::ENG_US);
+        $contentUpdateStruct->setField('body', 'Nontranslatable body v2', self::ENG_US);
+        $usContent = $contentService->updateContent($usDraft->getVersionInfo(), $contentUpdateStruct);
+        $contentService->publishVersion($usContent->getVersionInfo());
+
+        // Publishing the draft in ger-DE language
+        $contentUpdateStruct = new ContentUpdateStruct([
+            'initialLanguageCode' => self::GER_DE,
+            'fields' => $gerDraft->getFields(),
+        ]);
+        $contentUpdateStruct->setField('title', 'Title ger', self::GER_DE);
+        $gerContent = $contentService->updateContent($gerDraft->getVersionInfo(), $contentUpdateStruct);
+        $contentService->publishVersion($gerContent->getVersionInfo());
+
+        // Loading main content
+        $mainPublishedContent = $contentService->loadContent($gerContent->id);
+        $bodyFieldValue = $mainPublishedContent->getField('body')->getValue();
+
+        self::assertSame('Nontranslatable body v2', $bodyFieldValue->text);
+    }
+
     private function createNonTranslatableContentType(): void
     {
         $permissionResolver = self::getPermissionResolver();

--- a/tests/integration/Core/Repository/ContentService/CopyNonTranslatableFieldsFromPublishedVersionTest.php
+++ b/tests/integration/Core/Repository/ContentService/CopyNonTranslatableFieldsFromPublishedVersionTest.php
@@ -87,7 +87,7 @@ final class CopyNonTranslatableFieldsFromPublishedVersionTest extends Repository
     /**
      * @throws \eZ\Publish\API\Repository\Exceptions\Exception
      */
-    public function testCopyNonTranslatableFieldsFromPublishedVersionToLatestVersion(): void
+    public function testCopyNonTranslatableFieldsTwoParallelDrafts(): void
     {
         $this->createNonTranslatableContentType();
 
@@ -138,6 +138,66 @@ final class CopyNonTranslatableFieldsFromPublishedVersionTest extends Repository
         $bodyFieldValue = $mainPublishedContent->getField('body')->getValue();
 
         self::assertSame('Nontranslatable body v2', $bodyFieldValue->text);
+    }
+
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\Exception
+     */
+    public function testCopyNonTranslatableFieldsOverridesNonMainLanguageDrafts(): void
+    {
+        $this->createNonTranslatableContentType();
+
+        $contentService = self::getContentService();
+        $contentTypeService = self::getContentTypeService();
+        $locationService = self::getLocationService();
+
+        // Creating start content in eng-US language
+        $contentType = $contentTypeService->loadContentTypeByIdentifier(self::CONTENT_TYPE_IDENTIFIER);
+        $mainLanguageCode = self::ENG_US;
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, $mainLanguageCode);
+        $contentCreateStruct->setField('title', 'Test title');
+        $contentCreateStruct->setField('body', 'Test body');
+
+        $contentDraft = $contentService->createContent(
+            $contentCreateStruct,
+            [
+                $locationService->newLocationCreateStruct(2),
+            ]
+        );
+        $publishedContent = $contentService->publishVersion($contentDraft->getVersionInfo());
+
+        // Creating a draft in ger-DE language with the only field updated being 'title'
+        $gerDraft = $contentService->createContentDraft($publishedContent->contentInfo);
+
+        $contentUpdateStruct = new ContentUpdateStruct([
+            'initialLanguageCode' => self::GER_DE,
+            'fields' => $contentDraft->getFields(),
+        ]);
+
+        $contentUpdateStruct->setField('title', 'Folder GER', self::GER_DE);
+        $gerContent = $contentService->updateContent($gerDraft->getVersionInfo(), $contentUpdateStruct);
+        $publishedContent = $contentService->publishVersion($gerContent->getVersionInfo());
+
+        // Updating non-translatable field in eng-US language (allowed) and publishing it
+        $engContent = $contentService->createContentDraft($publishedContent->contentInfo);
+
+        $contentUpdateStruct = new ContentUpdateStruct([
+            'initialLanguageCode' => self::ENG_US,
+            'fields' => $contentDraft->getFields(),
+        ]);
+
+        $expectedBodyValue = 'Non-translatable value';
+        $contentUpdateStruct->setField('title', 'Title v2', self::ENG_US);
+        $contentUpdateStruct->setField('body', $expectedBodyValue, self::ENG_US);
+
+        $engContent = $contentService->updateContent($engContent->getVersionInfo(), $contentUpdateStruct);
+        $contentService->publishVersion($engContent->getVersionInfo());
+
+        // Loading content in ger-DE language
+        $mainPublishedContent = $contentService->loadContent($engContent->id, ['ger-DE']);
+        $bodyFieldValue = $mainPublishedContent->getField('body')->getValue();
+
+        self::assertSame($expectedBodyValue, $bodyFieldValue->text);
     }
 
     private function createNonTranslatableContentType(): void

--- a/tests/integration/Core/Repository/ContentService/CopyNonTranslatableFieldsFromPublishedVersionTest.php
+++ b/tests/integration/Core/Repository/ContentService/CopyNonTranslatableFieldsFromPublishedVersionTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace Ibexa\Tests\Integration\Core\Repository\ContentService;
 
 use DateTime;
+use eZ\Publish\API\Repository\Values\Content\Content;
 use eZ\Publish\API\Repository\Values\ContentType\FieldDefinitionCreateStruct;
 use eZ\Publish\Core\Repository\Values\Content\ContentUpdateStruct;
 use Ibexa\Tests\Integration\Core\RepositoryTestCase;
@@ -31,21 +32,9 @@ final class CopyNonTranslatableFieldsFromPublishedVersionTest extends Repository
         $this->createNonTranslatableContentType();
 
         $contentService = self::getContentService();
-        $contentTypeService = self::getContentTypeService();
-        $locationService = self::getLocationService();
 
         // Creating start content in eng-US language
-        $contentType = $contentTypeService->loadContentTypeByIdentifier(self::CONTENT_TYPE_IDENTIFIER);
-        $mainLanguageCode = self::ENG_US;
-        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, $mainLanguageCode);
-        $contentCreateStruct->setField('title', 'Test title');
-
-        $contentDraft = $contentService->createContent(
-            $contentCreateStruct,
-            [
-                $locationService->newLocationCreateStruct(2),
-            ]
-        );
+        $contentDraft = $this->createEngDraft();
         $publishedContent = $contentService->publishVersion($contentDraft->getVersionInfo());
 
         // Creating a draft in ger-DE language with the only field updated being 'title'
@@ -92,22 +81,9 @@ final class CopyNonTranslatableFieldsFromPublishedVersionTest extends Repository
         $this->createNonTranslatableContentType();
 
         $contentService = self::getContentService();
-        $contentTypeService = self::getContentTypeService();
-        $locationService = self::getLocationService();
 
         // Creating start content in eng-US language
-        $contentType = $contentTypeService->loadContentTypeByIdentifier(self::CONTENT_TYPE_IDENTIFIER);
-        $mainLanguageCode = self::ENG_US;
-        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, $mainLanguageCode);
-        $contentCreateStruct->setField('title', 'Test title');
-        $contentCreateStruct->setField('body', 'Nontranslatable body');
-
-        $contentDraft = $contentService->createContent(
-            $contentCreateStruct,
-            [
-                $locationService->newLocationCreateStruct(2),
-            ]
-        );
+        $contentDraft = $this->createEngDraft();
         $publishedContent = $contentService->publishVersion($contentDraft->getVersionInfo());
 
         // Creating two drafts at the same time
@@ -148,22 +124,9 @@ final class CopyNonTranslatableFieldsFromPublishedVersionTest extends Repository
         $this->createNonTranslatableContentType();
 
         $contentService = self::getContentService();
-        $contentTypeService = self::getContentTypeService();
-        $locationService = self::getLocationService();
 
         // Creating start content in eng-US language
-        $contentType = $contentTypeService->loadContentTypeByIdentifier(self::CONTENT_TYPE_IDENTIFIER);
-        $mainLanguageCode = self::ENG_US;
-        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, $mainLanguageCode);
-        $contentCreateStruct->setField('title', 'Test title');
-        $contentCreateStruct->setField('body', 'Test body');
-
-        $contentDraft = $contentService->createContent(
-            $contentCreateStruct,
-            [
-                $locationService->newLocationCreateStruct(2),
-            ]
-        );
+        $contentDraft = $this->createEngDraft();
         $publishedContent = $contentService->publishVersion($contentDraft->getVersionInfo());
 
         // Creating a draft in ger-DE language with the only field updated being 'title'
@@ -198,6 +161,26 @@ final class CopyNonTranslatableFieldsFromPublishedVersionTest extends Repository
         $bodyFieldValue = $mainPublishedContent->getField('body')->getValue();
 
         self::assertSame($expectedBodyValue, $bodyFieldValue->text);
+    }
+
+    private function createEngDraft(): Content
+    {
+        $contentService = self::getContentService();
+        $contentTypeService = self::getContentTypeService();
+        $locationService = self::getLocationService();
+
+        $contentType = $contentTypeService->loadContentTypeByIdentifier(self::CONTENT_TYPE_IDENTIFIER);
+        $mainLanguageCode = self::ENG_US;
+        $contentCreateStruct = $contentService->newContentCreateStruct($contentType, $mainLanguageCode);
+        $contentCreateStruct->setField('title', 'Test title');
+        $contentCreateStruct->setField('body', 'Test body');
+
+        return $contentService->createContent(
+            $contentCreateStruct,
+            [
+                $locationService->newLocationCreateStruct(2),
+            ]
+        );
     }
 
     private function createNonTranslatableContentType(): void


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6494](https://issues.ibexa.co/browse/IBX-6494)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

The issue was present before the `copyNonTranslatableFieldsFromPublishedVersion` was introduced. However, this method would allow us to handle also the case given in the public ticket.

_Maintainer update_

#### QA

This fix makes non-translatable fields to be copied regardless of if they're coming from higher or lower version number, so we need some extensive testing both for scenario in the ticket and some other ideas of how Editor could manipulate content and possibly break it. The version number simple math comparison  (`>`) was there _probably_ since eZ Publish. However I think this was never a good determinant of if something should be overridden.

_Side note: would be nice to have in such case a version comparison response which would result in an UI dialog stating that the field changed in some other version, prompting user to choose proper value. But we're nowhere near that yet._

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
