### PR TITLE
IBX-8562: Fixed flooding content attributes table with duplicates

### DIFF
--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
@@ -332,7 +332,7 @@ class FieldHandler
                 if (isset($updateFieldMap[$fieldDefinition->id][$languageCode])) {
                     $field = clone $updateFieldMap[$fieldDefinition->id][$languageCode];
                     $field->versionNo = $content->versionInfo->versionNo;
-                    if (null !== $field->id && array_key_exists($field->languageCode, $existingLanguageCodes)) {
+                    if (isset($field->id) && array_key_exists($field->languageCode, $existingLanguageCodes)) {
                         $this->updateField($field, $content);
                         $updatedFields[$fieldDefinition->id][$languageCode] = $field;
                     } else {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
@@ -363,8 +363,7 @@ class FieldHandler
                     $field->versionNo = $content->versionInfo->versionNo;
                     // Persist virtual field
                     if (null === $field->id) {
-                        $this->updateField($field, $content);
-                        $updatedFields[$fieldDefinition->id][$languageCode] = $field;
+                        $this->createNewField($field, $content);
                     }
                 }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/FieldHandler.php
@@ -332,7 +332,7 @@ class FieldHandler
                 if (isset($updateFieldMap[$fieldDefinition->id][$languageCode])) {
                     $field = clone $updateFieldMap[$fieldDefinition->id][$languageCode];
                     $field->versionNo = $content->versionInfo->versionNo;
-                    if (isset($field->id) && array_key_exists($field->languageCode, $existingLanguageCodes)) {
+                    if (null !== $field->id && array_key_exists($field->languageCode, $existingLanguageCodes)) {
                         $this->updateField($field, $content);
                         $updatedFields[$fieldDefinition->id][$languageCode] = $field;
                     } else {
@@ -358,6 +358,14 @@ class FieldHandler
                     // also update copied field data
                     // Register for processing after all given fields are updated
                     $nonTranslatableCopiesUpdateSet[$fieldDefinition->id][] = $languageCode;
+                } elseif (isset($contentFieldMap[$fieldDefinition->id][$languageCode])) {
+                    $field = clone $contentFieldMap[$fieldDefinition->id][$languageCode];
+                    $field->versionNo = $content->versionInfo->versionNo;
+                    // Persist virtual field
+                    if (null === $field->id) {
+                        $this->updateField($field, $content);
+                        $updatedFields[$fieldDefinition->id][$languageCode] = $field;
+                    }
                 }
 
                 // If no above conditions were met - do nothing
@@ -417,7 +425,7 @@ class FieldHandler
      * @param \eZ\Publish\SPI\Persistence\Content\Field[] $fields
      * @param array $languageCodes
      *
-     * @return \eZ\Publish\SPI\Persistence\Content\Field[][]
+     * @return array<int, array<string, \eZ\Publish\SPI\Persistence\Content\Field>>
      */
     protected function getFieldMap(array $fields, &$languageCodes = null)
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -320,7 +320,9 @@ class Handler implements BaseContentHandler
             $this->contentGateway->loadVersionedNameData([[
                 'id' => $id,
                 'version' => $rows[0]['ezcontentobject_version_version'],
-            ]])
+            ]]),
+            'ezcontentobject_',
+            $translations
         );
         $content = $contentObjects[0];
         unset($rows, $contentObjects);
@@ -371,7 +373,9 @@ class Handler implements BaseContentHandler
             try {
                 $contentList = $this->mapper->extractContentFromRows(
                     $contentItemsRow,
-                    $contentItemNameData[$contentId]
+                    $contentItemNameData[$contentId],
+                    'ezcontentobject_',
+                    $translations
                 );
                 $contentItems[$contentId] = $contentList[0];
             } catch (Exception $e) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -263,6 +263,8 @@ class Handler implements BaseContentHandler
      * @param string|null $languageCode
      *
      * @return \eZ\Publish\SPI\Persistence\Content
+     *
+     * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
      */
     public function createDraftFromVersion($contentId, $srcVersion, $userId, ?string $languageCode = null)
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -85,7 +85,10 @@ class Handler implements BaseContentHandler
      */
     protected $treeHandler;
 
-    protected LanguageHandler $languageHandler;
+    /**
+     * @var \eZ\Publish\SPI\Persistence\Content\Language\Handler
+     */
+    protected $languageHandler;
 
     /** @var \Psr\Log\LoggerInterface */
     private $logger;

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Handler.php
@@ -15,6 +15,7 @@ use eZ\Publish\SPI\Persistence\Content;
 use eZ\Publish\SPI\Persistence\Content\CreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Field;
 use eZ\Publish\SPI\Persistence\Content\Handler as BaseContentHandler;
+use eZ\Publish\SPI\Persistence\Content\Language\Handler as LanguageHandler;
 use eZ\Publish\SPI\Persistence\Content\MetadataUpdateStruct;
 use eZ\Publish\SPI\Persistence\Content\Relation\CreateStruct as RelationCreateStruct;
 use eZ\Publish\SPI\Persistence\Content\Type\Handler as ContentTypeHandler;
@@ -84,6 +85,8 @@ class Handler implements BaseContentHandler
      */
     protected $treeHandler;
 
+    protected LanguageHandler $languageHandler;
+
     /** @var \Psr\Log\LoggerInterface */
     private $logger;
 
@@ -109,6 +112,7 @@ class Handler implements BaseContentHandler
         UrlAliasGateway $urlAliasGateway,
         ContentTypeHandler $contentTypeHandler,
         TreeHandler $treeHandler,
+        LanguageHandler $languageHandler,
         LoggerInterface $logger = null
     ) {
         $this->contentGateway = $contentGateway;
@@ -119,6 +123,7 @@ class Handler implements BaseContentHandler
         $this->urlAliasGateway = $urlAliasGateway;
         $this->contentTypeHandler = $contentTypeHandler;
         $this->treeHandler = $treeHandler;
+        $this->languageHandler = $languageHandler;
         $this->logger = null !== $logger ? $logger : new NullLogger();
     }
 
@@ -274,6 +279,14 @@ class Handler implements BaseContentHandler
 
         // Clone fields from previous version and append them to the new one
         $this->fieldHandler->createExistingFieldsInNewVersion($content);
+
+        // Persist virtual fields
+        $contentType = $this->contentTypeHandler->load($content->versionInfo->contentInfo->contentTypeId);
+        $this->fieldHandler->updateFields($content, new UpdateStruct([
+            'initialLanguageId' => $this->languageHandler->loadByLanguageCode(
+                $content->versionInfo->initialLanguageCode
+            )->id,
+        ]), $contentType);
 
         // Create relations for new version
         $relations = $this->contentGateway->loadRelations($contentId, $srcVersion);

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -220,6 +220,7 @@ class Mapper
      * @param array<array<string, scalar>> $rows
      * @param array<array<string, scalar>> $nameRows
      * @param string $prefix
+     * @param array<string>|null $translations
      *
      * @return \eZ\Publish\SPI\Persistence\Content[]
      *
@@ -228,7 +229,8 @@ class Mapper
     public function extractContentFromRows(
         array $rows,
         array $nameRows,
-        string $prefix = 'ezcontentobject_'
+        string $prefix = 'ezcontentobject_',
+        ?array $translations = null
     ): array {
         $versionedNameData = [];
 
@@ -245,7 +247,8 @@ class Mapper
 
         $fieldDefinitions = $this->loadCachedVersionFieldDefinitionsPerLanguage(
             $rows,
-            $prefix
+            $prefix,
+            $translations
         );
 
         foreach ($rows as $row) {
@@ -348,7 +351,8 @@ class Mapper
      */
     private function loadCachedVersionFieldDefinitionsPerLanguage(
         array $rows,
-        string $prefix
+        string $prefix,
+        ?array $translations = null
     ): array {
         $fieldDefinitions = [];
         $contentTypes = [];
@@ -364,7 +368,8 @@ class Mapper
                 continue;
             }
 
-            $languageCodes = $this->extractLanguageCodesFromMask($languageMask, $allLanguages);
+            $allLanguagesCodes = $this->extractLanguageCodesFromMask($languageMask, $allLanguages);
+            $languageCodes = empty($translations) ? $allLanguagesCodes : array_intersect($translations, $allLanguagesCodes);
             $contentTypes[$contentTypeId] = $contentTypes[$contentTypeId] ?? $this->contentTypeHandler->load($contentTypeId);
             $contentType = $contentTypes[$contentTypeId];
             foreach ($contentType->fieldDefinitions as $fieldDefinition) {

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -313,9 +313,10 @@ class Mapper
                 $content->versionInfo = $versionInfo;
                 $content->versionInfo->names = $names;
                 $content->versionInfo->contentInfo = $contentInfo;
-                $content->fields = array_values($fields[$contentId][$versionId]);
+                $content->fields = array_values($fields[$contentId][$versionId] ?? []);
 
-                $missingVersionFieldDefinitions = $missingFieldDefinitions[$contentId][$versionId];
+                $missingVersionFieldDefinitions = $missingFieldDefinitions[$contentId][$versionId] ?? [];
+
                 foreach ($missingVersionFieldDefinitions as $languageCode => $versionFieldDefinitions) {
                     foreach ($versionFieldDefinitions as $fieldDefinition) {
                         $event = $this->eventDispatcher->dispatch(

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Mapper.php
@@ -345,6 +345,8 @@ class Mapper
     }
 
     /**
+     * @param string[]|null $translations
+     *
      * @phpstan-return TVersionedLanguageFieldDefinitionsMap
      *
      * @throws \eZ\Publish\API\Repository\Exceptions\NotFoundException
@@ -374,7 +376,8 @@ class Mapper
             $contentType = $contentTypes[$contentTypeId];
             foreach ($contentType->fieldDefinitions as $fieldDefinition) {
                 foreach ($languageCodes as $languageCode) {
-                    $id = $fieldDefinition->id;
+                    $id = (int)$fieldDefinition->id;
+                    $languageCode = (string)$languageCode;
                     $fieldDefinitions[$contentId][$versionId][$languageCode][$id] = $fieldDefinition;
                 }
             }

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
@@ -110,9 +110,9 @@ class ContentHandlerTest extends TestCase
     protected $contentTypeHandlerMock;
 
     /**
-     * @var \eZ\Publish\Core\Persistence\Legacy\Content\Language\Handler
+     * @var \PHPUnit\Framework\MockObject\MockObject&\eZ\Publish\Core\Persistence\Legacy\Content\Language\Handler
      */
-    protected $languageHandlerMock;
+    private $languageHandlerMock;
 
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Handler::create
@@ -1617,7 +1617,7 @@ class ContentHandlerTest extends TestCase
     }
 
     /**
-     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Persistence\Legacy\Content\Language\Handler
+     * @return \PHPUnit\Framework\MockObject\MockObject&\eZ\Publish\Core\Persistence\Legacy\Content\Language\Handler
      */
     protected function getLanguageHandlerMock(): LanguageHandler
     {

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
@@ -11,6 +11,7 @@ use eZ\Publish\Core\Base\Exceptions\NotFoundException;
 use eZ\Publish\Core\Persistence\Legacy\Content\FieldHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Handler;
+use eZ\Publish\Core\Persistence\Legacy\Content\Language\Handler as LanguageHandler;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Mapper;
 use eZ\Publish\Core\Persistence\Legacy\Content\TreeHandler;
@@ -107,6 +108,8 @@ class ContentHandlerTest extends TestCase
      * @var \eZ\Publish\Core\Persistence\Legacy\Content\Type\Handler
      */
     protected $contentTypeHandlerMock;
+
+    protected LanguageHandler $languageHandlerMock;
 
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Handler::create
@@ -384,6 +387,8 @@ class ContentHandlerTest extends TestCase
         $mapperMock = $this->getMapperMock();
         $gatewayMock = $this->getGatewayMock();
         $fieldHandlerMock = $this->getFieldHandlerMock();
+        $languageHandlerMock = $this->getLanguageHandlerMock();
+        $contentTypeHandlerMock = $this->getContentTypeHandlerMock();
 
         $handler->expects($this->once())
             ->method('load')
@@ -402,10 +407,17 @@ class ContentHandlerTest extends TestCase
                         [
                             'names' => [],
                             'versionNo' => 3,
+                            'contentInfo' => new ContentInfo(),
                         ]
                     )
                 )
             );
+
+        $languageHandlerMock->method('loadByLanguageCode')
+            ->willReturn(new Content\Language());
+
+        $contentTypeHandlerMock->method('load')
+            ->willReturn(new Type());
 
         $gatewayMock->expects($this->once())
             ->method('insertVersion')
@@ -1538,7 +1550,8 @@ class ContentHandlerTest extends TestCase
                 $this->getSlugConverterMock(),
                 $this->getUrlAliasGatewayMock(),
                 $this->getContentTypeHandlerMock(),
-                $this->getTreeHandlerMock()
+                $this->getTreeHandlerMock(),
+                $this->getLanguageHandlerMock(),
             );
         }
 
@@ -1566,6 +1579,7 @@ class ContentHandlerTest extends TestCase
                     $this->getUrlAliasGatewayMock(),
                     $this->getContentTypeHandlerMock(),
                     $this->getTreeHandlerMock(),
+                    $this->getLanguageHandlerMock(),
                 ]
             )
             ->getMock();
@@ -1597,6 +1611,18 @@ class ContentHandlerTest extends TestCase
         }
 
         return $this->contentTypeHandlerMock;
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject|\eZ\Publish\Core\Persistence\Legacy\Content\Language\Handler
+     */
+    protected function getLanguageHandlerMock(): LanguageHandler
+    {
+        if (!isset($this->languageHandlerMock)) {
+            $this->languageHandlerMock = $this->createMock(LanguageHandler::class);
+        }
+
+        return $this->languageHandlerMock;
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/ContentHandlerTest.php
@@ -109,7 +109,10 @@ class ContentHandlerTest extends TestCase
      */
     protected $contentTypeHandlerMock;
 
-    protected LanguageHandler $languageHandlerMock;
+    /**
+     * @var \eZ\Publish\Core\Persistence\Legacy\Content\Language\Handler
+     */
+    protected $languageHandlerMock;
 
     /**
      * @covers \eZ\Publish\Core\Persistence\Legacy\Content\Handler::create

--- a/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldHandlerTest.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Tests/Content/FieldHandlerTest.php
@@ -633,7 +633,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
         $callNo = 0;
         $fieldValue = new FieldValue();
         $fieldsToCopy = [];
-        foreach ([1, 2, 3] as $fieldDefinitionId) {
+        foreach ([1, 2, 3] as $id => $fieldDefinitionId) {
             $field = new Field(
                 [
                     'fieldDefinitionId' => $fieldDefinitionId,
@@ -646,6 +646,7 @@ class FieldHandlerTest extends LanguageAwareTestCase
             // These fields are copied from main language
             if ($fieldDefinitionId == 2 || $fieldDefinitionId == 3) {
                 $originalField = clone $field;
+                $originalField->id = $fieldDefinitionId;
                 $originalField->languageCode = 'eng-GB';
                 $fieldsToCopy[] = [
                     'copy' => clone $field,
@@ -845,20 +846,13 @@ class FieldHandlerTest extends LanguageAwareTestCase
         $field->value = new FieldValue();
         $field->languageCode = 'eng-GB';
 
-        $firstField = clone $field;
-        $firstField->fieldDefinitionId = 1;
+        foreach ([1, 2, 3] as $id) {
+            $contentField = clone $field;
+            $contentField->id = $id;
+            $contentField->fieldDefinitionId = $id;
 
-        $secondField = clone $field;
-        $secondField->fieldDefinitionId = 2;
-
-        $thirdField = clone $field;
-        $thirdField->fieldDefinitionId = 3;
-
-        $content->fields = [
-            $firstField,
-            $secondField,
-            $thirdField,
-        ];
+            $content->fields[] = $contentField;
+        }
 
         return $content;
     }

--- a/eZ/Publish/Core/settings/storage_engines/legacy/content.yml
+++ b/eZ/Publish/Core/settings/storage_engines/legacy/content.yml
@@ -68,5 +68,6 @@ services:
             - "@ezpublish.persistence.legacy.url_alias.gateway"
             - "@ezpublish.spi.persistence.legacy.content_type.handler"
             - "@ezpublish.persistence.legacy.tree_handler"
+            - "@ezpublish.spi.persistence.legacy.language.handler"
             - "@logger"
         lazy: true


### PR DESCRIPTION
\+ IBX-8492: Fixed replacing only field of Content Type with virtual field

| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-8562](https://issues.ibexa.co/browse/IBX-8562), [IBX-8492](https://issues.ibexa.co/browse/IBX-8492)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

<!-- Replace this comment with Pull Request description -->

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
