### PR TITLE
IBX-7172: Fixed Repository Filtering by multiple ObjectStateId criteria

### DIFF
--- a/eZ/Publish/API/Repository/Tests/Filtering/ContentFilteringTest.php
+++ b/eZ/Publish/API/Repository/Tests/Filtering/ContentFilteringTest.php
@@ -30,11 +30,6 @@ use function sprintf;
  */
 final class ContentFilteringTest extends BaseRepositoryFilteringTestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-    }
-
     /**
      * Test that special cases of Location Sort Clauses are working correctly.
      *

--- a/eZ/Publish/API/Repository/Tests/Filtering/ContentFilteringTest.php
+++ b/eZ/Publish/API/Repository/Tests/Filtering/ContentFilteringTest.php
@@ -32,9 +32,9 @@ final class ContentFilteringTest extends BaseRepositoryFilteringTestCase
 {
     protected function setUp(): void
     {
-        parent::setUp();
         $this->getSetupFactory()->getRepository(true);
         $this->contentProvider = new TestContentProvider($this->getRepository(true), $this);
+        parent::setUp();
     }
 
     /**
@@ -360,7 +360,7 @@ final class ContentFilteringTest extends BaseRepositoryFilteringTestCase
         $objectStateCreateStruct->identifier = 'public';
         $objectStateCreateStruct->names = ['eng-GB' => 'Public'];
         $objectStateCreateStruct->defaultLanguageCode = 'eng-GB';
-        $objectStatePublic = $objectStateService->createObjectState($objectStateGroup, $objectStateCreateStruct);
+        $objectStateService->createObjectState($objectStateGroup, $objectStateCreateStruct);
 
         $objectStateCreateStruct->identifier = 'private';
         $objectStateCreateStruct->names = ['eng-GB' => 'Private'];
@@ -393,7 +393,12 @@ final class ContentFilteringTest extends BaseRepositoryFilteringTestCase
 
         $results = $this->find($filter);
 
-        self::assertEquals(1, $results->getTotalCount(), 'Expected to find only one object which has state "not_locked" and "private"');
+        self::assertEquals(
+            1,
+            $results->getTotalCount(),
+            'Expected to find only one object which has state "not_locked" and "private"'
+        );
+
         /** @var \eZ\Publish\API\Repository\Values\Content\Location $result */
         foreach ($results as $result) {
             self::assertEquals($result->id, $content->id, 'Expected to find "Private Folder"');

--- a/eZ/Publish/API/Repository/Tests/Filtering/ContentFilteringTest.php
+++ b/eZ/Publish/API/Repository/Tests/Filtering/ContentFilteringTest.php
@@ -340,6 +340,9 @@ final class ContentFilteringTest extends BaseRepositoryFilteringTestCase
         self::assertSame(57, $contentList->getIterator()[0]->id);
     }
 
+    /**
+     * @throws \eZ\Publish\API\Repository\Exceptions\Exception
+     */
     public function testObjectStateIdCriterionOnMultipleObjectStates(): void
     {
         $contentService = $this->getRepository()->getContentService();

--- a/eZ/Publish/API/Repository/Tests/Filtering/ContentFilteringTest.php
+++ b/eZ/Publish/API/Repository/Tests/Filtering/ContentFilteringTest.php
@@ -380,7 +380,11 @@ final class ContentFilteringTest extends BaseRepositoryFilteringTestCase
         $contentService->publishVersion(
             $content->getVersionInfo()
         );
-        $objectStateService->setContentState($content->contentInfo, $objectStateGroup, $objectStatePrivate);
+        $objectStateService->setContentState(
+            $content->getVersionInfo()->getContentInfo(),
+            $objectStateGroup,
+            $objectStatePrivate
+        );
 
         $filter = new Filter();
         $filter
@@ -400,7 +404,6 @@ final class ContentFilteringTest extends BaseRepositoryFilteringTestCase
             'Expected to find only one object which has state "not_locked" and "private"'
         );
 
-        /** @var \eZ\Publish\API\Repository\Values\Content\Location $result */
         foreach ($results as $result) {
             self::assertEquals($result->id, $content->id, 'Expected to find "Private Folder"');
         }

--- a/eZ/Publish/API/Repository/Tests/Filtering/ContentFilteringTest.php
+++ b/eZ/Publish/API/Repository/Tests/Filtering/ContentFilteringTest.php
@@ -32,8 +32,6 @@ final class ContentFilteringTest extends BaseRepositoryFilteringTestCase
 {
     protected function setUp(): void
     {
-        $this->getSetupFactory()->getRepository(true);
-        $this->contentProvider = new TestContentProvider($this->getRepository(true), $this);
         parent::setUp();
     }
 
@@ -387,7 +385,7 @@ final class ContentFilteringTest extends BaseRepositoryFilteringTestCase
                 new Criterion\ParentLocationId(2),
                 new Criterion\LogicalAnd([
                     new Criterion\ObjectStateId(1),
-                    new Criterion\ObjectStateId(4),
+                    new Criterion\ObjectStateId($objectStatePrivate->id),
                 ]),
             ]));
 

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ObjectStateIdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ObjectStateIdQueryBuilder.php
@@ -33,7 +33,7 @@ final class ObjectStateIdQueryBuilder implements CriterionQueryBuilder
 
         /** @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion\ObjectStateId $criterion */
         $queryBuilder
-            ->joinOnce(
+            ->join(
                 'content',
                 Gateway::OBJECT_STATE_LINK_TABLE,
                 $tableAlias,

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ObjectStateIdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ObjectStateIdQueryBuilder.php
@@ -29,9 +29,7 @@ final class ObjectStateIdQueryBuilder implements CriterionQueryBuilder
         FilteringQueryBuilder $queryBuilder,
         FilteringCriterion $criterion
     ): ?string {
-        static $counter = 1;
-        $tableAlias = 'object_state_link_' . $counter;
-        ++$counter;
+        $tableAlias = uniqid('osl_');
 
         /** @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion\ObjectStateId $criterion */
         $queryBuilder

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ObjectStateIdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ObjectStateIdQueryBuilder.php
@@ -29,19 +29,23 @@ final class ObjectStateIdQueryBuilder implements CriterionQueryBuilder
         FilteringQueryBuilder $queryBuilder,
         FilteringCriterion $criterion
     ): ?string {
+        static $counter = 1;
+        $tableAlias = 'object_state_link_' . $counter;
+        ++$counter;
+
         /** @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion\ObjectStateId $criterion */
         $queryBuilder
             ->joinOnce(
                 'content',
                 Gateway::OBJECT_STATE_LINK_TABLE,
-                'object_state_link',
-                'content.id = object_state_link.contentobject_id',
+                $tableAlias,
+                'content.id = ' . $tableAlias . '.contentobject_id',
             );
 
         $value = (array)$criterion->value;
 
         return $queryBuilder->expr()->in(
-            'object_state_link.contentobject_state_id',
+            $tableAlias . '.contentobject_state_id',
             $queryBuilder->createNamedParameter($value, Connection::PARAM_INT_ARRAY)
         );
     }


### PR DESCRIPTION

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-7172](https://issues.ibexa.co/browse/IBX-7172)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

If user has policy with limitation on multiple object states, the api call for `$locationService->loadLocationChildren($location)` creates (`eZ\Publish\Core\Persistence\Legacy\Filter\CriterionQueryBuilder\Content\ObjectStateIdQueryBuilder`) an incorrect sql for checking the object states.

The sql looks as follows :
```
SELECT
  DISTINCT COUNT(DISTINCT location.node_id)
FROM
  ezcontentobject_tree location
  INNER JOIN ezcontentobject content ON content.id = location.contentobject_id
  INNER JOIN ezcontentobject_version version ON (
    content.id = version.contentobject_id
  )
  AND (
    content.current_version = version.version
  )
  AND (version.status = :dcValue1)
  INNER JOIN ezcobj_state_link object_state_link ON content.id = object_state_link.contentobject_id
  INNER JOIN ezcontent_language language ON language.id & version.language_mask = language.id
WHERE
  (
    location.parent_node_id IN (:dcValue2)
  )
  AND (
    (
      language.locale IN (:dcValue3)
    )
    OR (version.language_mask & 1 = 1)
  )
  AND (
    (
      content.section_id IN (:dcValue4)
    )
    AND (
      (
        object_state_link.contentobject_state_id IN (:dcValue5)
      )
      AND (
        object_state_link.contentobject_state_id IN (:dcValue6)
      )
    )
  )
```

Obviously, `object_state_link.contentobject_state_id` cannot be equal both `:dcValue5` and `:dcValue6` at the same time.
Instead the objet_state_link table should be joined once for each id and the sql should read:
```
SELECT
  DISTINCT COUNT(DISTINCT location.node_id)
FROM
  ezcontentobject_tree location
  INNER JOIN ezcontentobject content ON content.id = location.contentobject_id
  INNER JOIN ezcontentobject_version version ON (
    content.id = version.contentobject_id
  )
  AND (
    content.current_version = version.version
  )
  AND (version.status = :dcValue1)
  INNER JOIN ezcobj_state_link object_state_link_1 ON content.id = object_state_link.contentobject_id
  INNER JOIN ezcobj_state_link object_state_link_2 ON content.id = object_state_link.contentobject_id
  INNER JOIN ezcontent_language language ON language.id & version.language_mask = language.id
WHERE
  (
    location.parent_node_id IN (:dcValue2)
  )
  AND (
    (
      language.locale IN (:dcValue3)
    )
    OR (version.language_mask & 1 = 1)
  )
  AND (
    (
      content.section_id IN (:dcValue4)
    )
    AND (
      (
        object_state_link_1.contentobject_state_id IN (:dcValue5)
      )
      AND (
        object_state_link_2.contentobject_state_id IN (:dcValue6)
      )
    )
  )
```


#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
