### PR TITLE
IBX-7485: Implemented custom Filesystem that handles corrupted filepaths

### DIFF
--- a/eZ/Publish/Core/IO/Filesystem.php
+++ b/eZ/Publish/Core/IO/Filesystem.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\IO;
+
+use League\Flysystem\Filesystem as FlysystemFilesystem;
+use LogicException;
+
+class Filesystem extends FlysystemFilesystem
+{
+    public function getMetadata($path)
+    {
+        $path = $this->normalizeRelativePath($path);
+        $this->assertPresent($path);
+
+        return $this->getAdapter()->getMetadata($path);
+    }
+
+    public function has($path): bool
+    {
+        $path = $this->normalizeRelativePath($path);
+
+        return !(strlen($path) === 0) && (bool)$this->getAdapter()->has($path);
+    }
+
+    public function getMimetype($path)
+    {
+        $path = $this->normalizeRelativePath($path);
+        $this->assertPresent($path);
+
+        if ((!$object = $this->getAdapter()->getMimetype($path)) || !array_key_exists('mimetype', $object)) {
+            return false;
+        }
+
+        return $object['mimetype'];
+    }
+
+    public function delete($path)
+    {
+        $path = $this->normalizeRelativePath($path);
+        $this->assertPresent($path);
+
+        return $this->getAdapter()->delete($path);
+    }
+
+    private function normalizeRelativePath(string $path): string
+    {
+        $path = str_replace('\\', '/', $path);
+        $parts = [];
+
+        foreach (explode('/', $path) as $part) {
+            switch ($part) {
+                case '':
+                case '.':
+                    break;
+
+                case '..':
+                    if (empty($parts)) {
+                        throw new LogicException(
+                            'Path is outside of the defined root, path: [' . $path . ']'
+                        );
+                    }
+                    array_pop($parts);
+                    break;
+
+                default:
+                    $parts[] = $part;
+                    break;
+            }
+        }
+
+        return implode('/', $parts);
+    }
+}

--- a/eZ/Publish/Core/settings/io.yml
+++ b/eZ/Publish/Core/settings/io.yml
@@ -35,7 +35,7 @@ services:
             - "@ezpublish.core.io.default_url_decorator"
 
     ezpublish.core.io.flysystem.base_filesystem:
-        class: League\Flysystem\Filesystem
+        class: eZ\Publish\Core\IO\Filesystem
         abstract: true
 
     ezpublish.core.io.flysystem.default_filesystem:


### PR DESCRIPTION
### **Proof of concept PR** 

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7485](https://issues.ibexa.co/browse/IBX-7485)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR overrides `league/flysystem`'s `Filesystem` class so it handles already existing files with broken paths gracefully.

I intentionally overrode only some of the methods of the original class as we still should disallow uploading files with broken names, this should fix the issue with broken names already existing in the filesystem/db.

Another idea (skipping broken files): https://github.com/ezsystems/ezplatform-kernel/pull/400

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
