### PR TITLE
IBX-7485: Skipped files with corrupted filenames when loading and deleting

### DIFF
--- a/eZ/Publish/Core/IO/IOBinarydataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOBinarydataHandler/Flysystem.php
@@ -11,6 +11,7 @@ use eZ\Publish\Core\IO\IOBinarydataHandler;
 use eZ\Publish\Core\IO\UrlDecorator;
 use eZ\Publish\SPI\IO\BinaryFileCreateStruct;
 use League\Flysystem\AdapterInterface;
+use League\Flysystem\CorruptedPathDetected;
 use League\Flysystem\FileExistsException;
 use League\Flysystem\FileNotFoundException as FlysystemNotFoundException;
 use League\Flysystem\FilesystemInterface;
@@ -56,7 +57,7 @@ class Flysystem implements IOBinaryDataHandler
     {
         try {
             $this->filesystem->delete($spiBinaryFileId);
-        } catch (FlysystemNotFoundException $e) {
+        } catch (FlysystemNotFoundException|CorruptedPathDetected $e) {
             throw new BinaryFileNotFoundException($spiBinaryFileId, $e);
         }
     }

--- a/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
+++ b/eZ/Publish/Core/IO/IOMetadataHandler/Flysystem.php
@@ -11,6 +11,7 @@ use eZ\Publish\Core\IO\Exception\BinaryFileNotFoundException;
 use eZ\Publish\Core\IO\IOMetadataHandler;
 use eZ\Publish\SPI\IO\BinaryFile as SPIBinaryFile;
 use eZ\Publish\SPI\IO\BinaryFileCreateStruct as SPIBinaryFileCreateStruct;
+use League\Flysystem\CorruptedPathDetected;
 use League\Flysystem\FileNotFoundException;
 use League\Flysystem\FilesystemInterface;
 
@@ -47,7 +48,7 @@ class Flysystem implements IOMetadataHandler
     {
         try {
             $info = $this->filesystem->getMetadata($spiBinaryFileId);
-        } catch (FileNotFoundException $e) {
+        } catch (FileNotFoundException|CorruptedPathDetected $e) {
             throw new BinaryFileNotFoundException($spiBinaryFileId);
         }
 
@@ -64,7 +65,11 @@ class Flysystem implements IOMetadataHandler
 
     public function exists($spiBinaryFileId)
     {
-        return $this->filesystem->has($spiBinaryFileId);
+        try {
+            return $this->filesystem->has($spiBinaryFileId);
+        } catch (CorruptedPathDetected $e) {
+            return false;
+        }
     }
 
     public function getMimeType($spiBinaryFileId)


### PR DESCRIPTION
### **Proof of concept PR** 

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7485](https://issues.ibexa.co/browse/IBX-7485)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

This PR try/catches the `CorruptedPathDetected` exception originating from the `flysystem/league` package. Files will be treated as missing.

Another idea (Filesystem override https://github.com/ezsystems/ezplatform-kernel/pull/399): 

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
