### PR TITLE
IBX-8019: Refactored Object State Id criterion

### DIFF
--- a/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
+++ b/eZ/Publish/Core/Limitation/ObjectStateLimitationType.php
@@ -225,13 +225,7 @@ class ObjectStateLimitationType extends AbstractPersistenceLimitationType implem
             return new Criterion\ObjectStateId($groupedLimitationValues[0]);
         }
 
-        // limitations from different groups require logical AND between them
-        $criterions = [];
-        foreach ($groupedLimitationValues as $limitationGroup) {
-            $criterions[] = new Criterion\ObjectStateId($limitationGroup);
-        }
-
-        return new Criterion\LogicalAnd($criterions);
+        return new Criterion\ObjectStateId($value->limitationValues);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ObjectStateIdQueryBuilder.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/CriterionQueryBuilder/Content/ObjectStateIdQueryBuilder.php
@@ -29,21 +29,19 @@ final class ObjectStateIdQueryBuilder implements CriterionQueryBuilder
         FilteringQueryBuilder $queryBuilder,
         FilteringCriterion $criterion
     ): ?string {
-        $tableAlias = uniqid('osl_');
-
         /** @var \eZ\Publish\API\Repository\Values\Content\Query\Criterion\ObjectStateId $criterion */
         $queryBuilder
-            ->join(
+            ->joinOnce(
                 'content',
                 Gateway::OBJECT_STATE_LINK_TABLE,
-                $tableAlias,
-                'content.id = ' . $tableAlias . '.contentobject_id',
+                'object_state_link',
+                'content.id = object_state_link.contentobject_id',
             );
 
         $value = (array)$criterion->value;
 
         return $queryBuilder->expr()->in(
-            $tableAlias . '.contentobject_state_id',
+            'object_state_link.contentobject_state_id',
             $queryBuilder->createNamedParameter($value, Connection::PARAM_INT_ARRAY)
         );
     }


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-8019](https://issues.ibexa.co/browse/IBX-8019)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | yes/no

The reason for the performance drop caused by https://github.com/ezsystems/ezplatform-kernel/pull/401 is the fact that we can have literally hundreds of join of the same table if there are so many object state.

I would say the real cause of the problem is the criterion building itself.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
