### PR TITLE
IBX-6965: Set preview active in the `PreviewRequestListener`

### DIFF
--- a/eZ/Bundle/EzPublishCoreBundle/EventListener/PreviewRequestListener.php
+++ b/eZ/Bundle/EzPublishCoreBundle/EventListener/PreviewRequestListener.php
@@ -6,6 +6,7 @@
  */
 namespace eZ\Bundle\EzPublishCoreBundle\EventListener;
 
+use eZ\Publish\Core\Helper\ContentPreviewHelper;
 use eZ\Publish\Core\MVC\Symfony\Controller\Content\PreviewController;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -18,9 +19,13 @@ class PreviewRequestListener implements EventSubscriberInterface
     /** @var \Symfony\Component\HttpFoundation\RequestStack */
     private $requestStack;
 
-    public function __construct(RequestStack $requestStack)
+    /** @var \eZ\Publish\Core\Helper\ContentPreviewHelper */
+    private $contentPreviewHelper;
+
+    public function __construct(RequestStack $requestStack, ContentPreviewHelper $contentPreviewHelper)
     {
         $this->requestStack = $requestStack;
+        $this->contentPreviewHelper = $contentPreviewHelper;
     }
 
     public static function getSubscribedEvents(): array
@@ -35,6 +40,8 @@ class PreviewRequestListener implements EventSubscriberInterface
      */
     public function onKernelRequest(RequestEvent $event): void
     {
+        $this->contentPreviewHelper->setPreviewActive(true);
+
         if ($event->getRequestType() === HttpKernelInterface::MASTER_REQUEST) {
             return;
         }

--- a/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
+++ b/eZ/Bundle/EzPublishCoreBundle/Resources/config/routing.yml
@@ -152,7 +152,9 @@ services:
 
     ezpublish.preview_request_listener:
         class: eZ\Bundle\EzPublishCoreBundle\EventListener\PreviewRequestListener
-        arguments: ["@request_stack"]
+        arguments:
+            $requestStack: '@request_stack'
+            $contentPreviewHelper: '@ezpublish.content_preview_helper'
         tags:
             - { name: kernel.event_subscriber }
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6965](https://issues.ibexa.co/browse/IBX-6965)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Related PR: https://github.com/ezsystems/ezplatform-page-builder/pull/983 (not needed anymore)

Varnish/Fastly requests are handled by `PreviewRequestListener`, it should set preview to active, as the name itself says.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
