### PR TITLE
IBX-8019: Added performance consideration notice to `LocationService::loadLocationChildren`

### DIFF
--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -97,6 +97,10 @@ interface LocationService
     /**
      * Loads children which are readable by the current user of a location object sorted by sortField and sortOrder.
      *
+     * Use this method with caution. It performs heavy queries on the database.
+     * Consider using {@see \eZ\Publish\API\Repository\SearchService::findLocations()} with
+     * {@see \eZ\Publish\Core\QueryType\BuiltIn\ChildrenQueryType} as an alternative.
+     *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
      * @param int $offset the start offset for paging
      * @param int $limit the number of locations returned


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-8019](https://issues.ibexa.co/browse/IBX-8019)
| **Type**                                   | improvement
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

#401 fixed the issue but some performance related issues became apparent. Due to current database schema shape we cannot provide further optimizations. In cases where there are many children, the query has to fetch all records and join version and language tables. This becomes even worse when Permission criterions are applied adding even more JOINs to the query. Test example from the ticket causes 100000 locations to be loaded which is necessary to perform location sort. This is where majority of query time comes from.

The recommendation is to use `SearchService::findLocations` instead of `LocationService::loadLocationChildren` where possible. I've added a notice to the method in order to warn people about potential performance issues.

Existing `\eZ\Publish\Core\QueryType\BuiltIn\ChildrenQueryType` can be used instead of manually creating the query for SearchService.

Related PRs:
- https://github.com/ezsystems/ezplatform-kernel/pull/407
- https://github.com/ezsystems/ezplatform-admin-ui/pull/2119
- https://github.com/ezsystems/ezrecommendation-client/pull/114

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
