### PR TITLE
IBX-7346: Reindexed reverse-related content after deleting source content

### DIFF
--- a/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResult.php
+++ b/eZ/Publish/API/Repository/Values/Content/Trash/TrashItemDeleteResult.php
@@ -24,4 +24,7 @@ class TrashItemDeleteResult extends ValueObject
      * @var bool
      */
     public $contentRemoved = false;
+
+    /** @var array<int> */
+    public $reverseRelationContentIds = [];
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Trash/Handler.php
@@ -246,11 +246,14 @@ class Handler implements BaseTrashHandler
         $result->trashItemId = $trashItem->id;
         $result->contentId = $trashItem->contentId;
 
+        $reverseRelations = $this->contentHandler->loadReverseRelations($trashItem->contentId);
+
         $this->locationGateway->removeElementFromTrash($trashItem->id);
 
         if ($this->locationGateway->countLocationsByContentId($trashItem->contentId) < 1) {
             $this->contentHandler->deleteContent($trashItem->contentId);
             $result->contentRemoved = true;
+            $result->reverseRelationContentIds = array_column($reverseRelations, 'sourceContentId');
         }
 
         return $result;

--- a/eZ/Publish/Core/Search/Common/EventSubscriber/TrashEventSubscriber.php
+++ b/eZ/Publish/Core/Search/Common/EventSubscriber/TrashEventSubscriber.php
@@ -11,8 +11,6 @@ use eZ\Publish\API\Repository\Events\Trash\EmptyTrashEvent;
 use eZ\Publish\API\Repository\Events\Trash\RecoverEvent;
 use eZ\Publish\API\Repository\Events\Trash\TrashEvent;
 use eZ\Publish\API\Repository\Values\Content\TrashItem;
-use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
-use eZ\Publish\SPI\Search\Handler as SearchHandler;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class TrashEventSubscriber extends AbstractSearchEventSubscriber implements EventSubscriberInterface

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -281,11 +281,6 @@ parameters:
 			path: eZ/Publish/API/Repository/Tests/SearchServiceTranslationLanguageFallbackTest.php
 
 		-
-			message: "#^Undefined variable\\: \\$loader$#"
-			count: 3
-			path: eZ/Publish/API/Repository/Tests/SetupFactory/Legacy.php
-
-		-
 			message: "#^Method eZ\\\\Publish\\\\API\\\\Repository\\\\Tests\\\\URLWildcardServiceAuthorizationTest\\:\\:testCreateThrowsUnauthorizedException\\(\\) should return eZ\\\\Publish\\\\API\\\\Repository\\\\Values\\\\Content\\\\URLWildcard but return statement is missing\\.$#"
 			count: 1
 			path: eZ/Publish/API/Repository/Tests/URLWildcardServiceAuthorizationTest.php
@@ -504,11 +499,6 @@ parameters:
 			message: "#^Method eZ\\\\Publish\\\\Core\\\\Persistence\\\\Legacy\\\\Content\\\\Type\\\\Handler\\:\\:addFieldDefinition\\(\\) should return eZ\\\\Publish\\\\SPI\\\\Persistence\\\\Content\\\\Type\\\\FieldDefinition but return statement is missing\\.$#"
 			count: 1
 			path: eZ/Publish/Core/Persistence/Legacy/Content/Type/Handler.php
-
-		-
-			message: "#^Undefined variable\\: \\$loader$#"
-			count: 2
-			path: eZ/Publish/Core/Persistence/Legacy/Tests/HandlerTest.php
 
 		-
 			message: "#^Class eZ\\\\Publish\\\\SPI\\\\Persistence\\\\Content\\\\UrlAlias referenced with incorrect case\\: eZ\\\\Publish\\\\SPI\\\\Persistence\\\\Content\\\\URLAlias\\.$#"

--- a/tests/lib/Search/Common/EventSubscriber/TrashEventSubscriberTest.php
+++ b/tests/lib/Search/Common/EventSubscriber/TrashEventSubscriberTest.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace Ibexa\Tests\Core\Search\Common\EventSubscriber;
+
+use eZ\Publish\API\Repository\Events\Trash\DeleteTrashItemEvent;
+use eZ\Publish\API\Repository\Values\Content\Trash\TrashItemDeleteResult;
+use eZ\Publish\Core\Repository\Values\Content\TrashItem;
+use eZ\Publish\Core\Search\Common\EventSubscriber\TrashEventSubscriber;
+use eZ\Publish\SPI\Persistence\Content as PersistenceContent;
+use eZ\Publish\SPI\Persistence\Content\Handler;
+use eZ\Publish\SPI\Persistence\Handler as PersistenceHandler;
+use eZ\Publish\SPI\Search\Handler as SearchHandler;
+use PHPUnit\Framework\TestCase;
+
+final class TrashEventSubscriberTest extends TestCase
+{
+    /** @var \eZ\Publish\SPI\Search\Handler&\PHPUnit\Framework\MockObject\MockObject */
+    private $searchHandler;
+
+    /** @var \eZ\Publish\SPI\Persistence\Handler&\PHPUnit\Framework\MockObject\MockObject */
+    private $persistenceHandler;
+
+    /** @var \eZ\Publish\Core\Search\Common\EventSubscriber\TrashEventSubscriber */
+    private $subscriber;
+
+    protected function setUp(): void
+    {
+        $this->searchHandler = $this->createMock(SearchHandler::class);
+        $this->persistenceHandler = $this->createMock(PersistenceHandler::class);
+
+        $this->subscriber = new TrashEventSubscriber(
+            $this->searchHandler,
+            $this->persistenceHandler
+        );
+    }
+
+    public function testOnDeleteTrashItem(): void
+    {
+        $trashItem = new TrashItem(['id' => 12345]);
+        $reverseRelationContentId = 12;
+        $trashItemDeleteResult = new TrashItemDeleteResult(
+            [
+                'trashItemId' => $trashItem->id,
+                'reverseRelationContentIds' => [$reverseRelationContentId],
+            ]
+        );
+
+        $this->persistenceHandler
+            ->expects(self::once())
+            ->method('contentHandler')
+            ->willReturn($contentHandler = $this->createMock(Handler::class));
+
+        $contentHandler
+            ->expects(self::once())
+            ->method('load')
+            ->with($reverseRelationContentId)
+            ->willReturn($content = new PersistenceContent());
+
+        $this->searchHandler
+            ->expects(self::once())
+            ->method('indexContent')
+            ->with($content);
+
+        $this->subscriber->onDeleteTrashItem(
+            new DeleteTrashItemEvent(
+                $trashItemDeleteResult,
+                $trashItem,
+            )
+        );
+    }
+}


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7346](https://issues.ibexa.co/browse/IBX-7346)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Currently, content that is deleted and is used in relation to other content won't be removed from search engines fields, however, it should. Therefore, in this PR, reverse relations are fetched when deleting `TrashItem` and later those contents are reindexed again to account for destination content deletion.

Two specific actions are handled here and those are:
- `emptyTrash`
- `deleteTrashItem`

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
