### PR TITLE
IBX-6592: Removed unusable location/subtree limitations from `state/assign` policy

### DIFF
--- a/eZ/Publish/Core/settings/policies.yml
+++ b/eZ/Publish/Core/settings/policies.yml
@@ -26,7 +26,7 @@ parameters:
             delete: ~
 
         state:
-            assign: { Class: true, Section: true, Owner: true, Group: true, Node: true, Subtree: true, State: true, NewState: true }
+            assign: { Class: true, Section: true, Owner: true, Group: true, State: true, NewState: true }
             administrate: ~
 
         role:


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-6592](https://issues.ibexa.co/browse/IBX-6592)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | ?

As agreed in https://github.com/ezsystems/ezplatform-admin-ui/pull/2112#issuecomment-1862919805 we decided to remove Subtree and Node limitations from `state/assign` policy.

Cleanup SQL PR: https://github.com/ibexa/installer/pull/134

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
