### PR TITLE
IBX-10186 Add $limit Option to Count

### DIFF
--- a/eZ/Publish/API/Repository/ContentService.php
+++ b/eZ/Publish/API/Repository/ContentService.php
@@ -588,6 +588,8 @@ interface ContentService
      * @param string[] $languages a list of language codes to be added as additional constraints.
      *        If skipped, by default, unless SiteAccessAware layer has been disabled, languages set
      *        for a SiteAccess in a current context will be used.
+     * @param int|null $limit If set, the count will be limited to first $limit items found.
+     *        In some cases it can significantly speed up a count operation for more complex filters.
      */
-    public function count(Filter $filter, ?array $languages = null): int;
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int;
 }

--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -127,7 +127,7 @@ interface LocationService
      *
      * @return int
      */
-    public function getLocationChildCount(Location $location): int;
+    public function getLocationChildCount(Location $location, ?int $limit = null): int;
 
     /**
      * Return the subtree size of a given location.
@@ -278,6 +278,8 @@ interface LocationService
      * @param string[] $languages a list of language codes to be added as additional constraints.
      *        If skipped, by default, unless SiteAccessAware layer has been disabled, languages set
      *        for a SiteAccess in a current context will be used.
+     * @param int|null $limit If set, the count will be limited to first $limit items found.
+     *        In some cases it can significantly speed up a count operation for more complex filters.
      */
-    public function count(Filter $filter, ?array $languages = null): int;
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int;
 }

--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -133,8 +133,11 @@ interface LocationService
      * Return the subtree size of a given location.
      *
      * Warning! This method is not permission aware by design.
+     * 
+     * @param \eZ\Publish\API\Repository\Values\Content\Location $location
+     * @param int|null $limit Optional limit to the number of locations to count. (Can be used to limit the number of locations counted in large subtrees.)
      */
-    public function getSubtreeSize(Location $location): int;
+    public function getSubtreeSize(Location $location, ?int $limit = null): int;
 
     /**
      * Creates the new $location in the content repository for the given content.

--- a/eZ/Publish/API/Repository/LocationService.php
+++ b/eZ/Publish/API/Repository/LocationService.php
@@ -133,7 +133,7 @@ interface LocationService
      * Return the subtree size of a given location.
      *
      * Warning! This method is not permission aware by design.
-     * 
+     *
      * @param \eZ\Publish\API\Repository\Values\Content\Location $location
      * @param int|null $limit Optional limit to the number of locations to count. (Can be used to limit the number of locations counted in large subtrees.)
      */

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -3552,6 +3552,43 @@ class LocationServiceTest extends BaseTest
         return $location;
     }
 
+    public function testGetSubtreeSizeWithLimit(): Location
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $folder = $this->createFolder(['eng-GB' => 'Parent Folder'], 2);
+        $location = $folder->getVersionInfo()->getContentInfo()->getMainLocation();
+        self::assertSame(1, $locationService->getSubtreeSize($location));
+
+        for ($i = 1; $i <= 10; $i++) {
+            $this->createFolder(['eng-GB' => 'Child ' . $i], $location->id);
+        }
+
+        self::assertSame(3, $locationService->getSubtreeSize($location, 3));
+
+        return $location;
+    }
+
+     public function testGetSubtreeSizeWithInvalidLimitHasNoEffect(): Location
+    {
+        $repository = $this->getRepository();
+        $locationService = $repository->getLocationService();
+
+        $folder = $this->createFolder(['eng-GB' => 'Parent Folder'], 2);
+        $location = $folder->getVersionInfo()->getContentInfo()->getMainLocation();
+        self::assertSame(1, $locationService->getSubtreeSize($location));
+
+        for ($i = 1; $i <= 10; $i++) {
+            $this->createFolder(['eng-GB' => 'Child ' . $i], $location->id);
+        }
+
+
+        self::assertSame(11, $locationService->getSubtreeSize($location, -2));
+
+        return $location;
+    }
+
     /**
      * Loads properties from all locations in the $location's subtree.
      *

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1114,6 +1114,26 @@ class LocationServiceTest extends BaseTest
         );
     }
 
+     /**
+     * Test for the getLocationChildCount() method with a limitation on the number of children.
+     *
+     * @see \eZ\Publish\API\Repository\LocationService::getLocationChildCount()
+     * @depends eZ\Publish\API\Repository\Tests\LocationServiceTest::testLoadLocation
+     */
+    public function testGetLocationChildCountWithLimitation()
+    {
+        // $locationId is the ID of an existing location
+        $locationService = $this->getRepository()->getLocationService();
+
+        $this->assertSame(
+            2,
+            $locationService->getLocationChildCount(
+                $locationService->loadLocation($this->generateId('location', 5)),
+                2
+            )
+        );
+    }
+
     /**
      * Test for the loadLocationChildren() method.
      *

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -3561,7 +3561,7 @@ class LocationServiceTest extends BaseTest
         $location = $folder->getVersionInfo()->getContentInfo()->getMainLocation();
         self::assertSame(1, $locationService->getSubtreeSize($location));
 
-        for ($i = 1; $i <= 10; $i++) {
+        for ($i = 1; $i <= 10; ++$i) {
             $this->createFolder(['eng-GB' => 'Child ' . $i], $location->id);
         }
 
@@ -3570,7 +3570,7 @@ class LocationServiceTest extends BaseTest
         return $location;
     }
 
-     public function testGetSubtreeSizeWithInvalidLimitHasNoEffect(): Location
+    public function testGetSubtreeSizeWithInvalidLimitHasNoEffect(): Location
     {
         $repository = $this->getRepository();
         $locationService = $repository->getLocationService();
@@ -3579,10 +3579,9 @@ class LocationServiceTest extends BaseTest
         $location = $folder->getVersionInfo()->getContentInfo()->getMainLocation();
         self::assertSame(1, $locationService->getSubtreeSize($location));
 
-        for ($i = 1; $i <= 10; $i++) {
+        for ($i = 1; $i <= 10; ++$i) {
             $this->createFolder(['eng-GB' => 'Child ' . $i], $location->id);
         }
-
 
         self::assertSame(11, $locationService->getSubtreeSize($location, -2));
 

--- a/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
+++ b/eZ/Publish/API/Repository/Tests/LocationServiceTest.php
@@ -1114,7 +1114,7 @@ class LocationServiceTest extends BaseTest
         );
     }
 
-     /**
+    /**
      * Test for the getLocationChildCount() method with a limitation on the number of children.
      *
      * @see \eZ\Publish\API\Repository\LocationService::getLocationChildCount()

--- a/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
+++ b/eZ/Publish/Core/Persistence/Cache/LocationHandler.php
@@ -259,13 +259,13 @@ class LocationHandler extends AbstractInMemoryPersistenceHandler implements Loca
         return $this->persistenceHandler->locationHandler()->copySubtree($sourceId, $destinationParentId, $newOwnerId);
     }
 
-    public function getSubtreeSize(string $path): int
+    public function getSubtreeSize(string $path, ?int $limit = null): int
     {
         $this->logger->logCall(__METHOD__, [
             'path' => $path,
         ]);
 
-        return $this->persistenceHandler->locationHandler()->getSubtreeSize($path);
+        return $this->persistenceHandler->locationHandler()->getSubtreeSize($path, $limit);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway.php
@@ -111,7 +111,7 @@ abstract class Gateway
      */
     abstract public function getSubtreeContent(int $sourceId, bool $onlyIds = false): array;
 
-    abstract public function getSubtreeSize(string $path): int;
+    abstract public function getSubtreeSize(string $path, ?int $limit = null): int;
 
     /**
      * Returns data for the first level children of the location identified by given $locationId.

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -237,17 +237,30 @@ final class DoctrineDatabase extends Gateway
             : $results;
     }
 
-    public function getSubtreeSize(string $path): int
+    public function getSubtreeSize(string $path, ?int $limit = null): int
     {
-        $query = $this->createNodeQueryBuilder([$this->dbPlatform->getCountExpression('node_id')]);
+        $useLimit = $limit !== null && $limit > 0;
+
+        $query = $this->createNodeQueryBuilder([$useLimit ? 'node_id': $this->dbPlatform->getCountExpression('node_id')]);
         $query->andWhere(
-            $query->expr()->like(
+              $query->expr()->like(
                 't.path_string',
                 $query->createPositionalParameter(
                     $path . '%',
-                )
+                ),
             )
         );
+
+        if ($useLimit) {
+            $query->setMaxResults($limit);
+            $outerQuery = $this
+                ->connection
+                ->createQueryBuilder()
+                ->select($this->dbPlatform->getCountExpression( '*'))
+                ->from('(' . $query->getSQL() . ')', 't')  
+                ->setParameters($query->getParameters());
+            return (int) $outerQuery->execute()->fetchOne();
+        }
 
         return (int) $query->execute()->fetchOne();
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -16,6 +16,7 @@ use eZ\Publish\Core\Base\Exceptions\NotFoundException as NotFound;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Language\MaskGenerator;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway;
+use eZ\Publish\Core\Persistence\Legacy\Traits\Doctrine\LimitedCountQueryTrait;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\CriteriaConverter;
 use eZ\Publish\Core\Search\Legacy\Content\Common\Gateway\SortClauseConverter;
 use eZ\Publish\SPI\Persistence\Content\ContentInfo;
@@ -35,6 +36,8 @@ use function time;
  */
 final class DoctrineDatabase extends Gateway
 {
+    use LimitedCountQueryTrait;
+
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
@@ -239,9 +242,7 @@ final class DoctrineDatabase extends Gateway
 
     public function getSubtreeSize(string $path, ?int $limit = null): int
     {
-        $useLimit = $limit !== null && $limit > 0;
-
-        $query = $this->createNodeQueryBuilder([$useLimit ? 'node_id' : $this->dbPlatform->getCountExpression('node_id')]);
+        $query = $this->createNodeQueryBuilder([$this->dbPlatform->getCountExpression('node_id')]);
         $query->andWhere(
             $query->expr()->like(
                 't.path_string',
@@ -251,17 +252,11 @@ final class DoctrineDatabase extends Gateway
             )
         );
 
-        if ($useLimit) {
-            $query->setMaxResults($limit);
-            $outerQuery = $this
-                ->connection
-                ->createQueryBuilder()
-                ->select($this->dbPlatform->getCountExpression('*'))
-                ->from('(' . $query->getSQL() . ')', 't')
-                ->setParameters($query->getParameters());
-
-            return (int) $outerQuery->execute()->fetchOne();
-        }
+        $query = $this->wrapCountQuery(
+            $query,
+            't.node_id',
+            $limit
+        );
 
         return (int) $query->execute()->fetchOne();
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/DoctrineDatabase.php
@@ -241,9 +241,9 @@ final class DoctrineDatabase extends Gateway
     {
         $useLimit = $limit !== null && $limit > 0;
 
-        $query = $this->createNodeQueryBuilder([$useLimit ? 'node_id': $this->dbPlatform->getCountExpression('node_id')]);
+        $query = $this->createNodeQueryBuilder([$useLimit ? 'node_id' : $this->dbPlatform->getCountExpression('node_id')]);
         $query->andWhere(
-              $query->expr()->like(
+            $query->expr()->like(
                 't.path_string',
                 $query->createPositionalParameter(
                     $path . '%',
@@ -256,9 +256,10 @@ final class DoctrineDatabase extends Gateway
             $outerQuery = $this
                 ->connection
                 ->createQueryBuilder()
-                ->select($this->dbPlatform->getCountExpression( '*'))
-                ->from('(' . $query->getSQL() . ')', 't')  
+                ->select($this->dbPlatform->getCountExpression('*'))
+                ->from('(' . $query->getSQL() . ')', 't')
                 ->setParameters($query->getParameters());
+
             return (int) $outerQuery->execute()->fetchOne();
         }
 

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Gateway/ExceptionConversion.php
@@ -106,10 +106,10 @@ final class ExceptionConversion extends Gateway
         }
     }
 
-    public function getSubtreeSize(string $path): int
+    public function getSubtreeSize(string $path, ?int $limit = null): int
     {
         try {
-            return $this->innerGateway->getSubtreeSize($path);
+            return $this->innerGateway->getSubtreeSize($path, $limit);
         } catch (DBALException | PDOException $e) {
             throw DatabaseException::wrap($e);
         }

--- a/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Content/Location/Handler.php
@@ -346,9 +346,9 @@ class Handler implements BaseLocationHandler
         return $copiedSubtreeRootLocation;
     }
 
-    public function getSubtreeSize(string $path): int
+    public function getSubtreeSize(string $path, ?int $limit = null): int
     {
-        return $this->locationGateway->getSubtreeSize($path);
+        return $this->locationGateway->getSubtreeSize($path, $limit);
     }
 
     /**

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Content/Doctrine/DoctrineGateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Content/Doctrine/DoctrineGateway.php
@@ -87,12 +87,32 @@ final class DoctrineGateway implements Gateway
         }
     }
 
-    public function count(FilteringCriterion $criterion): int
+    public function count(FilteringCriterion $criterion, ?int $limit = null): int
     {
+        $useLimit = $limit !== null && $limit > 0;
+
         $query = $this->buildQuery(
-            [$this->getDatabasePlatform()->getCountExpression('DISTINCT content.id')],
-            $criterion
+            [$useLimit ?
+            'content.id' :
+             $this->getDatabasePlatform()->getCountExpression('DISTINCT content.id')],
+             $criterion
         );
+
+
+        if ($useLimit) {
+            $query->setMaxResults($limit);
+            $outerQuery = $this->connection->createQueryBuilder();
+            $outerQuery
+                ->select(
+                    $this->getDatabasePlatform()->getCountExpression('*')
+                )
+                ->from('(' . $query->getSQL() . ')', 'subquery')
+                ->setParameters($query->getParameters(), $query->getParameterTypes())
+            ;
+            
+           
+            return (int)$outerQuery->execute()->fetch(FetchMode::COLUMN);
+        }
 
         return (int)$query->execute()->fetch(FetchMode::COLUMN);
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Content/Doctrine/DoctrineGateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Content/Doctrine/DoctrineGateway.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Persistence\Legacy\Filter\Gateway\Content\Doctrine;
 
-use eZ\Publish\Core\Persistence\Legacy\Traits\Doctrine\LimitedCountQueryTrait;
 use function array_filter;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
@@ -19,6 +18,7 @@ use eZ\Publish\Core\Base\Exceptions\DatabaseException;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
 use eZ\Publish\Core\Persistence\Legacy\Filter\Gateway\Gateway;
+use eZ\Publish\Core\Persistence\Legacy\Traits\Doctrine\LimitedCountQueryTrait;
 use eZ\Publish\SPI\Persistence\Filter\CriterionVisitor;
 use eZ\Publish\SPI\Persistence\Filter\Doctrine\FilteringQueryBuilder;
 use eZ\Publish\SPI\Persistence\Filter\SortClauseVisitor;
@@ -94,7 +94,7 @@ final class DoctrineGateway implements Gateway
     {
         $query = $this->buildQuery(
             [$this->getDatabasePlatform()->getCountExpression('DISTINCT content.id')],
-             $criterion
+            $criterion
         );
 
         $query = $this->wrapCountQuery(

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Content/Doctrine/DoctrineGateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Content/Doctrine/DoctrineGateway.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace eZ\Publish\Core\Persistence\Legacy\Filter\Gateway\Content\Doctrine;
 
+use eZ\Publish\Core\Persistence\Legacy\Traits\Doctrine\LimitedCountQueryTrait;
 use function array_filter;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
@@ -31,6 +32,8 @@ use Traversable;
  */
 final class DoctrineGateway implements Gateway
 {
+    use LimitedCountQueryTrait;
+
     public const COLUMN_MAP = [
         // Content Info
         'content_id' => 'content.id',
@@ -89,30 +92,16 @@ final class DoctrineGateway implements Gateway
 
     public function count(FilteringCriterion $criterion, ?int $limit = null): int
     {
-        $useLimit = $limit !== null && $limit > 0;
-
         $query = $this->buildQuery(
-            [$useLimit ?
-            'content.id' :
-             $this->getDatabasePlatform()->getCountExpression('DISTINCT content.id')],
+            [$this->getDatabasePlatform()->getCountExpression('DISTINCT content.id')],
              $criterion
         );
 
-
-        if ($useLimit) {
-            $query->setMaxResults($limit);
-            $outerQuery = $this->connection->createQueryBuilder();
-            $outerQuery
-                ->select(
-                    $this->getDatabasePlatform()->getCountExpression('*')
-                )
-                ->from('(' . $query->getSQL() . ')', 'subquery')
-                ->setParameters($query->getParameters(), $query->getParameterTypes())
-            ;
-            
-           
-            return (int)$outerQuery->execute()->fetch(FetchMode::COLUMN);
-        }
+        $query = $this->wrapCountQuery(
+            $query,
+            'content.id',
+            $limit
+        );
 
         return (int)$query->execute()->fetch(FetchMode::COLUMN);
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Gateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Gateway.php
@@ -18,9 +18,9 @@ use eZ\Publish\SPI\Repository\Values\Filter\FilteringCriterion;
 interface Gateway
 {
     /**
-     * Return number of matched rows for the given Criteria (a total count w/o pagination constraints).
+     * Return number of matched rows for the given Criteria (a total count w/o pagination constraints unless an upper limit is applied).
      */
-    public function count(FilteringCriterion $criterion): int;
+    public function count(FilteringCriterion $criterion, ?int $limit = null): int;
 
     /**
      * Return iterator for raw Repository data for the given Query result filtered by the given Criteria,

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Location/Doctrine/DoctrineGateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Location/Doctrine/DoctrineGateway.php
@@ -12,6 +12,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Exception;
 use eZ\Publish\Core\Base\Exceptions\DatabaseException;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
@@ -54,11 +55,32 @@ final class DoctrineGateway implements Gateway
         }
     }
 
-    public function count(FilteringCriterion $criterion): int
+    public function count(FilteringCriterion $criterion, ?int $limit = null): int
     {
+        $useLimit = $limit !== null && $limit > 0;
         $query = $this->buildQuery($criterion);
 
-        $query->select($this->getDatabasePlatform()->getCountExpression('DISTINCT location.node_id'));
+        $query->select(
+            $useLimit ?
+            'location.node_id' :
+             $this->getDatabasePlatform()->getCountExpression('DISTINCT location.node_id')
+        );
+
+
+        if ($useLimit) {
+            $query->setMaxResults($limit);
+            $outerQuery = $this->connection->createQueryBuilder();
+            $outerQuery
+                ->select(
+                    $this->getDatabasePlatform()->getCountExpression('*')
+                )
+                ->from('(' . $query->getSQL() . ')', 'subquery')
+                ->setParameters($query->getParameters(), $query->getParameterTypes())
+            ;
+            
+           
+            return (int)$outerQuery->execute()->fetch(FetchMode::COLUMN);
+        }
 
         return (int)$query->execute()->fetch(FetchMode::COLUMN);
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Location/Doctrine/DoctrineGateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Location/Doctrine/DoctrineGateway.php
@@ -12,7 +12,6 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\DBALException;
 use Doctrine\DBAL\FetchMode;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
-use Exception;
 use eZ\Publish\Core\Base\Exceptions\DatabaseException;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Location/Doctrine/DoctrineGateway.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Gateway/Location/Doctrine/DoctrineGateway.php
@@ -17,6 +17,7 @@ use eZ\Publish\Core\Base\Exceptions\DatabaseException;
 use eZ\Publish\Core\Persistence\Legacy\Content\Gateway as ContentGateway;
 use eZ\Publish\Core\Persistence\Legacy\Content\Location\Gateway as LocationGateway;
 use eZ\Publish\Core\Persistence\Legacy\Filter\Gateway\Gateway;
+use eZ\Publish\Core\Persistence\Legacy\Traits\Doctrine\LimitedCountQueryTrait;
 use eZ\Publish\SPI\Persistence\Filter\CriterionVisitor;
 use eZ\Publish\SPI\Persistence\Filter\Doctrine\FilteringQueryBuilder;
 use eZ\Publish\SPI\Persistence\Filter\SortClauseVisitor;
@@ -27,6 +28,8 @@ use eZ\Publish\SPI\Repository\Values\Filter\FilteringCriterion;
  */
 final class DoctrineGateway implements Gateway
 {
+    use LimitedCountQueryTrait;
+
     /** @var \Doctrine\DBAL\Connection */
     private $connection;
 
@@ -57,30 +60,15 @@ final class DoctrineGateway implements Gateway
 
     public function count(FilteringCriterion $criterion, ?int $limit = null): int
     {
-        $useLimit = $limit !== null && $limit > 0;
         $query = $this->buildQuery($criterion);
 
-        $query->select(
-            $useLimit ?
-            'location.node_id' :
-             $this->getDatabasePlatform()->getCountExpression('DISTINCT location.node_id')
+        $query->select($this->getDatabasePlatform()->getCountExpression('DISTINCT location.node_id'));
+
+        $query = $this->wrapCountQuery(
+            $query,
+            'location.node_id',
+            $limit
         );
-
-
-        if ($useLimit) {
-            $query->setMaxResults($limit);
-            $outerQuery = $this->connection->createQueryBuilder();
-            $outerQuery
-                ->select(
-                    $this->getDatabasePlatform()->getCountExpression('*')
-                )
-                ->from('(' . $query->getSQL() . ')', 'subquery')
-                ->setParameters($query->getParameters(), $query->getParameterTypes())
-            ;
-            
-           
-            return (int)$outerQuery->execute()->fetch(FetchMode::COLUMN);
-        }
 
         return (int)$query->execute()->fetch(FetchMode::COLUMN);
     }

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Handler/ContentFilteringHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Handler/ContentFilteringHandler.php
@@ -73,8 +73,8 @@ final class ContentFilteringHandler implements Handler
         return $list;
     }
 
-    public function count(Filter $filter): int
+    public function count(Filter $filter, ?int $limit = null): int
     {
-        return $this->gateway->count($filter->getCriterion());
+        return $this->gateway->count($filter->getCriterion(), $limit);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Filter/Handler/LocationFilteringHandler.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Filter/Handler/LocationFilteringHandler.php
@@ -69,8 +69,8 @@ class LocationFilteringHandler implements Handler
         return $list;
     }
 
-    public function count(Filter $filter): int
+    public function count(Filter $filter, ?int $limit = null): int
     {
-        return $this->gateway->count($filter->getCriterion());
+        return $this->gateway->count($filter->getCriterion(), $limit);
     }
 }

--- a/eZ/Publish/Core/Persistence/Legacy/Traits/Doctrine/LimitedCountQueryTrait.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Traits/Doctrine/LimitedCountQueryTrait.php
@@ -17,15 +17,16 @@ use Doctrine\DBAL\Query\QueryBuilder;
 trait LimitedCountQueryTrait
 {
     /**
-     * Takes a QueryBuilder and wraps it in a count query. 
+     * Takes a QueryBuilder and wraps it in a count query.
      * This performs the following transformation to the passed query
      * SELECT DISTINCT COUNT(DISTINCT someField) FROM XXX WHERE YYY;
      * To
-     * SELECT COUNT(*) FROM (SELECT DISTINCT someField FROM XXX WHERE YYY LIMIT N) AS csub;
-     * 
+     * SELECT COUNT(*) FROM (SELECT DISTINCT someField FROM XXX WHERE YYY LIMIT N) AS csub;.
+     *
      * @param \Doctrine\DBAL\Query\QueryBuilder $queryBuilder
      * @param string $countableField
      * @param mixed $limit
+     *
      * @return \Doctrine\DBAL\Query\QueryBuilder
      */
     protected function wrapCountQuery(
@@ -35,7 +36,7 @@ trait LimitedCountQueryTrait
     ): QueryBuilder {
         $useLimit = $limit !== null && $limit > 0;
 
-        if(!$useLimit) {
+        if (!$useLimit) {
             return $queryBuilder;
         }
 
@@ -44,6 +45,7 @@ trait LimitedCountQueryTrait
             ->getSQL();
 
         $countQuery = $this->connection->createQueryBuilder();
+
         return $countQuery
             ->select(
                 $queryBuilder->getConnection()->getDatabasePlatform()->getCountExpression('*')

--- a/eZ/Publish/Core/Persistence/Legacy/Traits/Doctrine/LimitedCountQueryTrait.php
+++ b/eZ/Publish/Core/Persistence/Legacy/Traits/Doctrine/LimitedCountQueryTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @copyright Copyright (C) Ibexa AS. All rights reserved.
+ * @license For full copyright and license information view LICENSE file distributed with this source code.
+ */
+declare(strict_types=1);
+
+namespace eZ\Publish\Core\Persistence\Legacy\Traits\Doctrine;
+
+use Doctrine\DBAL\Query\QueryBuilder;
+
+/**
+ * Limited Count count trait. Used to allow for proper limiting of count queries
+ * when using Doctrine DBAL QueryBuilder.
+ */
+trait LimitedCountQueryTrait
+{
+    /**
+     * Takes a QueryBuilder and wraps it in a count query. 
+     * This performs the following transformation to the passed query
+     * SELECT DISTINCT COUNT(DISTINCT someField) FROM XXX WHERE YYY;
+     * To
+     * SELECT COUNT(*) FROM (SELECT DISTINCT someField FROM XXX WHERE YYY LIMIT N) AS csub;
+     * 
+     * @param \Doctrine\DBAL\Query\QueryBuilder $queryBuilder
+     * @param string $countableField
+     * @param mixed $limit
+     * @return \Doctrine\DBAL\Query\QueryBuilder
+     */
+    protected function wrapCountQuery(
+        QueryBuilder $queryBuilder,
+        string $countableField,
+        ?int $limit,
+    ): QueryBuilder {
+        $useLimit = $limit !== null && $limit > 0;
+
+        if(!$useLimit) {
+            return $queryBuilder;
+        }
+
+        $querySql = $queryBuilder->select($countableField)
+            ->setMaxResults($limit)
+            ->getSQL();
+
+        $countQuery = $this->connection->createQueryBuilder();
+        return $countQuery
+            ->select(
+                $queryBuilder->getConnection()->getDatabasePlatform()->getCountExpression('*')
+            )
+            ->from('(' . $querySql . ')', 'csub')
+            ->setParameters($queryBuilder->getParameters(), $queryBuilder->getParameterTypes());
+    }
+}

--- a/eZ/Publish/Core/Repository/ContentService.php
+++ b/eZ/Publish/Core/Repository/ContentService.php
@@ -2626,7 +2626,7 @@ class ContentService implements ContentServiceInterface
         return new ContentList($contentItemsIterator->getTotalCount(), $contentItems);
     }
 
-    public function count(Filter $filter, ?array $languages = null): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int
     {
         $filter = clone $filter;
         if (!empty($languages)) {
@@ -2646,6 +2646,6 @@ class ContentService implements ContentServiceInterface
             $filter->andWithCriterion($permissionCriterion);
         }
 
-        return $this->contentFilteringHandler->count($filter);
+        return $this->contentFilteringHandler->count($filter, $limit);
     }
 }

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -372,11 +372,11 @@ class LocationService implements LocationServiceInterface
     /**
      * Returns the number of children which are readable by the current user of a Location object.
      */
-    public function getLocationChildCount(APILocation $location, ?int $limit =  null): int
+    public function getLocationChildCount(APILocation $location, ?int $limit = null): int
     {
         $filter = $this->buildLocationChildrenFilter($location);
 
-        return $this->count($filter,null, $limit);
+        return $this->count($filter, null, $limit);
     }
 
     public function getSubtreeSize(APILocation $location, ?int $limit = null): int

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -379,10 +379,11 @@ class LocationService implements LocationServiceInterface
         return $this->count($filter);
     }
 
-    public function getSubtreeSize(APILocation $location): int
+    public function getSubtreeSize(APILocation $location, ?int $limit = null): int
     {
         return $this->persistenceHandler->locationHandler()->getSubtreeSize(
-            $location->getPathString()
+            $location->getPathString(),
+            $limit
         );
     }
 

--- a/eZ/Publish/Core/Repository/LocationService.php
+++ b/eZ/Publish/Core/Repository/LocationService.php
@@ -372,11 +372,11 @@ class LocationService implements LocationServiceInterface
     /**
      * Returns the number of children which are readable by the current user of a Location object.
      */
-    public function getLocationChildCount(APILocation $location): int
+    public function getLocationChildCount(APILocation $location, ?int $limit =  null): int
     {
         $filter = $this->buildLocationChildrenFilter($location);
 
-        return $this->count($filter);
+        return $this->count($filter,null, $limit);
     }
 
     public function getSubtreeSize(APILocation $location, ?int $limit = null): int
@@ -944,7 +944,7 @@ class LocationService implements LocationServiceInterface
         );
     }
 
-    public function count(Filter $filter, ?array $languages = null): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int
     {
         $filter = clone $filter;
         if (!empty($languages)) {
@@ -964,7 +964,7 @@ class LocationService implements LocationServiceInterface
             $filter->andWithCriterion($permissionCriterion);
         }
 
-        return $this->locationFilteringHandler->count($filter);
+        return $this->locationFilteringHandler->count($filter, $limit);
     }
 
     /**

--- a/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/ContentService.php
@@ -284,11 +284,12 @@ class ContentService implements ContentServiceInterface
         );
     }
 
-    public function count(Filter $filter, ?array $languages = null): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int
     {
         return $this->service->count(
             $filter,
-            $this->languageResolver->getPrioritizedLanguages($languages)
+            $this->languageResolver->getPrioritizedLanguages($languages),
+            $limit
         );
     }
 }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
@@ -104,9 +104,9 @@ class LocationService implements LocationServiceInterface
         );
     }
 
-    public function getLocationChildCount(Location $location): int
+    public function getLocationChildCount(Location $location, ?int $limit = null ): int
     {
-        return $this->service->getLocationChildCount($location);
+        return $this->service->getLocationChildCount($location, $limit);
     }
 
     public function getSubtreeSize(Location $location, ?int $limit = null): int
@@ -192,11 +192,12 @@ class LocationService implements LocationServiceInterface
         );
     }
 
-    public function count(Filter $filter, ?array $languages = null): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int
     {
         return $this->service->count(
             $filter,
-            $this->languageResolver->getPrioritizedLanguages($languages)
+            $this->languageResolver->getPrioritizedLanguages($languages),
+            $limit
         );
     }
 }

--- a/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
+++ b/eZ/Publish/Core/Repository/SiteAccessAware/LocationService.php
@@ -109,9 +109,9 @@ class LocationService implements LocationServiceInterface
         return $this->service->getLocationChildCount($location);
     }
 
-    public function getSubtreeSize(Location $location): int
+    public function getSubtreeSize(Location $location, ?int $limit = null): int
     {
-        return $this->service->getSubtreeSize($location);
+        return $this->service->getSubtreeSize($location, $limit);
     }
 
     public function createLocation(ContentInfo $contentInfo, LocationCreateStruct $locationCreateStruct): Location

--- a/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Content/Location/Handler.php
@@ -110,7 +110,7 @@ interface Handler
      */
     public function copySubtree($sourceId, $destinationParentId);
 
-    public function getSubtreeSize(string $path): int;
+    public function getSubtreeSize(string $path, ?int $limit = null): int;
 
     /**
      * Moves location identified by $sourceId into new parent identified by $destinationParentId.

--- a/eZ/Publish/SPI/Persistence/Filter/Content/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Filter/Content/Handler.php
@@ -22,5 +22,5 @@ interface Handler
      */
     public function find(Filter $filter): iterable;
 
-    public function count(Filter $filter): int;
+    public function count(Filter $filter, ?int $limit = null): int;
 }

--- a/eZ/Publish/SPI/Persistence/Filter/Location/Handler.php
+++ b/eZ/Publish/SPI/Persistence/Filter/Location/Handler.php
@@ -22,5 +22,5 @@ interface Handler
      */
     public function find(Filter $filter): iterable;
 
-    public function count(Filter $filter): int;
+    public function count(Filter $filter, ?int $limit = null): int;
 }

--- a/eZ/Publish/SPI/Repository/Decorator/ContentServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/ContentServiceDecorator.php
@@ -276,7 +276,7 @@ abstract class ContentServiceDecorator implements ContentService
         return $this->innerService->find($filter, $languages);
     }
 
-    public function count(Filter $filter, ?array $languages = null): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = $limit): int
     {
         return $this->innerService->count($filter, $languages);
     }

--- a/eZ/Publish/SPI/Repository/Decorator/ContentServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/ContentServiceDecorator.php
@@ -276,8 +276,8 @@ abstract class ContentServiceDecorator implements ContentService
         return $this->innerService->find($filter, $languages);
     }
 
-    public function count(Filter $filter, ?array $languages = null, ?int $limit = $limit): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int
     {
-        return $this->innerService->count($filter, $languages);
+        return $this->innerService->count($filter, $languages, $limit);
     }
 }

--- a/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
@@ -82,9 +82,9 @@ abstract class LocationServiceDecorator implements LocationService
         return $this->innerService->loadParentLocationsForDraftContent($versionInfo, $prioritizedLanguages);
     }
 
-    public function getLocationChildCount(Location $location): int
+    public function getLocationChildCount(Location $location, ?int $limit = null): int
     {
-        return $this->innerService->getLocationChildCount($location);
+        return $this->innerService->getLocationChildCount($location, $limit);
     }
 
     public function getSubtreeSize(Location $location, ?int $limit = null): int
@@ -160,8 +160,8 @@ abstract class LocationServiceDecorator implements LocationService
         return $this->innerService->find($filter, $languages);
     }
 
-    public function count(Filter $filter, ?array $languages = null): int
+    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int
     {
-        return $this->innerService->count($filter, $languages);
+        return $this->innerService->count($filter, $languages, $limit);
     }
 }

--- a/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
+++ b/eZ/Publish/SPI/Repository/Decorator/LocationServiceDecorator.php
@@ -87,9 +87,9 @@ abstract class LocationServiceDecorator implements LocationService
         return $this->innerService->getLocationChildCount($location);
     }
 
-    public function getSubtreeSize(Location $location): int
+    public function getSubtreeSize(Location $location, ?int $limit = null): int
     {
-        return $this->innerService->getSubtreeSize($location);
+        return $this->innerService->getSubtreeSize($location, $limit);
     }
 
     public function createLocation(

--- a/eZ/Publish/SPI/Repository/Tests/Decorator/LocationServiceDecoratorTest.php
+++ b/eZ/Publish/SPI/Repository/Tests/Decorator/LocationServiceDecoratorTest.php
@@ -151,7 +151,7 @@ class LocationServiceDecoratorTest extends TestCase
         $serviceMock = $this->createServiceMock();
         $decoratedService = $this->createDecorator($serviceMock);
 
-        $parameters = [$this->createMock(Location::class)];
+        $parameters = [$this->createMock(Location::class), 8];
 
         $serviceMock->expects($this->once())->method('getLocationChildCount')->with(...$parameters);
 


### PR DESCRIPTION
| Question                                  | Answer
| ---------------------------------------- | ------------------
| **JIRA issue**                         | [IBX-10186](https://issues.ibexa.co/browse/IBX-10186)
| **Type**                                  | improvement
| **Target Ibexa version**      | `v3.3`
| **BC breaks**                         | no
| **Depends on**                     | https://github.com/ezsystems/ezplatform-kernel/pull/412 (Included with this PR)
|**Required by**                      | https://github.com/ezsystems/ezplatform-admin-ui/pull/2125

>[!WARNING]
> This PR contains all of the changes from https://github.com/ezsystems/ezplatform-kernel/pull/412 verbatim. Please read the description of that PR for relevant details of changes from that branch.

# What
This PR continues the work started in [IBX-10174](https://issues.ibexa.co/browse/IBX-10174) by adding a $limit clause to `LocationService::count` and `ContentService::count` count. The Public facing API's have been changed accordingly.
The changes to the public API this PR specifically makes are:
```php
interface LocationService {
    # ...

    public function count(Filter $filter, ?array $languages = null): int;

    # ...
}

interface ContentService {
    # ...

     count(Filter $filter, ?array $languages = null): int;

    # ...
}
```
To the following:

```php
interface LocationService {
    # ...

    public function count(Filter $filter, ?array $languages = null, ?int $limit = null): int;

    # ...
}

interface ContentService {
    # ...

     count(Filter $filter, ?array $languages = null, ?int $filter = null): int;

    # ...
}
```

This opens up the ability to limit the total item count pulled back from the DB and proportionally cuts down on overall processing times.
This is especially useful for when:
 * You want to ascertain if there is _any_ sub items / a single instance of an item matching a count (A very common case as seen in the associated admin PR)
 * If you want to know if there is a count up to a certain number, which is a useful mechanism for regulating the impact of otherwise potentially very expensive queries
 
# How
Based on the above API changes most top level repository `count` queries have a limit option. A new trait has been added for converting SQL Like:
```sql
SELECT DISTINCT COUNT(DISTINCT location.node_id) FROM ezcontentobject_tree location INNER JOIN ezcontentobject content ON content.id = location.contentobject_id INNER JOIN ezcontentobject_version version ON (content.id = version.contentobject_id) AND (content.current_version = version.version) AND (version.status = 1) WHERE location.parent_node_id IN (43) 
```
to
```
SELECT COUNT(*) FROM( SELECT DISTINCT location.node_id FROM ezcontentobject_tree location INNER JOIN ezcontentobject content ON content.id = location.contentobject_id INNER JOIN ezcontentobject_version version ON (content.id = version.contentobject_id) AND (content.current_version = version.version) AND (version.status = 1) WHERE location.parent_node_id IN (43) LIMIT {x} ) AS x;
```

It should be noted that the count query **does not change** until a limit is directly passed. Given by default this is set to `null` no underlying queries made by current sites will change unless a limit is passed meaning this PR should result in no BC breaks

# Why
Performance of eZ Platform Count queries (Given the number of required joins and existing database schema) scale poorly, especially in cases where _many_ content items match the given count query. This is exacerbated when the associated user has a larger set of permissions  

From benchmarking here is how eZ Scales to a location count query with **no** limitations . 
![query_performance_admin_2](https://github.com/user-attachments/assets/e7df4031-b099-417c-bccc-8cade3f1357e)

As you can see the number of items pulled back is directly proportional the time the query takes to resolve. (The red dot representing the current implementation). In the CMS many such queries are made to generate pages over the lifespan of the request. Many of which can be satisfied with limits of 1 or a lower number. 

For our use case the effect of these queries are so catastrophic the CMS is completely unusable / some pages take 10+ seconds to load. (Most of this can be attributed to IBX-10186 and IBX-10174)

This trend gets even worse with the eZ Permissions system where Count queries can quickly spiral into the single limiting factor in overall page performance. (See below a chat like above be the query is bounded by some more specific permissions)
![query_performance](https://github.com/user-attachments/assets/71ac5437-4e82-4fba-977e-32bb2a8f39be)

#### Checklist:
- [x] Provided PR description.
- [x] Tested the solution manually.
- [x] Provided automated test coverage.
- [x] Checked that target branch is set correctly (master for features, the oldest supported for bugs).
- [x] Ran PHP CS Fixer for new PHP code (use `$ composer fix-cs`).
- [x] Asked for a review (ping `@ezsystems/engineering-team`).
 


