### PR TITLE
Fixed missing return types for DebugTemplate

### DIFF
--- a/eZ/Bundle/EzPublishDebugBundle/Twig/DebugTemplate.php
+++ b/eZ/Bundle/EzPublishDebugBundle/Twig/DebugTemplate.php
@@ -7,6 +7,7 @@
 namespace eZ\Bundle\EzPublishDebugBundle\Twig;
 
 use Symfony\Component\Filesystem\Filesystem;
+use Twig\Source;
 use Twig\Template;
 
 /**
@@ -19,7 +20,7 @@ class DebugTemplate extends Template
 {
     private $fileSystem;
 
-    public function display(array $context, array $blocks = [])
+    public function display(array $context, array $blocks = []): void
     {
         $this->fileSystem = $this->fileSystem ?: new Filesystem();
 
@@ -65,34 +66,25 @@ class DebugTemplate extends Template
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getTemplateName()
+    public function getTemplateName(): string
+    {
+        return '';
+    }
+
+    public function getSourceContext(): Source
+    {
+        return new Source('', '');
+    }
+
+    protected function doDisplay(array $context, array $blocks = []): string
     {
         return '';
     }
 
     /**
-     * {@inheritdoc}
+     * @return array<mixed>
      */
-    public function getSourceContext()
-    {
-        return '';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function doDisplay(array $context, array $blocks = [])
-    {
-        return '';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getDebugInfo()
+    public function getDebugInfo(): array
     {
         return [];
     }


### PR DESCRIPTION
| :ticket: Issue | N/A |
|----------------|-----------|

This is a backport of https://github.com/ibexa/core/pull/355 as the issue exists on 3.3.

> Twig 3.9.x introduced return type to an internal class, which we extend. As a current issue resolution I have added return types where applicable.

As said above - the base Twig Template is internal - so we shouldn't really extend it. It's debatable if that legacy code is still needed or if even if it's working (TBD), however for now we provided the quick fix.