### PR TITLE
IBX-10174 Add limit option to getSubtreeSize

### DIFF
--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -133,8 +133,11 @@ interface LocationService
      * Return the subtree size of a given location.
      *
      * Warning! This method is not permission aware by design.
+     * 
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     * @param int|null $limit Optional limit to the number of locations to count. (Can be used to limit the number of locations counted in large subtrees.)
      */
-    public function getSubtreeSize(Location $location): int;
+    public function getSubtreeSize(Location $location, ?int $limit = null): int;
 
     /**
      * Creates the new $location in the content repository for the given content.

--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -133,7 +133,7 @@ interface LocationService
      * Return the subtree size of a given location.
      *
      * Warning! This method is not permission aware by design.
-     * 
+     *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
      * @param int|null $limit Optional limit to the number of locations to count. (Can be used to limit the number of locations counted in large subtrees.)
      */

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -3552,6 +3552,43 @@ class LocationServiceTest extends BaseTest
         return $location;
     }
 
+    public function testGetSubtreeSizeWithLimit(): Location
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $folder = $this->createFolder(['eng-GB' => 'Parent Folder'], 2);
+        $location = $folder->getVersionInfo()->getContentInfo()->getMainLocation();
+        self::assertSame(1, $locationService->getSubtreeSize($location));
+
+        for ($i = 1; $i <= 10; $i++) {
+            $this->createFolder(['eng-GB' => 'Child ' . $i], $location->id);
+        }
+
+        self::assertSame(3, $locationService->getSubtreeSize($location, 3));
+
+        return $location;
+    }
+
+     public function testGetSubtreeSizeWithInvalidLimitHasNoEffect(): Location
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $folder = $this->createFolder(['eng-GB' => 'Parent Folder'], 2);
+        $location = $folder->getVersionInfo()->getContentInfo()->getMainLocation();
+        self::assertSame(1, $locationService->getSubtreeSize($location));
+
+        for ($i = 1; $i <= 10; $i++) {
+            $this->createFolder(['eng-GB' => 'Child ' . $i], $location->id);
+        }
+
+
+        self::assertSame(11, $locationService->getSubtreeSize($location, -2));
+
+        return $location;
+    }
+
     /**
      * Loads properties from all locations in the $location's subtree.
      *

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -3561,7 +3561,7 @@ class LocationServiceTest extends BaseTest
         $location = $folder->getVersionInfo()->getContentInfo()->getMainLocation();
         self::assertSame(1, $locationService->getSubtreeSize($location));
 
-        for ($i = 1; $i <= 10; $i++) {
+        for ($i = 1; $i <= 10; ++$i) {
             $this->createFolder(['eng-GB' => 'Child ' . $i], $location->id);
         }
 
@@ -3570,7 +3570,7 @@ class LocationServiceTest extends BaseTest
         return $location;
     }
 
-     public function testGetSubtreeSizeWithInvalidLimitHasNoEffect(): Location
+    public function testGetSubtreeSizeWithInvalidLimitHasNoEffect(): Location
     {
         $repository = $this->getRepository();
         $locationService = $repository->getLocationService();
@@ -3579,10 +3579,9 @@ class LocationServiceTest extends BaseTest
         $location = $folder->getVersionInfo()->getContentInfo()->getMainLocation();
         self::assertSame(1, $locationService->getSubtreeSize($location));
 
-        for ($i = 1; $i <= 10; $i++) {
+        for ($i = 1; $i <= 10; ++$i) {
             $this->createFolder(['eng-GB' => 'Child ' . $i], $location->id);
         }
-
 
         self::assertSame(11, $locationService->getSubtreeSize($location, -2));
 

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -259,13 +259,13 @@ class LocationHandler extends AbstractInMemoryPersistenceHandler implements Loca
         return $this->persistenceHandler->locationHandler()->copySubtree($sourceId, $destinationParentId, $newOwnerId);
     }
 
-    public function getSubtreeSize(string $path): int
+    public function getSubtreeSize(string $path, ?int $limit = null): int
     {
         $this->logger->logCall(__METHOD__, [
             'path' => $path,
         ]);
 
-        return $this->persistenceHandler->locationHandler()->getSubtreeSize($path);
+        return $this->persistenceHandler->locationHandler()->getSubtreeSize($path, $limit);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -111,7 +111,7 @@ abstract class Gateway
      */
     abstract public function getSubtreeContent(int $sourceId, bool $onlyIds = false): array;
 
-    abstract public function getSubtreeSize(string $path): int;
+    abstract public function getSubtreeSize(string $path, ?int $limit = null): int;
 
     /**
      * Returns data for the first level children of the location identified by given $locationId.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -237,17 +237,30 @@ final class DoctrineDatabase extends Gateway
             : $results;
     }
 
-    public function getSubtreeSize(string $path): int
+    public function getSubtreeSize(string $path, ?int $limit = null): int
     {
-        $query = $this->createNodeQueryBuilder([$this->dbPlatform->getCountExpression('node_id')]);
+        $useLimit = $limit !== null && $limit > 0;
+
+        $query = $this->createNodeQueryBuilder([$useLimit ? 'node_id': $this->dbPlatform->getCountExpression('node_id')]);
         $query->andWhere(
-            $query->expr()->like(
+              $query->expr()->like(
                 't.path_string',
                 $query->createPositionalParameter(
                     $path . '%',
-                )
+                ),
             )
         );
+
+        if ($useLimit) {
+            $query->setMaxResults($limit);
+            $outerQuery = $this
+                ->connection
+                ->createQueryBuilder()
+                ->select($this->dbPlatform->getCountExpression( '*'))
+                ->from('(' . $query->getSQL() . ')', 't')  
+                ->setParameters($query->getParameters());
+            return (int) $outerQuery->execute()->fetchOne();
+        }
 
         return (int) $query->execute()->fetchOne();
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -241,9 +241,9 @@ final class DoctrineDatabase extends Gateway
     {
         $useLimit = $limit !== null && $limit > 0;
 
-        $query = $this->createNodeQueryBuilder([$useLimit ? 'node_id': $this->dbPlatform->getCountExpression('node_id')]);
+        $query = $this->createNodeQueryBuilder([$useLimit ? 'node_id' : $this->dbPlatform->getCountExpression('node_id')]);
         $query->andWhere(
-              $query->expr()->like(
+            $query->expr()->like(
                 't.path_string',
                 $query->createPositionalParameter(
                     $path . '%',
@@ -256,9 +256,10 @@ final class DoctrineDatabase extends Gateway
             $outerQuery = $this
                 ->connection
                 ->createQueryBuilder()
-                ->select($this->dbPlatform->getCountExpression( '*'))
-                ->from('(' . $query->getSQL() . ')', 't')  
+                ->select($this->dbPlatform->getCountExpression('*'))
+                ->from('(' . $query->getSQL() . ')', 't')
                 ->setParameters($query->getParameters());
+
             return (int) $outerQuery->execute()->fetchOne();
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -106,10 +106,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function getSubtreeSize(string $path): int
+    public function getSubtreeSize(string $path, ?int $limit = null): int
     {
         try {
-            return $this->innerGateway->getSubtreeSize($path);
+            return $this->innerGateway->getSubtreeSize($path, $limit);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -346,9 +346,9 @@ class Handler implements BaseLocationHandler
         return $copiedSubtreeRootLocation;
     }
 
-    public function getSubtreeSize(string $path): int
+    public function getSubtreeSize(string $path, ?int $limit = null): int
     {
-        return $this->locationGateway->getSubtreeSize($path);
+        return $this->locationGateway->getSubtreeSize($path, $limit);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -379,10 +379,11 @@ class LocationService implements LocationServiceInterface
         return $this->count($filter);
     }
 
-    public function getSubtreeSize(APILocation $location): int
+    public function getSubtreeSize(APILocation $location, ?int $limit = null): int
     {
         return $this->persistenceHandler->locationHandler()->getSubtreeSize(
-            $location->getPathString()
+            $location->getPathString(),
+            $limit
         );
     }
 

--- a/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
@@ -109,9 +109,9 @@ class LocationService implements LocationServiceInterface
         return $this->service->getLocationChildCount($location);
     }
 
-    public function getSubtreeSize(Location $location): int
+    public function getSubtreeSize(Location $location, ?int $limit = null): int
     {
-        return $this->service->getSubtreeSize($location);
+        return $this->service->getSubtreeSize($location, $limit);
     }
 
     public function createLocation(ContentInfo $contentInfo, LocationCreateStruct $locationCreateStruct): Location

--- a/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
@@ -110,7 +110,7 @@ interface Handler
      */
     public function copySubtree($sourceId, $destinationParentId);
 
-    public function getSubtreeSize(string $path): int;
+    public function getSubtreeSize(string $path, ?int $limit = null): int;
 
     /**
      * Moves location identified by $sourceId into new parent identified by $destinationParentId.

--- a/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
@@ -87,9 +87,9 @@ abstract class LocationServiceDecorator implements LocationService
         return $this->innerService->getLocationChildCount($location);
     }
 
-    public function getSubtreeSize(Location $location): int
+    public function getSubtreeSize(Location $location, ?int $limit = null): int
     {
-        return $this->innerService->getSubtreeSize($location);
+        return $this->innerService->getSubtreeSize($location, $limit);
     }
 
     public function createLocation(


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                          | [IBX-10174](https://issues.ibexa.co/browse/IBX-10174)
| **Type**                                   | bug
| **Target Ibexa version** | `v3/V4`
| **BC breaks**                          | no
| **Required by**                      | https://github.com/ezsystems/ezplatform-admin-ui/pull/2124


# What
This PR adds a new "$limit" option to the `LocationService::getSubtreeSize` query in order to reduce the effects of expensive count queries within the CMS. 

In https://github.com/ezsystems/ezplatform-kernel/pull/360 the `LocationService::getSubtreeSize` was introduced to address prior issues with the prior `LocationService::count` being two slow. This PR aims to follow on from that by addressing further issues with `LocationService::getSubtreeSize` resulting in disproportionately slow queries in it's own right.

This has been done by adding a function to limit the overall selected `subTree` size by changing the public API from 
```php
interface LocationService {
    # ...

    public function getSubtreeSize(Location $location): int;

    # ...
}
```
To
```php
interface LocationService {
    # ...

    public function getSubtreeSize(Location $location, ?int $limit  = null): int;

    # ...
}
```

# Why
In some circumstances (Where a content object may have a large number of child items) the impact of a single call to the `getSubtreeSize` function can account for over 30 percent of the total page load time

See the following flame chart for loading the "view" page in the CMS for a content object with a large number of sub-items:
![image](https://github.com/user-attachments/assets/ab170e62-7e30-4882-9a2d-3110e0f37828)

With this patch included this becomes
![image](https://github.com/user-attachments/assets/080e1270-1082-4009-9b23-b9d9b03a63af)

The time the function takes to resolve falls from `407MS` -> `1MS` for what is functionally the same query.

# How
This PR introduces a `$limit` parameter that targets the use case presented by `IsWithinCopySubtreeLimit` (The only usecase presented by the current eZ Codebase). The query is aiming to ascertain if there are **more than** a number of given number of sub items in a content object tree. 

The current implementation is prone to over scanning the table due to there being no limit properly set on the table in relation to the primary usecase for the function.

The query it currently generates is:
```sql
SELECT COUNT(node_id) FROM ezcontentobject_tree t WHERE t.path_string LIKE '/1/2/80/136/%'; 
```
Which performs an entire table scan against existing indexes:
```
-> Aggregate: count(t.node_id)  (cost=78629.40 rows=1) (actual time=550.231..550.232 rows=1 loops=1)    -> Filter: (t.path_string like '/1/2/80/136/%')  (cost=58454.40 rows=201750) (actual time=0.028..547.540 rows=85943 loops=1)        -> Covering index range scan on t using ezcontentobject_tree_path over ('/1/2/80/136/                                                                                                                                                                              ' <= path_string <= '/1/2/80/136/????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????')  (cost=58454.40 rows=201750) (actual time=0.024..538.213 rows=85943 loops=1) |
```

In the new approach the  query is terminated early resulting in much faster query times
```sql
 SELECT COUNT(*) FROM (SELECT t.node_id FROM ezcontentobject_tree t WHERE t.path_string LIKE '/1/2/80/136/%' LIMIT 100) AS x;
```
which gives
```
-> Aggregate: count(0)  (cost=58463.76..58463.76 rows=1) (actual time=0.508..0.508 rows=1 loops=1)    -> Table scan on x  (cost=0.04..3.75 rows=100) (actual time=0.002..0.004 rows=100 loops=1)        -> Materialize  (cost=58450.05..58453.76 rows=100) (actual time=0.496..0.502 rows=100 loops=1)            -> Limit: 100 row(s)  (cost=58440.01 rows=100) (actual time=0.045..0.469 rows=100 loops=1)                -> Filter: (t.path_string like '/1/2/80/136/%')  (cost=58440.01 rows=201750) (actual time=0.044..0.463 rows=100 loops=1)                    -> Covering index range scan on t using ezcontentobject_tree_path over ('/1/2/80/136/                                                                                                                                                                  ' <= path_string <= '/1/2/80/136/????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????')  (cost=58440.01 rows=201750) (actual time=0.039..0.446 rows=100 loops=1) |
```

Special care has been taken so that no existing code paths should be effected by this change given the new query is only used _if_ a limitation is supplied (where by default it is not)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
