### PR TITLE
IBX-9455: Upgraded Twig to ^3.19.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "friendsofsymfony/http-cache-bundle": "^2.8",
         "sensio/framework-extra-bundle": "^6.1",
         "jms/translation-bundle": "^1.5",
-        "twig/twig": "^3.0",
+        "twig/twig": "^3.19.0",
         "twig/extra-bundle": "^3.0",
         "friendsofsymfony/jsrouting-bundle": "^2.5",
         "friendsofphp/proxy-manager-lts": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "friendsofsymfony/http-cache-bundle": "^2.8",
         "sensio/framework-extra-bundle": "^6.1",
         "jms/translation-bundle": "^1.5",
-        "twig/twig": "^3.19.0",
+        "twig/twig": ">=3.0 <3.16 || ^3.19.0",
         "twig/extra-bundle": "^3.0",
         "friendsofsymfony/jsrouting-bundle": "^2.5",
         "friendsofphp/proxy-manager-lts": "^1.0",


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-9455](https://issues.ibexa.co/browse/IBX-9455)
| **Type**                                   | bug
| **Target Ibexa version** | `v3.3`
| **BC breaks**                          | no

Upgrade Twig to 3.19 due to null coalesce operator issue:
https://github.com/twigphp/Twig/security/advisories/GHSA-3xg3-cgvq-2xwr

We can't require 3.19 as it doesn't support PHP 7, but that's fine because the problem is limited to `>= 3.16, <3.19`. PHP 7 installs 3.11.0 which is not affected.

QA: Should be no functionality change, sanities only.

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [ ] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] ~Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).~
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
